### PR TITLE
docs: Correct some examples of config file

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -76,28 +76,26 @@ All of these options are optional, the default values are listed above. If you w
 | mysql_options      |              |         | MySQL server options                                                            |
 |                    | add          | String  | Server address, "127.0.0.1:4002" by default                                     |
 |                    | runtime_size | Integer | The number of server worker threads, 2 by default                               |
-| influxdb_options   |              |         |                                                                                 |
+| influxdb_options   |              |         | InfluxDB Protocol options                                                       |
 |                    | enable       | Boolean | Whether to enable InfluxDB protocol in HTTP API, true by default                |
 | opentsdb_options   |              |         | OpenTSDB Protocol options                                                       |
-|                    | enable       | Boolean | Whether to enable OpenTSDB protocol in HTTP API, true by default                |
 |                    | addr         | String  | OpenTSDB telnet API server address, "127.0.0.1:4242" by default                 |
 |                    | runtime_size | Integer | The number of server worker threads, 2 by default                               |
 | prometheus_options |              |         | Prometheus protocol options                                                     |
 |                    | enable       | Boolean | Whether to enable Prometheus remote write and read in HTTP API, true by default |
 | postgres_options   |              |         | PostgresSQL server options                                                      |
-|                    | addr         | String  | Server address, '127.0.0.1:4003' by default                                     |
+|                    | addr         | String  | Server address, "127.0.0.1:4003" by default                                     |
 |                    | runtime_size | Integer | The number of server worker threads, 2 by default                               |
-|                    | check_pwd    | boolean | Whether to check password, it's not supported right now, always false.          |
 
 ### Node options
 
 There are also some node options in common:
 
 
-| Option | Key       | Type    | Description                                                                        |
-|--------|-----------|---------|------------------------------------------------------------------------------------|
-|        | node_id   | Integer | The datanode identifier, set it 0 in standalone mode, otherwise should be different|
-|        | mode      | String  | Node running mode, includes 'standalone' or 'distributed'                          |
+| Option | Key                     | Type    | Description                                                                        |
+|--------|-------------------------|---------|------------------------------------------------------------------------------------|
+|        | mode                    | String  | Node running mode, includes "standalone" or "distributed"                          |
+|        | enable_memory_catalog   | Boolean | Use in-memory catalog, false by default                                            |
 
 ### Storage option
 
@@ -105,11 +103,11 @@ The `storage` options are valid in datanode and standalone mode, which specify t
 
 | Option  | Key      | Type   | Description                                         |
 |---------|----------|--------|-----------------------------------------------------|
-| storage |          |        | Storage engine options                              |
-|         | type     | String | Storage engine type, Only supports 'File' or 'S3' right now |
-| File    |          |        | File storage options, valid when type='file'        |
+| storage |          |        | Storage options                                     |
+|         | type     | String | Storage type, Only supports "File" or "S3" right now |
+| File    |          |        | File storage options, valid when type="file"        |
 |         | data_dir | String | Data directory, "/tmp/greptimedb/data" by default   |
-| S3      |          |        | S3 storage options, valid when type='S3'            |
+| S3      |          |        | S3 storage options, valid when type="S3"            |
 |         | bucket   | String | The s3 bucket name                                  |
 |         | root     | String | The root path in s3 bucket                          |
 |         | access_key_id     | String | The s3 acccess key id                      |
@@ -119,19 +117,19 @@ A file sample configuration:
 
 ```toml
 [storage]
-type = 'File'
-data_dir = '/tmp/greptimedb/data/'
+type = "File"
+data_dir = "/tmp/greptimedb/data/"
 ```
 
 A s3 sample configuration:
 
 ```toml
 [storage]
-type = 'S3'
-bucket = 'test_greptimedb'
-root = '/greptimedb'
-access_key_id = '<access key id>'
-secret_access_key = '<secret access key>'
+type = "S3"
+bucket = "test_greptimedb"
+root = "/greptimedb"
+access_key_id = "<access key id>"
+secret_access_key = "<secret access key>"
 ```
 
 ## Standalone
@@ -139,38 +137,37 @@ secret_access_key = '<secret access key>'
 When you use GreptimeDB in the standalone mode, you can configure it as below:
 
 ```toml
-node_id = 0
-mode = 'standalone'
+mode = "standalone"
 
 [http_options]
-addr = '127.0.0.1:4000'
+addr = "127.0.0.1:4000"
 timeout = "30s"
 
 [wal]
 dir = "/tmp/greptimedb/wal"
-file_size = '1GB'
-purge_interval = '10m'
-purge_threshold = '50GB'
+file_size = "1GB"
+purge_interval = "10m"
+purge_threshold = "50GB"
 read_batch_size = 128
 sync_write = false
 
 [storage]
-type = 'File'
-data_dir = '/tmp/greptimedb/data/'
+type = "File"
+data_dir = "/tmp/greptimedb/data/"
 
 [grpc_options]
-addr = '127.0.0.1:4001'
+addr = "127.0.0.1:4001"
 runtime_size = 8
 
 [mysql_options]
-addr = '127.0.0.1:4002'
+addr = "127.0.0.1:4002"
 runtime_size = 2
 
 [influxdb_options]
 enable = true
 
 [opentsdb_options]
-addr = '127.0.0.1:4242'
+addr = "127.0.0.1:4242"
 enable = true
 runtime_size = 2
 
@@ -178,7 +175,7 @@ runtime_size = 2
 enable = true
 
 [postgres_options]
-addr = '127.0.0.1:4003'
+addr = "127.0.0.1:4003"
 runtime_size = 2
 ```
 
