### PR TITLE
docs: typo backquote -> single quote

### DIFF
--- a/docs/en/v0.4/developer-guide/metasrv/admin-api.md
+++ b/docs/en/v0.4/developer-guide/metasrv/admin-api.md
@@ -138,7 +138,7 @@ curl -X GET http://localhost:3002/admin/tables
 #### Request
 
 ```bash
-curl -X GET `http://localhost:3002/admin/tables?catalog_name=greptime&schema_name=public`
+curl -X GET 'http://localhost:3002/admin/tables?catalog_name=greptime&schema_name=public'
 ```
 
 #### Response

--- a/docs/zh/v0.4/developer-guide/metasrv/admin-api.md
+++ b/docs/zh/v0.4/developer-guide/metasrv/admin-api.md
@@ -138,7 +138,7 @@ curl -X GET http://localhost:3002/admin/tables
 #### Request
 
 ```bash
-curl -X GET `http://localhost:3002/admin/tables?catalog_name=greptime&schema_name=public`
+curl -X GET 'http://localhost:3002/admin/tables?catalog_name=greptime&schema_name=public'
 ```
 
 #### Response


### PR DESCRIPTION
## What's Changed in this PR

This pr mainly fix typo backquote -> single quote.

## Checklist

- [x] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [x] This change requires follow-up update in localized docs.
