### PR TITLE
docs: fix typo and format

### DIFF
--- a/docs/developer-guide/overview.md
+++ b/docs/developer-guide/overview.md
@@ -22,7 +22,7 @@ relational databases. A `region` could be replicated on multiple `datanode` and 
 replicas is writable and can serve write requests, while any replica can serve read requests.
 - A `datanode` stores and serves `region` to frontends. One `datanode` can serve multiple `regions`
 and one `region` can be served by multiple `datanodes`.
-- The `meta` server stores the metadata of the cluster, such as tables, `datanodes`, `regions` of ach
+- The `meta` server stores the metadata of the cluster, such as tables, `datanodes`, `regions` of each
 table, etc. It also coordinates frontends and `datanodes`.
 - Each `datanode` or frontend has a remote catalog implementation, which fetches the metadata from
 meta, tells which `region` of a `table` is served by which `datanode`.

--- a/docs/user-guide/reading-writing-data.md
+++ b/docs/user-guide/reading-writing-data.md
@@ -33,23 +33,29 @@ First, you need to create a table. Take the SQL
 in [Getting Started](../getting-started/overview.md) guide as example:
 
 ```SQL
-mysql> CREATE TABLE system_metrics (
-    ->     host STRING,
-    ->     idc STRING,
-    ->     cpu_util DOUBLE,
-    ->     memory_util DOUBLE,
-    ->     disk_util DOUBLE,
-    ->     ts TIMESTAMP,
-    ->     PRIMARY KEY(host, idc),
-    ->     TIME INDEX(ts)
-    -> );
+CREATE TABLE system_metrics (
+     host STRING,
+     idc STRING,
+     cpu_util DOUBLE,
+     memory_util DOUBLE,
+     disk_util DOUBLE,
+     ts TIMESTAMP,
+     PRIMARY KEY(host, idc),
+     TIME INDEX(ts)
+);
+```
+
+```text
 Query OK, 1 row affected (0.01 sec)
 ```
 
 A table named `system_metrics` was created. You can use `show tables` to view it:
 
-```SQL
-mysql> show tables;
+```sql
+show tables;
+```
+
+```text
 +----------------+
 | Tables         |
 +----------------+
@@ -66,11 +72,14 @@ Let's insert some testing data. You can use the `INSERT INTO` SQL
 statements:
 
 ```SQL
-mysql> INSERT INTO system_metrics
-    -> VALUES
-    ->     ("host1", "idc_a", 11.8, 10.3, 10.3, 1667446797460),
-    ->     ("host2", "idc_a", 80.1, 70.3, 90.0, 1667446797461),
-    ->     ("host1", "idc_b", 50.0, 66.7, 40.6, 1667446797462);
+INSERT INTO system_metrics
+ VALUES
+     ("host1", "idc_a", 11.8, 10.3, 10.3, 1667446797460),
+     ("host2", "idc_a", 80.1, 70.3, 90.0, 1667446797461),
+     ("host1", "idc_b", 50.0, 66.7, 40.6, 1667446797462);
+```
+
+```text
 Query OK, 3 rows affected (0.01 sec)
 ```
 
@@ -81,7 +90,10 @@ Then we are good to query it!
 You can use the `SELECT` statement to query data:
 
 ```SQL
-mysql> select * from system_metrics;
+select * from system_metrics;
+```
+
+```text
 +-------+-------+----------+-------------+-----------+---------------------+
 | host  | idc   | cpu_util | memory_util | disk_util | ts                  |
 +-------+-------+----------+-------------+-----------+---------------------+
@@ -112,7 +124,7 @@ GreptimeDB's gRPC service is listening on `127.0.0.1:3001` by default.
 Let's create a table called `hello_greptime`:
 
 ```shell
-~ % grpcurl -plaintext -d '
+grpcurl -plaintext -d '
 {
   "header": { "tenant": "0" },
   "admins": [
@@ -154,7 +166,7 @@ Let's create a table called `hello_greptime`:
 Our newly created table has 3 columns. If created successfully, GreptimeDB's
 gRPC service will return:
 
-```shell
+```json
 {
   "admins": [
     {
@@ -179,7 +191,7 @@ gRPC service will return:
 Insert data:
 
 ```shell
-~ % grpcurl -plaintext -d '
+grpcurl -plaintext -d '
 {
   "header": {
     "tenant": "0"
@@ -232,7 +244,7 @@ insert
 
 The result of the insert request is simple:
 
-```
+```json
 {
   "admins": [{}],
   "databases": [
@@ -327,7 +339,7 @@ in `select.proto` file to `import "column.proto"`(Because protoc's
 "decode" can not find the imported proto files in that way)
 1. Submit your gRPC request
 
-``` shell
+```shell
 grpcurl -plaintext -d '
 {
   "header": {

--- a/docs/user-guide/supported-protocols/http-api.md
+++ b/docs/user-guide/supported-protocols/http-api.md
@@ -8,13 +8,13 @@ The GreptimeDB dashboard is a web console based on HTTP API.
 
 Available API:
 
-- /sql
-- /scripts and /run-script
-- /opentsdb to support OpenTSDB protocol
-- /influxdb to support InfluxDB line protocol
-- /prometheus to support Prometheus Endpoints
+- `/sql`
+- `/scripts` and `/run-script`
+- `/opentsdb` to support OpenTSDB protocol
+- `/influxdb` to support InfluxDB line protocol
+- `/prometheus` to support Prometheus Endpoints
 
-All these APIs are under the parent resource /v1,  which specifies the current HTTP API version.
+All these APIs are under the parent resource `/v1`,  which specifies the current HTTP API version.
 
 ## `/sql`
 

--- a/docs/user-guide/supported-protocols/prometheus.md
+++ b/docs/user-guide/supported-protocols/prometheus.md
@@ -1,7 +1,6 @@
 # Prometheus
 
 GreptimeDB supports both of Prometheus's remote Read and Write endpoints:
-Suggestion:
 
 - `/v1/prometheus/write` for remote write
 - `/v1/prometheus/read` for remote read


### PR DESCRIPTION
Main changes:

* Fixed typo in developer guide overview
* Fixed code block.