### PR TITLE
fix: grafana version and the link of date functions

### DIFF
--- a/docs/v0.4/en/getting-started/quick-start/prerequisites.md
+++ b/docs/v0.4/en/getting-started/quick-start/prerequisites.md
@@ -9,7 +9,7 @@ Here we use [Docker Compose](https://docs.docker.com/compose/) to start Greptime
 ```yaml
 services:
   grafana:
-    image: grafana/grafana-oss:latest
+    image: grafana/grafana-oss:9.5.15
     container_name: grafana
     ports:
       - 3000:3000

--- a/docs/v0.4/en/getting-started/quick-start/prometheus.md
+++ b/docs/v0.4/en/getting-started/quick-start/prometheus.md
@@ -34,7 +34,7 @@ We use [Docker Compose](https://docs.docker.com/compose/) to start GreptimeDB, P
 ```yaml
 services:
   grafana:
-    image: grafana/grafana-oss:latest
+    image: grafana/grafana-oss:9.5.15
     container_name: grafana
     ports:
       - 3000:3000

--- a/docs/v0.4/en/getting-started/quick-start/vector.md
+++ b/docs/v0.4/en/getting-started/quick-start/vector.md
@@ -30,7 +30,7 @@ Here we use [Docker Compose](https://docs.docker.com/compose/) to start Greptime
 ```yaml
 services:
   grafana:
-    image: grafana/grafana-oss:latest
+    image: grafana/grafana-oss:9.5.15
     container_name: grafana
     ports:
       - 3000:3000

--- a/docs/v0.4/en/reference/sql/functions.md
+++ b/docs/v0.4/en/reference/sql/functions.md
@@ -156,4 +156,4 @@ Some commonly used fields are:
 
 ### More Functions
 
-GreptimeDB compiled PostgreSQL's date functions. Please refer to [PostgreSQL's documentation](https://www.postgresql.org/docs/current/functions-datetime.html) for more functions.
+For more functions related to time and date, please refer to the [Time and Date Functions](https://arrow.apache.org/datafusion/user-guide/sql/scalar_functions.html#time-and-date-functions) section of the DataFusion documentation.

--- a/docs/v0.4/zh/getting-started/quick-start/prerequisites.md
+++ b/docs/v0.4/zh/getting-started/quick-start/prerequisites.md
@@ -9,7 +9,7 @@
 ```yaml
 services:
   grafana:
-    image: grafana/grafana-oss:latest
+    image: grafana/grafana-oss:9.5.15
     container_name: grafana
     ports:
       - 3000:3000

--- a/docs/v0.4/zh/getting-started/quick-start/prometheus.md
+++ b/docs/v0.4/zh/getting-started/quick-start/prometheus.md
@@ -34,7 +34,7 @@ remote_write:
 ```yaml
 services:
   grafana:
-    image: grafana/grafana-oss:latest
+    image: grafana/grafana-oss:9.5.15
     container_name: grafana
     ports:
       - 3000:3000

--- a/docs/v0.4/zh/getting-started/quick-start/vector.md
+++ b/docs/v0.4/zh/getting-started/quick-start/vector.md
@@ -29,7 +29,7 @@ dbname = "public"
 ```yaml
 services:
   grafana:
-    image: grafana/grafana-oss:latest
+    image: grafana/grafana-oss:9.5.15
     container_name: grafana
     ports:
       - 3000:3000

--- a/docs/v0.4/zh/reference/sql/functions.md
+++ b/docs/v0.4/zh/reference/sql/functions.md
@@ -155,4 +155,4 @@ date_part(field, source)
 
 ### 更多 Functions
 
-GreptimeDB 兼容 PostgreSQL 的日期函数。请参考 [PostgreSQL 文档](https://www.postgresql.org/docs/current/functions-datetime.html) 获取更多函数。
+有关时间和日期的更多函数，请参考 DataFusion 文档中的 [Time and Date Functions](https://arrow.apache.org/datafusion/user-guide/sql/scalar_functions.html#time-and-date-functions) 部分。

--- a/docs/v0.5/en/getting-started/quick-start/prerequisites.md
+++ b/docs/v0.5/en/getting-started/quick-start/prerequisites.md
@@ -9,7 +9,7 @@ Here we use [Docker Compose](https://docs.docker.com/compose/) to start Greptime
 ```yaml
 services:
   grafana:
-    image: grafana/grafana-oss:latest
+    image: grafana/grafana-oss:9.5.15
     container_name: grafana
     ports:
       - 3000:3000

--- a/docs/v0.5/en/getting-started/quick-start/prometheus.md
+++ b/docs/v0.5/en/getting-started/quick-start/prometheus.md
@@ -34,7 +34,7 @@ We use [Docker Compose](https://docs.docker.com/compose/) to start GreptimeDB, P
 ```yaml
 services:
   grafana:
-    image: grafana/grafana-oss:latest
+    image: grafana/grafana-oss:9.5.15
     container_name: grafana
     ports:
       - 3000:3000

--- a/docs/v0.5/en/getting-started/quick-start/vector.md
+++ b/docs/v0.5/en/getting-started/quick-start/vector.md
@@ -30,7 +30,7 @@ Here we use [Docker Compose](https://docs.docker.com/compose/) to start Greptime
 ```yaml
 services:
   grafana:
-    image: grafana/grafana-oss:latest
+    image: grafana/grafana-oss:9.5.15
     container_name: grafana
     ports:
       - 3000:3000

--- a/docs/v0.5/en/reference/sql/functions.md
+++ b/docs/v0.5/en/reference/sql/functions.md
@@ -156,4 +156,4 @@ Some commonly used fields are:
 
 ### More Functions
 
-GreptimeDB compiled PostgreSQL's date functions. Please refer to [PostgreSQL's documentation](https://www.postgresql.org/docs/current/functions-datetime.html) for more functions.
+For more functions related to time and date, please refer to the [Time and Date Functions](https://arrow.apache.org/datafusion/user-guide/sql/scalar_functions.html#time-and-date-functions) section of the DataFusion documentation.

--- a/docs/v0.5/zh/getting-started/quick-start/prerequisites.md
+++ b/docs/v0.5/zh/getting-started/quick-start/prerequisites.md
@@ -9,7 +9,7 @@
 ```yaml
 services:
   grafana:
-    image: grafana/grafana-oss:latest
+    image: grafana/grafana-oss:9.5.15
     container_name: grafana
     ports:
       - 3000:3000

--- a/docs/v0.5/zh/getting-started/quick-start/prometheus.md
+++ b/docs/v0.5/zh/getting-started/quick-start/prometheus.md
@@ -34,7 +34,7 @@ remote_write:
 ```yaml
 services:
   grafana:
-    image: grafana/grafana-oss:latest
+    image: grafana/grafana-oss:9.5.15
     container_name: grafana
     ports:
       - 3000:3000

--- a/docs/v0.5/zh/getting-started/quick-start/vector.md
+++ b/docs/v0.5/zh/getting-started/quick-start/vector.md
@@ -29,7 +29,7 @@ dbname = "public"
 ```yaml
 services:
   grafana:
-    image: grafana/grafana-oss:latest
+    image: grafana/grafana-oss:9.5.15
     container_name: grafana
     ports:
       - 3000:3000

--- a/docs/v0.5/zh/reference/sql/functions.md
+++ b/docs/v0.5/zh/reference/sql/functions.md
@@ -155,4 +155,4 @@ date_part(field, source)
 
 ### 更多 Functions
 
-GreptimeDB 兼容 PostgreSQL 的日期函数。请参考 [PostgreSQL 文档](https://www.postgresql.org/docs/current/functions-datetime.html) 获取更多函数。
+有关时间和日期的更多函数，请参考 DataFusion 文档中的 [Time and Date Functions](https://arrow.apache.org/datafusion/user-guide/sql/scalar_functions.html#time-and-date-functions) 部分。


### PR DESCRIPTION
## What's Changed in this PR

- Use grafana 9.5.15 in quick start
- The datafusion link of date functions

## Checklist

- [x] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
