### PR TITLE
docs: Update list of build dependencies

### DIFF
--- a/docs/developer-guide/get-started.md
+++ b/docs/developer-guide/get-started.md
@@ -12,14 +12,15 @@ At the moment, GreptimeDB now only supports Linux(amd64) and macOS (both amd64 a
 
 ### Build Dependencies
 
+- Git (optional)
+  - Clone the source from
+- C/C++ Toolchain: provides basic tools for compiling and linking. This is available as build-essential on ubuntu and similar name on other platforms.
 - Rust ([guide][1])
   - Compile the source code
 - Protobuf ([guide][2])
   - Compile the proto file
-- Git (optional)
-  - Clone the source from
 
-[1]: <https://www.rust-lang.org/learn/get-started>
+[1]: <https://www.rust-lang.org/tools/install/>
 [2]: <https://grpc.io/docs/protoc-installation/>
 
 ## Compile and Run

--- a/docs/developer-guide/get-started.md
+++ b/docs/developer-guide/get-started.md
@@ -14,7 +14,7 @@ At the moment, GreptimeDB now only supports Linux(amd64) and macOS (both amd64 a
 
 - Git (optional)
   - Clone the source from
-- C/C++ Toolchain: provides basic tools for compiling and linking. This is available as build-essential on ubuntu and similar name on other platforms.
+- C/C++ Toolchain: provides essential tools for compiling and linking. This is available either as `build-essential` on ubuntu or a similar name on other platforms.
 - Rust ([guide][1])
   - Compile the source code
 - Protobuf ([guide][2])


### PR DESCRIPTION
## Changes
Adds C/C++ toolchain to the list, changes the order of the dependencies, and updates the link of Rust to the official install guide.