### PR TITLE
fix(user-guide): change termux download link to github release

### DIFF
--- a/docs/en/v0.4/user-guide/operations/run-on-android.md
+++ b/docs/en/v0.4/user-guide/operations/run-on-android.md
@@ -4,7 +4,7 @@ Since v0.4.0, GreptimeDB supports running on Android platforms with ARM64 CPU an
 
 ## Install terminal emulator on Android
 
-You can install [Termux](https://termux.dev/) from [Github release page](https://github.com/termux/termux-app/releases/latest).
+You can install [Termux](https://termux.dev/) from [GitHub release page](https://github.com/termux/termux-app/releases/latest).
 
 
 ## Download GreptimeDB Android binary.

--- a/docs/en/v0.4/user-guide/operations/run-on-android.md
+++ b/docs/en/v0.4/user-guide/operations/run-on-android.md
@@ -4,7 +4,7 @@ Since v0.4.0, GreptimeDB supports running on Android platforms with ARM64 CPU an
 
 ## Install terminal emulator on Android
 
-You can install [Termux](https://termux.dev/) from [Google Play store](https://play.google.com/store/apps/details?id=com.termux).
+You can install [Termux](https://termux.dev/) from [Github release page](https://github.com/termux/termux-app/releases/latest).
 
 
 ## Download GreptimeDB Android binary.

--- a/docs/zh/v0.4/user-guide/operations/run-on-android.md
+++ b/docs/zh/v0.4/user-guide/operations/run-on-android.md
@@ -4,7 +4,7 @@
 
 ## 安装终端模拟器
 
-您可以从 [Github release 页面](https://github.com/termux/termux-app/releases/latest) 下载 [Termux 终端模拟器](https://termux.dev/) 来运行 GreptimeDB.
+您可以从 [GitHub release 页面](https://github.com/termux/termux-app/releases/latest) 下载 [Termux 终端模拟器](https://termux.dev/) 来运行 GreptimeDB.
 
 
 

--- a/docs/zh/v0.4/user-guide/operations/run-on-android.md
+++ b/docs/zh/v0.4/user-guide/operations/run-on-android.md
@@ -4,7 +4,7 @@
 
 ## 安装终端模拟器
 
-您可以从 [Google Play 商店安装](https://play.google.com/store/apps/details?id=com.termux)终端模拟器，如 [Termux](https://termux.dev/)，来运行 GreptimeDB.
+您可以从 [Github release 页面](https://github.com/termux/termux-app/releases/latest) 下载 [Termux 终端模拟器](https://termux.dev/) 来运行 GreptimeDB.
 
 
 


### PR DESCRIPTION
## What's Changed in this PR

Change Termux download link from Google Play to Github release page.


## Checklist

- [X] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
