### PR TITLE
fix: langchain module path in greptimeai

### DIFF
--- a/docs/v0.4/en/greptimecloud/greptimeai/langchain.md
+++ b/docs/v0.4/en/greptimecloud/greptimeai/langchain.md
@@ -27,7 +27,7 @@ export OPENAI_API_KEY='sk-xxx'
 - Instrument your LLM application
 
 ```python
-from greptimeai.langchain.callback import GreptimeCallbackHandler
+from greptimeai.langchain_callback import GreptimeCallbackHandler
 from langchain.chains import LLMChain
 from langchain.llms import OpenAI
 from langchain.prompts import PromptTemplate


### PR DESCRIPTION
## What's Changed in this PR

change GreptimeCallbackHandler import path for langchain instrument in greptimeai

## Checklist

- [ ] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
