### PR TITLE
fix: change standalone mode default mysql port to 4002

### DIFF
--- a/docs/user-guide/table-management.md
+++ b/docs/user-guide/table-management.md
@@ -9,7 +9,7 @@ GreptimeDB provides table management functionality on both MySQL and gRPC protoc
 You can use standard MySQL client to connect to a running GreptimeDB instance.
 
 ``` bash
-$ mysql -h 127.0.0.1 -P 4202
+$ mysql -h 127.0.0.1 -P 4002
 mysql>
 ```
 


### PR DESCRIPTION
The default MySQL port for frontend in standalone mode is 4002