### PR TITLE
docs: fix error links

### DIFF
--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -3,9 +3,10 @@
 Begin to explore GreptimeDB's powerful core features.
 
 ## Install GreptimeDB
+
 You can try out GreptimeDB with our test builds released on [Download page](https://greptime.com/download).
 
-We use the simplest configuration for you to get started. For a comprehensive list of configurations available in GreptimeDB, see the [configuration documentation](../user-guide/operations/configuration.md).
+We use the simplest configuration for you to get started. For a comprehensive list of configurations available in GreptimeDB, see the [configuration documentation](/user-guide/operations/configuration.md).
 
 ### Linux & Mac
 
@@ -24,6 +25,7 @@ You can run GreptimeDB in the standalone mode:
 ```
 
 ### Docker
+
 Make sure the [Docker](https://www.docker.com/) is already installed. If not, you can follow the official [documents](https://www.docker.com/get-started/) to install Docker.
 
 ```shell
@@ -69,7 +71,7 @@ You can:
 
 ## Connect
 
-GreptimeDB supports [multiple protocols](../user-guide/clients/overview.md). We use MySQL client here for simplicity.
+GreptimeDB supports [multiple protocols](/user-guide/clients/overview.md). We use MySQL client here for simplicity.
 
 ```sql
 mysql -h 127.0.0.1 -P 4002
@@ -77,7 +79,7 @@ mysql -h 127.0.0.1 -P 4002
 
 ## Create table
 
-**Note: GreptimeDB offers a schemaless approach to writing data that eliminates the need to manually create tables using additional protocols. See [Automatic Schema Generation](../user-guide/write-data/overview.md#automatic-schema-generation).**
+**Note: GreptimeDB offers a schemaless approach to writing data that eliminates the need to manually create tables using additional protocols. See [Automatic Schema Generation](/user-guide/write-data/overview.md#automatic-schema-generation).**
 
 Now we create a table via MySQL. Let's start by creating the `system_metrics` table which contains system resource metrics, including CPU/memory/disk usage. The data is scraped every 5 seconds.
 
@@ -105,9 +107,9 @@ Field descriptions:
 | disk\_util   | double    | The percent use of disks               |
 | ts           | timestamp | Timestamp column incrementing          |
 
-* The table can be created automatically if you are using other protocols. See [Create Table](../user-guide/table-management#create-table).
-* For more information about creating table SQL, please refer to [CREATE](../reference/sql/create.md).
-* For data types, please check [data types](../reference/data-types.md).
+* The table can be created automatically if you are using other protocols. See [Create Table](/user-guide/table-management#create-table).
+* For more information about creating table SQL, please refer to [CREATE](/reference/sql/create.md).
+* For data types, please check [data types](/reference/data-types.md).
 
 ## Insert data
 
@@ -127,7 +129,7 @@ VALUES
     ("host1", "idc_b", 90.0, 39.9, 60.6, 1667446798250);
 ```
 
-For more information about the `INSERT` statement, please refer to [INSERT](../reference/sql/insert.md).
+For more information about the `INSERT` statement, please refer to [INSERT](/reference/sql/insert.md).
 
 ## Query data
 
@@ -201,7 +203,7 @@ SELECT idc, avg(memory_util) FROM system_metrics GROUP BY idc;
 2 rows in set (0.03 sec)
 ```
 
-For more information about the `SELECT` statement, please refer to [SELECT](../reference/sql/select.md).
+For more information about the `SELECT` statement, please refer to [SELECT](/reference/sql/select.md).
 
 ## Visualize data
 
@@ -209,13 +211,13 @@ Visualization plays a crucial role in effectively utilizing time series data. To
 
 The Dashboard is embedded into GreptimeDB's binary since GreptimeDB v0.2.0. After [starting GreptimeDB](#install-greptimedb), the dashboard can be visited via HTTP endpoint `http://localhost:4000/dashboard`. The current version of the dashboard supports MySQL and Python queries, with support for PromQL coming soon.
 
-Write SQL into the command text, then click `Run All`. We'll get all data in the system_metrics table.
+Write SQL into the command text, then click `Run All`. We'll got all data in system_metrics table.
 
 ```
 SELECT * FROM system_metrics;
 ```
 
-![](../public/dashboard-select.png)
+![dashboard-select](../public/dashboard-select.png)
 
 We offer various chart types to choose from based on different scenarios. The content of the charts will be richer when you have enough data.
 
@@ -229,11 +231,11 @@ We are committed to the ongoing development and iteration of this open source pr
 
 Congratulations you have learned the basic features of GreptimeDB. You are ready for the User Guide chapter.
 
-* [Concepts](../user-guide/concepts/overview.md)
-* [Clients](../user-guide/clients/overview.md)
-* [Table management](../user-guide/table-management.md)
-* [Write data](../user-guide/write-data/overview.md)
-* [Query data](../user-guide/query-data/overview.md)
-* [Scripts-&-functions](../user-guide/scripts-&-functions/overview.md)
-* [Cluster](../user-guide/cluster.md)
-* [Operations](../user-guide/operations/overview.md)
+* [Concepts](/user-guide/concepts/overview.md)
+* [Clients](/user-guide/clients/overview.md)
+* [Table management](/user-guide/table-management.md)
+* [Write data](/user-guide/write-data/overview.md)
+* [Query data](/user-guide/query-data/overview.md)
+* [Scripts-&-functions](/user-guide/scripts-&-functions/overview.md)
+* [Cluster](/user-guide/cluster.md)
+* [Operations](/user-guide/operations/overview.md)

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -5,7 +5,7 @@ Begin to explore GreptimeDB's powerful core features.
 ## Install GreptimeDB
 You can try out GreptimeDB with our test builds released on [Download page](https://greptime.com/download).
 
-We use the simplest configuration for you to get started. For a comprehensive list of configurations available in GreptimeDB, see the [configuration documentation](/user-guide/operations/configuration.md).
+We use the simplest configuration for you to get started. For a comprehensive list of configurations available in GreptimeDB, see the [configuration documentation](../user-guide/operations/configuration.md).
 
 ### Linux & Mac
 
@@ -24,7 +24,7 @@ You can run GreptimeDB in the standalone mode:
 ```
 
 ### Docker
-Make sure the [Docker](https://www.docker.com/) is already installed. If not, you can follow the official [documents](https://www.docker.com/getting-started/) to install Docker.
+Make sure the [Docker](https://www.docker.com/) is already installed. If not, you can follow the official [documents](https://www.docker.com/get-started/) to install Docker.
 
 ```shell
 docker run -p 4000-4004:4000-4004 \
@@ -69,7 +69,7 @@ You can:
 
 ## Connect
 
-GreptimeDB supports [multiple protocols](/user-guide/clients/overview.md). We use MySQL client here for simplicity.
+GreptimeDB supports [multiple protocols](../user-guide/clients/overview.md). We use MySQL client here for simplicity.
 
 ```sql
 mysql -h 127.0.0.1 -P 4002
@@ -77,7 +77,7 @@ mysql -h 127.0.0.1 -P 4002
 
 ## Create table
 
-**Note: GreptimeDB offers a schemaless approach to writing data that eliminates the need to manually create tables using additional protocols. See [Automatic Schema Generation](/user-guide/write-data/overview.md#automatic-schema-generation).**
+**Note: GreptimeDB offers a schemaless approach to writing data that eliminates the need to manually create tables using additional protocols. See [Automatic Schema Generation](../user-guide/write-data/overview.md#automatic-schema-generation).**
 
 Now we create a table via MySQL. Let's start by creating the `system_metrics` table which contains system resource metrics, including CPU/memory/disk usage. The data is scraped every 5 seconds.
 
@@ -105,9 +105,9 @@ Field descriptions:
 | disk\_util   | double    | The percent use of disks               |
 | ts           | timestamp | Timestamp column incrementing          |
 
-* The table can be created automatically if you are using other protocols. See [Create Table](/user-guide/table-management#create-table).
-* For more information about creating table SQL, please refer to [CREATE](/reference/sql/create.md).
-* For data types, please check [data types](/reference/data-types.md).
+* The table can be created automatically if you are using other protocols. See [Create Table](../user-guide/table-management#create-table).
+* For more information about creating table SQL, please refer to [CREATE](../reference/sql/create.md).
+* For data types, please check [data types](../reference/data-types.md).
 
 ## Insert data
 
@@ -127,7 +127,7 @@ VALUES
     ("host1", "idc_b", 90.0, 39.9, 60.6, 1667446798250);
 ```
 
-For more information about the `INSERT` statement, please refer to [INSERT](/reference/sql/insert.md).
+For more information about the `INSERT` statement, please refer to [INSERT](../reference/sql/insert.md).
 
 ## Query data
 
@@ -201,7 +201,7 @@ SELECT idc, avg(memory_util) FROM system_metrics GROUP BY idc;
 2 rows in set (0.03 sec)
 ```
 
-For more information about the `SELECT` statement, please refer to [SELECT](/reference/sql/select.md).
+For more information about the `SELECT` statement, please refer to [SELECT](../reference/sql/select.md).
 
 ## Visualize data
 
@@ -209,7 +209,7 @@ Visualization plays a crucial role in effectively utilizing time series data. To
 
 The Dashboard is embedded into GreptimeDB's binary since GreptimeDB v0.2.0. After [starting GreptimeDB](#install-greptimedb), the dashboard can be visited via HTTP endpoint `http://localhost:4000/dashboard`. The current version of the dashboard supports MySQL and Python queries, with support for PromQL coming soon.
 
-Write SQL into the command text, then click `Run All`. We'll got all data in system_metrics table.
+Write SQL into the command text, then click `Run All`. We'll get all data in the system_metrics table.
 
 ```
 SELECT * FROM system_metrics;
@@ -229,11 +229,11 @@ We are committed to the ongoing development and iteration of this open source pr
 
 Congratulations you have learned the basic features of GreptimeDB. You are ready for the User Guide chapter.
 
-* [Concepts](/user-guide/concepts/overview.md)
-* [Clients](/user-guide/clients/overview.md)
-* [Table management](/user-guide/table-management.md)
-* [Write data](/user-guide/write-data/overview.md)
-* [Query data](/user-guide/query-data/overview.md)
-* [Scripts-&-functions](/user-guide/scripts-&-functions/overview.md)
-* [Cluster](/user-guide/cluster.md)
-* [Operations](/user-guide/operations/overview.md)
+* [Concepts](../user-guide/concepts/overview.md)
+* [Clients](../user-guide/clients/overview.md)
+* [Table management](../user-guide/table-management.md)
+* [Write data](../user-guide/write-data/overview.md)
+* [Query data](../user-guide/query-data/overview.md)
+* [Scripts-&-functions](../user-guide/scripts-&-functions/overview.md)
+* [Cluster](../user-guide/cluster.md)
+* [Operations](../user-guide/operations/overview.md)

--- a/docs/zh/getting-started/overview.md
+++ b/docs/zh/getting-started/overview.md
@@ -6,7 +6,7 @@
 
 用户可以在[下载页面](https://greptime.cn/download)通过我们发布的测试版本尝试使用 GreptimeDB。
 
-我们先通过最简单的配置来开始。有关 GreptimeDB 中可用的所有配置选项的详细列表，请参考[配置文档](../user-guide/operations/configuration.md)。
+我们先通过最简单的配置来开始。有关 GreptimeDB 中可用的所有配置选项的详细列表，请参考[配置文档](/user-guide/operations/configuration.md)。
 
 ### Linux & Mac
 
@@ -70,7 +70,7 @@ greptime/greptimedb standalone start \
 
 ## 连接
 
-GreptimeDB 支持[多种协议](../user-guide/clients/overview.md)。这里使用 MySQL 客户端示例。
+GreptimeDB 支持[多种协议](/user-guide/clients/overview.md)。这里使用 MySQL 客户端示例。
 
 ```sql
 mysql -h 127.0.0.1 -P 4002
@@ -78,7 +78,7 @@ mysql -h 127.0.0.1 -P 4002
 
 ## 建表
 
-**注意: GreptimeDB 提供了一种 schemaless 的数据写入方法，不用像使用其他协议那样手动创建表。详情请参见 [自动生成表结构](../user-guide/write-data/overview.md#自动生成表结构)。**
+**注意: GreptimeDB 提供了一种 schemaless 的数据写入方法，不用像使用其他协议那样手动创建表。详情请参见 [自动生成表结构](/user-guide/write-data/overview.md#自动生成表结构)。**
 
 现在我们通过 MySQL 创建一个表。先创建 `system_metrics` 表，其中包含系统资源指标，包括 CPU /内存/磁盘的使用，这些数据每 5 秒就会被抓取一次。
 
@@ -106,9 +106,9 @@ Field 描述:
 | disk_util   | double    | The percent use of disks               |
 | ts          | timestamp | Timestamp column incrementing          |
 
-- 如果用户使用其他协议，该表可以自动创建。请参考 [Create Table](../user-guide/table-management#creat-table)。
-- 关于创建表的 SQL 信息，请参考 [CREATE](../reference/sql/create.md)。
-- 关于数据类型，请参考[数据类型](../reference/data-types.md)。
+- 如果用户使用其他协议，该表可以自动创建。请参考 [Create Table](/user-guide/table-management#creat-table)。
+- 关于创建表的 SQL 信息，请参考 [CREATE](/reference/sql/create.md)。
+- 关于数据类型，请参考[数据类型](/reference/data-types.md)。
 
 ## 数据写入
 
@@ -128,7 +128,7 @@ VALUES
     ("host1", "idc_b", 90.0, 39.9, 60.6, 1667446798250);
 ```
 
-关于 `INSERT` 语句的更多信息，请参考 [INSERT](../reference/sql/insert.md)。
+关于 `INSERT` 语句的更多信息，请参考 [INSERT](/reference/sql/insert.md)。
 
 ## 数据查询
 
@@ -203,7 +203,7 @@ SELECT idc, avg(memory_util) FROM system_metrics GROUP BY idc;
 2 rows in set (0.03 sec)
 ```
 
-关于 `SELECT` 语句的更多信息，请查看 [SELECT](../reference/sql/select.md) 文件。
+关于 `SELECT` 语句的更多信息，请查看 [SELECT](/reference/sql/select.md) 文件。
 
 ## Visualize data
 
@@ -217,7 +217,7 @@ Dashboard 自 GreptimeDB v0.2.0 版本以来已经嵌入到 GreptimeDB 的 binar
 SELECT * FROM system_metrics;
 ```
 
-![](../../public/dashboard-select.png)
+![dashboard-select](../../public/dashboard-select.png)
 
 我们提供不同种类的图表，可以根据不同的场景进行选择。当用户有足够的数据时，图表的内容将更加丰富。
 
@@ -230,11 +230,11 @@ SELECT * FROM system_metrics;
 
 至此我们展示了 GreptimeDB 的基本功能，更多的用户指南请查阅以下文档。
 
-- [概念](../user-guide/concepts/overview.md)
-- [客户端](../user-guide/clients/overview.md)
-- [管理表](../user-guide/table-management.md)
-- [数据写入](../user-guide/write-data/overview.md)
-- [数据查询](../user-guide/query-data/overview.md)
-- [脚本-&-函数](../user-guide/scripts-&-functions/overview.md)
-- [集群](../user-guide/cluster.md)
-- [运维操作](../user-guide/operations/overview.md)
+- [概念](/user-guide/concepts/overview.md)
+- [客户端](/user-guide/clients/overview.md)
+- [管理表](/user-guide/table-management.md)
+- [数据写入](/user-guide/write-data/overview.md)
+- [数据查询](/user-guide/query-data/overview.md)
+- [脚本-&-函数](/user-guide/scripts-&-functions/overview.md)
+- [集群](/user-guide/cluster.md)
+- [运维操作](/user-guide/operations/overview.md)

--- a/docs/zh/getting-started/overview.md
+++ b/docs/zh/getting-started/overview.md
@@ -6,7 +6,7 @@
 
 用户可以在[下载页面](https://greptime.cn/download)通过我们发布的测试版本尝试使用 GreptimeDB。
 
-我们先通过最简单的配置来开始。有关 GreptimeDB 中可用的所有配置选项的详细列表，请参考[配置文档](/user-guide/operations/configuration.md)。
+我们先通过最简单的配置来开始。有关 GreptimeDB 中可用的所有配置选项的详细列表，请参考[配置文档](../user-guide/operations/configuration.md)。
 
 ### Linux & Mac
 
@@ -26,7 +26,7 @@ curl -L https://raw.githubusercontent.com/GreptimeTeam/greptimedb/develop/script
 
 ### Docker
 
-请确保已经安装了 [Docker](https://www.docker.com/)。如果还没有安装，可以参考 Docker 官方的[文档](https://www.docker.com/getting-started/)进行安装。
+请确保已经安装了 [Docker](https://www.docker.com/)。如果还没有安装，可以参考 Docker 官方的[文档](https://www.docker.com/get-started/)进行安装。
 
 ```shell
 docker run -p 4000-4004:4000-4004 \
@@ -70,7 +70,7 @@ greptime/greptimedb standalone start \
 
 ## 连接
 
-GreptimeDB 支持[多种协议](/user-guide/clients/overview.md)。这里使用 MySQL 客户端示例。
+GreptimeDB 支持[多种协议](../user-guide/clients/overview.md)。这里使用 MySQL 客户端示例。
 
 ```sql
 mysql -h 127.0.0.1 -P 4002
@@ -78,7 +78,7 @@ mysql -h 127.0.0.1 -P 4002
 
 ## 建表
 
-**注意: GreptimeDB 提供了一种 schemaless 的数据写入方法，不用像使用其他协议那样手动创建表。详情请参见 [自动生成表结构](/user-guide/write-data/overview.md#自动生成表结构)。**
+**注意: GreptimeDB 提供了一种 schemaless 的数据写入方法，不用像使用其他协议那样手动创建表。详情请参见 [自动生成表结构](../user-guide/write-data/overview.md#自动生成表结构)。**
 
 现在我们通过 MySQL 创建一个表。先创建 `system_metrics` 表，其中包含系统资源指标，包括 CPU /内存/磁盘的使用，这些数据每 5 秒就会被抓取一次。
 
@@ -106,9 +106,9 @@ Field 描述:
 | disk_util   | double    | The percent use of disks               |
 | ts          | timestamp | Timestamp column incrementing          |
 
-- 如果用户使用其他协议，该表可以自动创建。请参考 [Create Table](/user-guide/table-management#creat-table)。
-- 关于创建表的 SQL 信息，请参考 [CREATE](/reference/sql/create.md)。
-- 关于数据类型，请参考[数据类型](/reference/data-types.md)。
+- 如果用户使用其他协议，该表可以自动创建。请参考 [Create Table](../user-guide/table-management#creat-table)。
+- 关于创建表的 SQL 信息，请参考 [CREATE](../reference/sql/create.md)。
+- 关于数据类型，请参考[数据类型](../reference/data-types.md)。
 
 ## 数据写入
 
@@ -128,7 +128,7 @@ VALUES
     ("host1", "idc_b", 90.0, 39.9, 60.6, 1667446798250);
 ```
 
-关于 `INSERT` 语句的更多信息，请参考 [INSERT](/reference/sql/insert.md)。
+关于 `INSERT` 语句的更多信息，请参考 [INSERT](../reference/sql/insert.md)。
 
 ## 数据查询
 
@@ -203,7 +203,7 @@ SELECT idc, avg(memory_util) FROM system_metrics GROUP BY idc;
 2 rows in set (0.03 sec)
 ```
 
-关于 `SELECT` 语句的更多信息，请查看 [SELECT](/reference/sql/select.md) 文件。
+关于 `SELECT` 语句的更多信息，请查看 [SELECT](../reference/sql/select.md) 文件。
 
 ## Visualize data
 


### PR DESCRIPTION
This [link](https://www.docker.com/getting-started/) for getting started with docker has moved to https://www.docker.com/get-started/ .

Then some links in the document use relative paths, but cannot be accessed normally in GitHub, so add '...` prefix.