### PR TITLE
docs: add password to cloud integration docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,8 @@
-# Checklist
+## What's Changed in this PR
+
+*Describe the change in this PR*
+
+## Checklist
 
 - [ ] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
+- [ ] This change requires follow-up update in localized docs.

--- a/docs/db-cloud-shared/clients/grafana-integration.md
+++ b/docs/db-cloud-shared/clients/grafana-integration.md
@@ -12,7 +12,7 @@ Fill in Prometheus server URL in HTTP:
 Click basic auth in the Auth section and fill in your GreptimeDB username and password in Basic Auth Details:
 
 - User: `<username>`
-- Password: *Your GreptimeDB password*
+- Password: `<password>`
 
 Then click Save & Test button to test the connection.
 
@@ -23,7 +23,7 @@ Click the Add data source button and select MySQL as the type. Fill in the follo
 - Host: `<host>:4002`
 - Database: `<dbname>`
 - User: `<username>`
-- Password: *Your GreptimeDB password*
+- Password: `<password>`
 - Session timezone: `UTC`
 
 Then click Save & Test button to test the connection.

--- a/docs/db-cloud-shared/clients/otlp-integration.md
+++ b/docs/db-cloud-shared/clients/otlp-integration.md
@@ -1,5 +1,5 @@
 
-GreptimeDB can be used as a collector to receive OpenTelemetry Metrics via the [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp) protocol. 
+GreptimeDB can be used as a collector to receive OpenTelemetry Metrics via the [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp) protocol.
 
 ### API
 
@@ -8,7 +8,7 @@ To send OpenTelemetry Metrics to GreptimeDB through OpenTelemetry SDK libraries,
 * URL: `https://<host>/v1/otlp/v1/metrics`
 * Headers:
   * `X-Greptime-DB-Name`: `<dbname>`
