### PR TITLE
feat: improve influxdb line document

### DIFF
--- a/docs/user-guide/write-data/influxdb-line.md
+++ b/docs/user-guide/write-data/influxdb-line.md
@@ -7,15 +7,18 @@ GreptimeDB supports HTTP InfluxDB Line protocol. You can write data via `/influx
 ```shell
 curl -i -XPOST "http://localhost:4000/v1/influxdb/write?db=public&precision=ms" \
 --data-binary \
-'system_metrics,host=host1,idc=idc_a cpu_util=11.8,memory_util=10.3,disk_util=10.3 1667446797450
- system_metrics,host=host2,idc=idc_a cpu_util=80.1,memory_util=70.3,disk_util=90.0 1667446797450
- system_metrics,host=host1,idc=idc_b cpu_util=50.0,memory_util=66.7,disk_util=40.6 1667446797450'
+'monitor,host=127.0.0.1 cpu=0.1,memory=0.4 1667446797450
+ monitor,host=127.0.0.2 cpu=0.2,memory=0.3 1667446798450
+ monitor,host=127.0.0.1 cpu=0.5,memory=0.2 1667446798450'
 ```
 
 The `/influxdb/write` supports query params including:
 
 * `db` specify which db to write, `public` by default.
 * `precision`, precision of timestamps in the line protocol. Accepts `ns` (nanoseconds), `us`(microseconds), `ms` (milliseconds) and `s` (seconds), nanoseconds by default.
+
+## Reference
+[InfluxDB Line protocol](https://docs.influxdata.com/influxdb/v2.7/reference/syntax/line-protocol/)
 
 <!-- TODO -->
 <!-- ## Delete -->


### PR DESCRIPTION
In `Table Management`, there is an example of creating a `monitor` table. In the following `Write Data/SQL` section, there is an example of inserting data into the `monitor` table. On the other hand, in `Write Data/InfluxDB Line` section, there is an example of inserting data into the `system_metrics` table. I guess that users should read `Write Data/InfluxDB Line` after they read `Table Management`. I think this might confuse them. 

So, this PR replaces `system_metrics` with `monitor` so that users can immediately execute a insert command after reading `Table Management`.

In addition, this PR appends a `InfluxdDB Line protocol` reference in the `Write Data/InfluxDB Line` section so that users could easily understand about the `InfluxdDB Line protocol`.

<img width="245" alt="image" src="https://github.com/GreptimeTeam/docs/assets/61189782/35362c15-5a43-455e-914e-30659f4c0bc5">
