### PR TITLE
docs: add table options to table-management

### DIFF
--- a/docs/reference/sql/create.md
+++ b/docs/reference/sql/create.md
@@ -66,9 +66,9 @@ Users can add table options by using `WITH`. The valid options contain the follo
 
 | Option  | Description  | Value |
 |---|---|---|
-| `ttl`  | The storage time of the table data  |   String value, such as `'60m'`, `'1h'` for one hour, `'14d'` for 14 days etc. |
+| `ttl`  | The storage time of the table data  |   String value, such as `'60m'`, `'1h'` for one hour, `'14d'` for 14 days etc. Supported time units are: `s` / `m` / `h` / `d` |
 |  `regions` | The region number of the table  | Integral value, such as 1, 5, 10 etc. |
-| `write_buffer_size` | Memtable size of the table | String value representing a valid size, such as `32MB`, `128MB`, etc. The default value of this option is `32MB`. |
+| `write_buffer_size` | Memtable size of the table | String value representing a valid size, such as `32MB`, `128MB`, etc. The default value of this option is `32MB`. Supported units are: `MB` / `GB`. |
 
 For example, to create a table with the storage data TTL(Time-To-Live) is seven days and region number is 10:
 ```sql

--- a/docs/reference/sql/create.md
+++ b/docs/reference/sql/create.md
@@ -66,8 +66,9 @@ Users can add table options by using `WITH`. The valid options contain the follo
 
 | Option  | Description  | Value |
 |---|---|---|
-| ttl  | The storage time of the table data  |   String value, such as `'60m'`, `'1h'` for one hour, `'14d'` for 14 days etc. |
-|  regions | The region number of the table  | Integral value, such as 1, 5, 10 etc. |
+| `ttl`  | The storage time of the table data  |   String value, such as `'60m'`, `'1h'` for one hour, `'14d'` for 14 days etc. |
+|  `regions` | The region number of the table  | Integral value, such as 1, 5, 10 etc. |
+| `write_buffer_size` | Memtable size of the table | String value representing a valid size, such as `32MB`, `128MB`, etc. |
 
 For example, to create a table with the storage data TTL(Time-To-Live) is seven days and region number is 10:
 ```sql

--- a/docs/reference/sql/create.md
+++ b/docs/reference/sql/create.md
@@ -68,7 +68,7 @@ Users can add table options by using `WITH`. The valid options contain the follo
 |---|---|---|
 | `ttl`  | The storage time of the table data  |   String value, such as `'60m'`, `'1h'` for one hour, `'14d'` for 14 days etc. |
 |  `regions` | The region number of the table  | Integral value, such as 1, 5, 10 etc. |
-| `write_buffer_size` | Memtable size of the table | String value representing a valid size, such as `32MB`, `128MB`, etc. |
+| `write_buffer_size` | Memtable size of the table | String value representing a valid size, such as `32MB`, `128MB`, etc. The default value of this option is `32MB`. |
 
 For example, to create a table with the storage data TTL(Time-To-Live) is seven days and region number is 10:
 ```sql

--- a/docs/user-guide/table-management.md
+++ b/docs/user-guide/table-management.md
@@ -88,6 +88,7 @@ data type for the time-series column, the inserted value of that column will be
 automatically converted to a timestamp in milliseconds.
 - Primary key: primary key is used to uniquely define a series of data, which is similar
 to tags in other time-series systems like [InfluxDB][1].
+- Table options: when creating a table, you can specify a set of table options, click [here](../reference/sql/create.md#table-options) for more details.
 
 [1]: <https://docs.influxdata.com/influxdb/v1.8/concepts/glossary/#tag-key>
 


### PR DESCRIPTION
- Add table option reference to "Table Management" sections
- Add `write_buffer_size` table option docs.

Fix #229 