### PR TITLE
fix: remove OTLP collector description

### DIFF
--- a/docs/en/v0.3/db-cloud-shared/clients/otlp-integration.md
+++ b/docs/en/v0.3/db-cloud-shared/clients/otlp-integration.md
@@ -1,5 +1,4 @@
-
-GreptimeDB can be used as a collector to receive OpenTelemetry Metrics via the [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp) protocol.
+GreptimeDB is an observability backend to consume OpenTelemetry Metrics natively via [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp) protocol.
 
 ### API
 

--- a/docs/en/v0.4/db-cloud-shared/clients/otlp-integration.md
+++ b/docs/en/v0.4/db-cloud-shared/clients/otlp-integration.md
@@ -1,5 +1,4 @@
-
-GreptimeDB can be used as a collector to receive OpenTelemetry Metrics via the [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp) protocol.
+GreptimeDB is an observability backend to consume OpenTelemetry Metrics natively via [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp) protocol.
 
 ### API
 

--- a/docs/zh/v0.3/db-cloud-shared/clients/otlp-integration.md
+++ b/docs/zh/v0.3/db-cloud-shared/clients/otlp-integration.md
@@ -1,5 +1,4 @@
-
-GreptimeDB 可以作为 collector 通过 [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp) 协议接收 OpenTelemetry 指标。
+GreptimeDB 通过原生支持 [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp) 协议，可以作为后端存储服务来接收 OpenTelemetry 指标数据。
 
 ### API
 

--- a/docs/zh/v0.4/db-cloud-shared/clients/otlp-integration.md
+++ b/docs/zh/v0.4/db-cloud-shared/clients/otlp-integration.md
@@ -1,5 +1,4 @@
-
-GreptimeDB 可以作为 collector 通过 [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp) 协议接收 OpenTelemetry 指标。
+GreptimeDB 通过原生支持 [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp) 协议，可以作为后端存储服务来接收 OpenTelemetry 指标数据。
 
 ### API
 


### PR DESCRIPTION
## What's Changed in this PR

GreptimeDB is not a collector, it is a backend, or vendor.  GreptimeDB has not implemented the collector part.

## Checklist

- [x] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.

## Reference

- https://opentelemetry.io/ecosystem/vendors/
- https://opentelemetry.io/docs/collector/