### PR TITLE
fix: correct use-promql title

### DIFF
--- a/docs/user-guide/use-promql.md
+++ b/docs/user-guide/use-promql.md
@@ -1,4 +1,4 @@
-# Java SDK
+# Use PromQL
 
 ## Introduction
 


### PR DESCRIPTION
Fix the title. Change from `Java SDK` to `Use PromQL`