-  * `Authorization`: `Basic` authentication, which is a Base64 encoded string of `<username>:<Your database password>`. For more information, please refer to [Authentication](https://docs.greptime.com/user-guide/clients/authentication) and [HTTP API](https://docs.greptime.com/user-guide/clients/http-api#authentication)
+  * `Authorization`: `Basic` authentication, which is a Base64 encoded string of `<username>:<password>`. For more information, please refer to [Authentication](https://docs.greptime.com/user-guide/clients/authentication) and [HTTP API](https://docs.greptime.com/user-guide/clients/http-api#authentication)
 
 The request uses binary protobuf to encode the payload, so you need to use packages that support `HTTP/protobuf`. For example, in Node.js, you can use [`exporter-trace-otlp-proto`](https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-proto); in Go, you can use [`go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp); in Java, you can use [`io.opentelemetry:opentelemetry-exporter-otlp`](https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-exporter-otlp); and in Python, you can use [`opentelemetry-exporter-otlp-proto-http`](https://pypi.org/project/opentelemetry-exporter-otlp-proto-http/).
 

--- a/docs/db-cloud-shared/clients/vector-integration.md
+++ b/docs/db-cloud-shared/clients/vector-integration.md
@@ -8,7 +8,7 @@ type = "greptimedb"
 endpoint = "<host>:4001"
 dbname = "<dbname>"
 username = "<username>"
-password = "Your database password of GreptimeDB"
+password = "<password>"
 ```
 
 For more configuration options, see [Vector GreptimeDB Configuration](https://vector.dev/docs/reference/sinks/greptimedb/).

--- a/docs/greptimecloud/integrations/influxdb.md
+++ b/docs/greptimecloud/integrations/influxdb.md
@@ -9,7 +9,7 @@ Please refer to [InfluxDB client](https://docs.greptime.com/user-guide/clients/i
 
 - URL: `https://<host>/v1/influxdb/write?db=<dbname>`
 - Username: `<username>`
-- Password: Your service password
+- Password: `<password>`
 
 ```sh
 curl -i 'https://<host>/v1/influxdb/write?db=<dbname>&u=<username>&p=PASSWORD' \

--- a/docs/greptimecloud/integrations/mysql.md
+++ b/docs/greptimecloud/integrations/mysql.md
@@ -10,7 +10,7 @@ To connect to GreptimeCloud in MySQL protocol, using information below:
 - Port: `4002`
 - Database: `<dbname>`
 - Username: `<username>`
-- Password: *Your GreptimeCloud service password*
+- Password: `<password>`
 
 ## MySQL CLI
 

--- a/docs/greptimecloud/integrations/postgresql.md
+++ b/docs/greptimecloud/integrations/postgresql.md
@@ -12,7 +12,7 @@ To connect to GreptimeCloud in Postgres wire protocol, using information below:
 - Port: `4003`
 - Database: `<dbname>`
 - Username: `<username>`
-- Password: *Your GreptimeCloud service password*
+- Password: `<password>`
 
 ## `psql`
 

--- a/docs/greptimecloud/integrations/postgresql.md
+++ b/docs/greptimecloud/integrations/postgresql.md
@@ -25,18 +25,16 @@ psql -h <host> -p 4003 -U <username> -d <dbname> -W
 ## Postgres Connection String
 
 Using the connection string below for compatible client libraries like psycopg,
-rust-postgres and more. Replace *PASSWORD* with the GreptimeCloud service
-password.
+rust-postgres and more.
 
 ```
-host=<host> port=4003 dbname=<dbname> user=<username> password=PASSWORD
+host=<host> port=4003 dbname=<dbname> user=<username> password=<password>
 ```
 
 ## Postgres JDBC URL
 
-Using the URL below with your Postgres JDBC client. Replace *PASSWORD* with the
-GreptimeCloud service password.
+Using the URL below with your Postgres JDBC client.
 
 ```
-jdbc:postgresql://<host>:4003/<dbname>?user=<username>&password=PASSOWRD&ssl=true
+jdbc:postgresql://<host>:4003/<dbname>?user=<username>&password=<password>&ssl=true
 ```

--- a/docs/greptimecloud/integrations/prometheus/quick-setup.md
+++ b/docs/greptimecloud/integrations/prometheus/quick-setup.md
@@ -16,13 +16,13 @@ remote_write:
   - url: https://<host>/v1/prometheus/write?db=<dbname>
     basic_auth:
       username: <username>
-      password: #paste your service password
+      password: <password>
 
 remote_read:
   - url: https://<host>/v1/prometheus/read?db=<dbname>
     basic_auth:
       username: <username>
-      password: #paste your service password
+      password: <password>
 ```
 
 ## Rule Management

--- a/docs/greptimecloud/integrations/sdk-libraries/go.md
+++ b/docs/greptimecloud/integrations/sdk-libraries/go.md
@@ -20,7 +20,7 @@ options := []grpc.DialOption{
 cfg := greptime.NewCfg("<host>").
     WithDatabase("<dbname>").
     WithPort(4001).
-    WithAuth("<username>", "*Your GreptimeCloud service password*").
+    WithAuth("<username>", "<password>").
     WithDialOptions(options...). // specify your gRPC dail options
     WithCallOptions()            // specify your gRPC call options
 

--- a/docs/greptimecloud/integrations/sdk-libraries/go.md
+++ b/docs/greptimecloud/integrations/sdk-libraries/go.md
@@ -8,7 +8,7 @@ To connect to GreptimeCloud, using information below:
 - Port: `4001`
 - Database: `<dbname>`
 - Username: `<username>`
-- Password: *Your GreptimeCloud service password*
+- Password: `<password>`
 
 The following code shows how to create a `client`.
 

--- a/docs/greptimecloud/integrations/sdk-libraries/java.md
+++ b/docs/greptimecloud/integrations/sdk-libraries/java.md
@@ -8,13 +8,13 @@ To connect to GreptimeCloud, using information below:
 - Port: `4001`
 - Database: `<dbname>`
 - Username: `<username>`
-- Password: *Your GreptimeCloud service password*
+- Password: `<password>`
 
 The following code snippet shows how to create a client.
 
 ```java
 String endpoint = "<host>:4001";
-AuthInfo authInfo = new AuthInfo("<username>", "*Your GreptimeCloud service password*");
+AuthInfo authInfo = new AuthInfo("<username>", "<password>");
 
 GreptimeOptions opts = GreptimeOptions.newBuilder(endpoint) //
         .authInfo(authInfo)

--- a/docs/zh/db-cloud-shared/clients/grafana-integration.md
+++ b/docs/zh/db-cloud-shared/clients/grafana-integration.md
@@ -13,7 +13,7 @@ GreptimeDB 服务可以配置为 [Grafana 数据源](https://grafana.com/docs/gr
 在 Auth 部分中单击 basic auth，并在 Basic Auth Details 中填写 GreptimeDB 的用户名和密码：
 
 - User: `<username>`
-- Password: *Your GreptimeDB password*
+- Password: `<password>`
 
 然后单击 Save & Test 按钮以测试连接。
 
@@ -24,7 +24,7 @@ GreptimeDB 服务可以配置为 [Grafana 数据源](https://grafana.com/docs/gr
 - Host: `<host>:4002`
 - Database: `<dbname>`
 - User: `<username>`
-- Password: *Your GreptimeDB password*
+- Password: `<password>`
 - Session timezone: `UTC`
 
 然后单击 Save & Test 按钮以测试连接。

--- a/docs/zh/db-cloud-shared/clients/otlp-integration.md
+++ b/docs/zh/db-cloud-shared/clients/otlp-integration.md
@@ -8,7 +8,7 @@ GreptimeDB 可以作为 collector 通过 [OTLP/HTTP](https://opentelemetry.io/do
 * URL: `https://<host>/v1/otlp/v1/metrics`
 * Headers:
   * `X-Greptime-DB-Name`: `<dbname>`
-* `Authorization`: `Basic` 认证，是 `<username>:<Your database password>` 的 Base64 编码字符串。更多信息请参考 [鉴权](https://docs.greptime.cn/user-guide/clients/authentication) 和 [HTTP API](https://docs.greptime.com/user-guide/clients/http-api#authentication)。
+* `Authorization`: `Basic` 认证，是 `<username>:<password>` 的 Base64 编码字符串。更多信息请参考 [鉴权](https://docs.greptime.cn/user-guide/clients/authentication) 和 [HTTP API](https://docs.greptime.com/user-guide/clients/http-api#authentication)。
 
 请求中使用 binary protobuf 编码 payload，因此你需要使用支持 `HTTP/protobuf` 的包。例如，在 Node.js 中，可以使用 [`exporter-trace-otlp-proto`](https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-proto)；在 Go 中，可以使用 [`go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp)；在 Java 中，可以使用 [`io.opentelemetry:opentelemetry-exporter-otlp`](https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-exporter-otlp)；在 Python 中，可以使用 [`opentelemetry-exporter-otlp-proto-http`](https://pypi.org/project/opentelemetry-exporter-otlp-proto-http/)。
 

--- a/docs/zh/db-cloud-shared/clients/vector-integration.md
+++ b/docs/zh/db-cloud-shared/clients/vector-integration.md
@@ -8,7 +8,7 @@ type = "greptimedb"
 endpoint = "<host>:4001"
 dbname = "<dbname>"
 username = "<username>"
-password = "Your database password of GreptimeDB"
+password = "<password>"
 ```
 
 请前往 [Vector GreptimeDB Configuration](https://vector.dev/docs/reference/sinks/greptimedb/) 查看更多配置项。

--- a/docs/zh/greptimecloud/integrations/grafana.md
+++ b/docs/zh/greptimecloud/integrations/grafana.md
@@ -1,4 +1,3 @@
 # Grafana
 
 <!--@include: ../../db-cloud-shared/clients/grafana-integration.md-->
-

--- a/docs/zh/greptimecloud/integrations/influxdb.md
+++ b/docs/zh/greptimecloud/integrations/influxdb.md
@@ -4,7 +4,7 @@ GreptimeCloud 提供了 [Influxdb line protocol](https://docs.influxdata.com/inf
 
 - URL: `https://<host>/v1/influxdb/write?db=<dbname>`
 - Username: `<username>`
-- Password: Your service password
+- Password: `<password>`
 
 ```sh
 curl -i 'https://<host>/v1/influxdb/write?db=<dbname>&u=<username>&p=PASSWORD' \

--- a/docs/zh/greptimecloud/integrations/mysql.md
+++ b/docs/zh/greptimecloud/integrations/mysql.md
@@ -8,7 +8,7 @@ GreptimeCloud 可以通过 MySQL 协议访问，兼容大多数标准客户端�
 - Port: `4002`
 - Database: `<dbname>`
 - Username: `<username>`
-- Password: *Your GreptimeCloud service password*
+- Password: `<password>`
 
 ## MySQL CLI
 

--- a/docs/zh/greptimecloud/integrations/postgresql.md
+++ b/docs/zh/greptimecloud/integrations/postgresql.md
@@ -22,16 +22,16 @@ psql -h <host> -p 4003 -U <username> -d <dbname> -W
 
 ## Postgres 连接字符串
 
-使用以下连接字符串与兼容的客户端库（如 psycopg、rust-postgres 等）连接。请将 *PASSWORD* 替换为 GreptimeCloud service 的密码。
+使用以下连接字符串与兼容的客户端库（如 psycopg、rust-postgres 等）连接。
 
 ```
-host=<host> port=4003 dbname=<dbname> user=<username> password=PASSWORD
+host=<host> port=4003 dbname=<dbname> user=<username> password=<password>
 ```
 
 ## Postgres JDBC URL
 
-在你的 Postgres JDBC 客户端使用以下 URL，请将 *PASSWORD* 替换为 GreptimeCloud service 的密码。
+在你的 Postgres JDBC 客户端使用以下 URL。
 
 ```
-jdbc:postgresql://<host>:4003/<dbname>?user=<username>&password=PASSOWRD&ssl=true
+jdbc:postgresql://<host>:4003/<dbname>?user=<username>&password=<password>&ssl=true
 ```

--- a/docs/zh/greptimecloud/integrations/postgresql.md
+++ b/docs/zh/greptimecloud/integrations/postgresql.md
@@ -10,7 +10,7 @@ GreptimeCloud 支持用 PostgreSQL v3 协议访问 GreptimeDB。大多数标准�
 - Port: `4003`
 - Database: `<dbname>`
 - Username: `<username>`
-- Password: *Your GreptimeCloud service password*
+- Password: `<password>`
 
 ## `psql`
 

--- a/docs/zh/greptimecloud/integrations/prometheus/quick-setup.md
+++ b/docs/zh/greptimecloud/integrations/prometheus/quick-setup.md
@@ -13,13 +13,13 @@ remote_write:
   - url: https://<host>/v1/prometheus/write?db=<dbname>
     basic_auth:
       username: <username>
-      password: #paste your service password
+      password: <password>
 
 remote_read:
   - url: https://<host>/v1/prometheus/read?db=<dbname>
     basic_auth:
       username: <username>
-      password: #paste your service password
+      password: <password>
 ```
 
 ## 规则管理

--- a/docs/zh/greptimecloud/integrations/sdk-libraries/go.md
+++ b/docs/zh/greptimecloud/integrations/sdk-libraries/go.md
@@ -9,7 +9,7 @@ GreptimeDB Go SDK 使用 gRPC 与数据库通信，
 - Port: `4001`
 - Database: `<dbname>`
 - Username: `<username>`
-- Password: *Your GreptimeCloud service password*
+- Password: `<password>`
 
 下方的代码片段展示了如何使用 Go SDK 建立一个 `client` 连接对象：
 
@@ -21,7 +21,7 @@ options := []grpc.DialOption{
 cfg := greptime.NewCfg("<host>").
     WithDatabase("<dbname>").
     WithPort(4001).
-    WithAuth("<username>", "*Your GreptimeCloud service password*").
+    WithAuth("<username>", "<password>").
     WithDialOptions(options...). // specify your gRPC dail options
     WithCallOptions()            // specify your gRPC call options
 

--- a/docs/zh/greptimecloud/integrations/sdk-libraries/java.md
+++ b/docs/zh/greptimecloud/integrations/sdk-libraries/java.md
@@ -9,13 +9,13 @@ GreptimeDB Java SDK 使用 gRPC 与数据库通信，
 - Port: `4001`
 - Database: `<dbname>`
 - Username: `<username>`
-- Password: *Your GreptimeCloud service password*
+- Password: `<password>`
 
 下方的代码片段展示了如何使用 Java SDK 建立一个 `client` 连接对象：
 
 ```java
 String endpoint = "<host>:4001";
-AuthInfo authInfo = new AuthInfo("<username>", "*Your GreptimeCloud service password*");
+AuthInfo authInfo = new AuthInfo("<username>", "<password>");
 
 GreptimeOptions opts = GreptimeOptions.newBuilder(endpoint) //
         .authInfo(authInfo)


### PR DESCRIPTION
# Checklist

- [x] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.

This patch adds password placeholder to cloud integration docs