@@ -191,7 +188,7 @@ Configure frontend in distributed mode:
 mode = "distributed"
 
 [http_options]
-addr = '127.0.0.1:4000'
+addr = "127.0.0.1:4000"
 timeout = "30s"
 
 [meta_client_options]
@@ -201,11 +198,12 @@ connect_timeout_millis = 5000
 tcp_nodelay = false
 ```
 
-The `meta_client_options` configure the metasrv client confugrations, incuding:
+The `meta_client_options` configure the metasrv client configuration, incuding:
 
 * `metasrv_addrs`, metasrv address list
 * `timeout_millis`, operation timeout in milliseconds, 3000 by default.
 * `connect_timeout_millis`, connect server timeout in milliseconds,5000 by default.
+* `tcp_nodelay`, `TCP_NODELAY` option for accepted connections, true by default.
 
 
 ## Datanode in distributed mode
@@ -215,22 +213,22 @@ Configure datanode in distributed mode:
 ```toml
 node_id = 42
 mode = "distributed"
-rpc_addr = '127.0.0.1:3001'
+rpc_addr = "127.0.0.1:3001"
 rpc_runtime_size = 8
-mysql_addr = '127.0.0.1:4406'
+mysql_addr = "127.0.0.1:4406"
 mysql_runtime_size = 4
 
 [wal]
 dir = "/tmp/greptimedb/wal"
-file_size = '1GB'
-purge_interval = '10m'
-purge_threshold = '50GB'
+file_size = "1GB"
+purge_interval = "10m"
+purge_threshold = "50GB"
 read_batch_size = 128
 sync_write = false
 
 [storage]
-type = 'File'
-data_dir = '/tmp/greptimedb/data/'
+type = "File"
+data_dir = "/tmp/greptimedb/data/"
 
 [meta_client_options]
 metasrv_addrs = ["127.0.0.1:3002"]
@@ -246,15 +244,15 @@ Datanode in distributed mode should set different `node_id` in different nodes.
 A sample configurations:
 
 ```toml
-bind_addr = '127.0.0.1:3002'
-server_addr = '127.0.0.1:3002'
-store_addr = '127.0.0.1:2379'
+bind_addr = "127.0.0.1:3002"
+server_addr = "127.0.0.1:3002"
+store_addr = "127.0.0.1:2379"
 datanode_lease_secs = 30
 ```
 
 | Key                 | Type    | Description                                                                                                             |
 |---------------------|---------|-------------------------------------------------------------------------------------------------------------------------|
-| bind_addr           | String  | The bind address of metasrv, '127.0.0.1:3002' by default.                                                                 |
-| server_addr         | String  | The communication server address for frontend and datanode to connect metasrv,  '127.0.0.1:3002' by default for localhost |
-| store_addr          | String  | Etcd server address, '127.0.0.1:2379' by default                                                                        |
+| bind_addr           | String  | The bind address of metasrv, "127.0.0.1:3002" by default.                                                                 |
+| server_addr         | String  | The communication server address for frontend and datanode to connect metasrv,  "127.0.0.1:3002" by default for localhost |
+| store_addr          | String  | Etcd server address, "127.0.0.1:2379" by default                                                                        |
 | datanode_lease_secs | Integer | Datanode lease in seconds, 15 seconds by default.                                                                       |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -94,7 +94,7 @@ There are also some node options in common:
 
 | Option | Key                     | Type    | Description                                                                        |
 |--------|-------------------------|---------|------------------------------------------------------------------------------------|
-|        | mode                    | String  | Node running mode, includes "standalone" or "distributed"                          |
+|        | mode                    | String  | Node running mode, includes "standalone" and "distributed"                         |
 |        | enable_memory_catalog   | Boolean | Use in-memory catalog, false by default                                            |
 
 ### Storage option
@@ -198,7 +198,7 @@ connect_timeout_millis = 5000
 tcp_nodelay = false
 ```
 
-The `meta_client_options` configure the metasrv client configuration, incuding:
+The `meta_client_options` configure the metasrv client, incuding:
 
 * `metasrv_addrs`, metasrv address list
 * `timeout_millis`, operation timeout in milliseconds, 3000 by default.
@@ -253,6 +253,6 @@ datanode_lease_secs = 30
 | Key                 | Type    | Description                                                                                                             |
 |---------------------|---------|-------------------------------------------------------------------------------------------------------------------------|
 | bind_addr           | String  | The bind address of metasrv, "127.0.0.1:3002" by default.                                                                 |
-| server_addr         | String  | The communication server address for frontend and datanode to connect metasrv,  "127.0.0.1:3002" by default for localhost |
+| server_addr         | String  | The communication server address for frontend and datanode to connect to metasrv,  "127.0.0.1:3002" by default for localhost |
 | store_addr          | String  | Etcd server address, "127.0.0.1:2379" by default                                                                        |
 | datanode_lease_secs | Integer | Datanode lease in seconds, 15 seconds by default.                                                                       |


### PR DESCRIPTION
This PR corrects outdated examples in the configuration section.

This fixes #210