### PR TITLE
fix: remove mysql standalone

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -150,7 +150,7 @@ datanode_rpc_addr = '127.0.0.1:3001'
 http_addr = '127.0.0.1:4000'
 
 [meta_client_opts]
-metasrv_addr = "1.1.1.1:3002"
+metasrv_addrs = ["127.0.0.1:3002"]
 timeout_millis = 3000
 connect_timeout_millis = 5000
 tcp_nodelay = false
@@ -160,7 +160,7 @@ The `datanode_rpc_addr` is not used in `distributed` mode, you can leave it in d
 
 The `meta_client_opts` configure the metasrv client confugrations, incuding:
 
-* `metasrv_addr`, metasrv address.
+* `metasrv_addrs`, metasrv address list
 * `timeout_millis`, operation timeout in milliseconds, 3000 by default.
 * `connect_timeout_millis`, connect server timeout in milliseconds,5000 by default.
 
@@ -183,7 +183,7 @@ type = 'File'
 data_dir = '/tmp/greptimedb/data/'
 
 [meta_client_opts]
-metasrv_addr = "1.1.1.1:3002"
+metasrv_addrs = ["1.1.1.1:3002"]
 timeout_millis = 3000
 connect_timeout_millis = 5000
 tcp_nodelay = false

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -103,8 +103,6 @@ When you use GreptimeDB in the standalone mode, you can configure it as below:
 node_id = 0
 mode = 'standalone'
 http_addr = '127.0.0.1:4000'
-datanode_mysql_addr = "127.0.0.1:3306"
-datanode_mysql_runtime_size = 4
 wal_dir = "/tmp/greptimedb/wal/"
 
 [storage]


### PR DESCRIPTION
Remove datanode MySQL options in standalone mode, please merge when https://github.com/GreptimeTeam/greptimedb/pull/595 is merged.