### PR TITLE
docs: align frontend cmd name to rpc 

### DIFF
--- a/docs/en/v0.4/user-guide/operations/configuration.md
+++ b/docs/en/v0.4/user-guide/operations/configuration.md
@@ -74,7 +74,7 @@ greptime frontend start --help
 - `-c`/`--config-file`: The configuration file for frontend;
 - `--disable-dashboard`: Disable dashboard http service, default is `false`.
 - `--env-prefix <ENV_PREFIX>`: The prefix of environment variables, default is `GREPTIMEDB_FRONTEND`;
-- `--grpc-addr <GPRC_ADDR>`: GRPC server address;
+- `--rpc-addr <RPC_ADDR>`: GRPC server address;
 - `--http-addr <HTTP_ADDR>`: HTTP server address;
 - `--http-timeout <HTTP_TIMEOUT>`: HTTP request timeout in seconds.
 - `--influxdb-enable`: Whether to enable InfluxDB protocol in HTTP API;

--- a/docs/zh/v0.4/user-guide/operations/configuration.md
+++ b/docs/zh/v0.4/user-guide/operations/configuration.md
@@ -74,7 +74,7 @@ greptime frontend start --help
 - `-c`/`--config-file`: 指定 `frontend` 启动配置文件
 - `--disable-dashboard`:  是否禁用 dashboard，默认为 `false`。
 - `--env-prefix <ENV_PREFIX>`: 配置的环境变量前缀，默认为`GREPTIMEDB_FRONTEND`;
-- `--grpc-addr <GPRC_ADDR>`: gRPC 服务地址
+- `--rpc-addr <RPC_ADDR>`: gRPC 服务地址
 - `--http-addr <HTTP_ADDR>`: HTTP 服务器地址
 - `--http-timeout <HTTP_TIMEOUT>`:  HTTP 超时设置，单位秒
 - `--influxdb-enable`:  是否启用 `influxdb` HTTP 接口，默认为 true。


### PR DESCRIPTION
## What's Changed in this PR

Update en and zh frontend cmd docs from grpc_addr to rpc_addr . Related change https://github.com/GreptimeTeam/greptimedb/pull/2609, https://github.com/GreptimeTeam/docs/issues/653

## Checklist

- [ ] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
