### PR TITLE
fix(global): add headers to protect against iframe injection

### DIFF
--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -1,2 +1,2 @@
 /*
-  Content-Security-Policy: frame-ancestors 'self' https://docs.greptime.com/*;
+  Content-Security-Policy: frame-ancestors 'self' https://greptime.com/*;

--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -1,2 +1,2 @@
 /*
-  Content-Security-Policy: frame-ancestors 'self' https://greptime.com/*;
+  Content-Security-Policy: frame-ancestors 'self' https://docs.greptime.com/*;

--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -1,0 +1,2 @@
+/*
+  Content-Security-Policy: frame-ancestors 'self' https://docs.greptime.com/*;


### PR DESCRIPTION
Steps To Reproduce:
- Create a new HTML file
- Put <iframe src="https://docs.greptime.com/"  frameborder="0"></iframe>
- Save the file in *.html format.
- Open that file in your browser.