### PR TITLE
ci: Add PR title checker

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -1,0 +1,10 @@
+{
+  "LABEL": {
+    "name": "Invalid PR Title",
+    "color": "B60205"
+  },
+  "CHECKS": {
+    "regexp": "^(feat|fix|test|refactor|chore|style|docs|perf|build|ci|revert)(\\(.*\\))?:.*",
+    "ignoreLabels" : ["ignore-title"]
+  }
+}

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,0 +1,20 @@
+name: "PR Title Checker"
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: thehanimo/pr-title-checker@v1.3.4
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pass_on_octokit_error: false
+          configuration_path: ".github/pr-title-checker-config.json"


### PR DESCRIPTION
## Changes
Adds PR title checker for this repo, the config is derived from [greptimedb](https://github.com/GreptimeTeam/greptimedb/blob/cefdffff099435bc5d8fc442b90efbaa3d3f4f33/.github/pr-title-checker-config.json)