### PR TITLE
fix: retrieve missing Quick Start documentation for GreptimeCloud

### DIFF
--- a/docs/v0.6/en/greptimecloud/getting-started/go.md
+++ b/docs/v0.6/en/greptimecloud/getting-started/go.md
@@ -4,11 +4,7 @@
 <!--@include: ./create-service.md-->
 
 ## Write Data
-<!--@include: ../../db-cloud-shared/quick-start/go.md-->
-
-```shell
-go run github.com/GreptimeCloudStarters/quick-start-go@latest -host=<host> -db=<dbname> -username=<username> -password=<password>
-```
+<!--@include: ./quick-start/go.md-->
 
 ## Visualize Data
 <!--@include: ./visualize-data.md-->

--- a/docs/v0.6/en/greptimecloud/getting-started/influxdb.md
+++ b/docs/v0.6/en/greptimecloud/getting-started/influxdb.md
@@ -4,11 +4,7 @@
 <!--@include: ./create-service.md-->
 
 ## Write Data
-<!--@include: ../../db-cloud-shared/quick-start/influxdb.md-->
-
-```shell
-curl -L https://raw.githubusercontent.com/GreptimeCloudStarters/quick-start-influxdb-line-protocol/main/quick-start.sh | bash -s -- -h <host> -d <dbname> -u <username> -p <password>
-```
+<!--@include: ./quick-start/influxdb.md-->
 
 ## Visualize Data
 <!--@include: ./visualize-data.md-->

--- a/docs/v0.6/en/greptimecloud/getting-started/java.md
+++ b/docs/v0.6/en/greptimecloud/getting-started/java.md
@@ -4,11 +4,7 @@
 <!--@include: ./create-service.md-->
 
 ## Write Data
-<!--@include: ../../db-cloud-shared/quick-start/java.md-->
-
-```shell
-curl -L https://github.com/GreptimeCloudStarters/quick-start-java/releases/latest/download/greptime-quick-start-java-all.jar --output quick-start.jar && java -jar quick-start.jar -h <host> -db <dbname> -u <username> -p <password>
-```
+<!--@include: ./quick-start/java.md-->
 
 ## Visualize Data
 <!--@include: ./visualize-data.md-->

--- a/docs/v0.6/en/greptimecloud/getting-started/mysql.md
+++ b/docs/v0.6/en/greptimecloud/getting-started/mysql.md
@@ -4,11 +4,7 @@
 <!--@include: ./create-service.md-->
 
 ## Write Data
-<!--@include: ../../db-cloud-shared/quick-start/mysql.md-->
-
-```shell
-curl -L https://raw.githubusercontent.com/GreptimeCloudStarters/quick-start-mysql/main/quick-start.sh | bash -s -- -h <host> -d <dbname> -u <username> -p <password>
-```
+<!--@include: ./quick-start/mysql.md-->
 
 ## Visualize Data
 <!--@include: ./visualize-data.md-->

--- a/docs/v0.6/en/greptimecloud/getting-started/node.md
+++ b/docs/v0.6/en/greptimecloud/getting-started/node.md
@@ -4,11 +4,7 @@
 <!--@include: ./create-service.md-->
 
 ## Write Data
-<!--@include: ../../db-cloud-shared/quick-start/node.md-->
-
-```shell
-npx greptime-cloud-quick-start@latest --host=<host> --db=<dbname> --username=<username> --password=<password>
-```
+<!--@include: ./quick-start/node.md-->
 
 ## Visualize Data
 <!--@include: ./visualize-data.md-->

--- a/docs/v0.6/en/greptimecloud/getting-started/python.md
+++ b/docs/v0.6/en/greptimecloud/getting-started/python.md
@@ -4,11 +4,7 @@
 <!--@include: ./create-service.md-->
 
 ## Write Data
-<!--@include: ../../db-cloud-shared/quick-start/python.md-->
-
-```shell
-pipx run --no-cache greptime-cloud-quick-start -host <host> -db <dbname> -u <username> -p <password>
-```
+<!--@include: ./quick-start/python.md-->
 
 ## Visualize Data
 <!--@include: ./visualize-data.md-->

--- a/docs/v0.6/en/greptimecloud/getting-started/quick-start/go.md
+++ b/docs/v0.6/en/greptimecloud/getting-started/quick-start/go.md
@@ -1,0 +1,6 @@
+
+<!--@include: ../../../db-cloud-shared/quick-start/go.md-->
+
+```shell
+go run github.com/GreptimeCloudStarters/quick-start-go@latest -host=<host> -db=<dbname> -username=<username> -password=<password>
+```

--- a/docs/v0.6/en/greptimecloud/getting-started/quick-start/influxdb.md
+++ b/docs/v0.6/en/greptimecloud/getting-started/quick-start/influxdb.md
@@ -1,0 +1,6 @@
+
+<!--@include: ../../../db-cloud-shared/quick-start/influxdb.md-->
+
+```shell
+curl -L https://raw.githubusercontent.com/GreptimeCloudStarters/quick-start-influxdb-line-protocol/main/quick-start.sh | bash -s -- -h <host> -d <dbname> -u <username> -p <password>
+```

--- a/docs/v0.6/en/greptimecloud/getting-started/quick-start/java.md
+++ b/docs/v0.6/en/greptimecloud/getting-started/quick-start/java.md
@@ -1,0 +1,6 @@
+
+<!--@include: ../../../db-cloud-shared/quick-start/java.md-->
+
+```shell
+curl -L https://github.com/GreptimeCloudStarters/quick-start-java/releases/latest/download/greptime-quick-start-java-all.jar --output quick-start.jar && java -jar quick-start.jar -h <host> -db <dbname> -u <username> -p <password>
+```

--- a/docs/v0.6/en/greptimecloud/getting-started/quick-start/mysql.md
+++ b/docs/v0.6/en/greptimecloud/getting-started/quick-start/mysql.md
@@ -1,0 +1,6 @@
+
+<!--@include: ../../../db-cloud-shared/quick-start/mysql.md-->
+
+```shell
+curl -L https://raw.githubusercontent.com/GreptimeCloudStarters/quick-start-mysql/main/quick-start.sh | bash -s -- -h <host> -d <dbname> -u <username> -p <password>
+```

--- a/docs/v0.6/en/greptimecloud/getting-started/quick-start/node.md
+++ b/docs/v0.6/en/greptimecloud/getting-started/quick-start/node.md
@@ -1,0 +1,6 @@
+
+<!--@include: ../../../db-cloud-shared/quick-start/node.md-->
+
+```shell
+npx greptime-cloud-quick-start@latest --host=<host> --db=<dbname> --username=<username> --password=<password>
+```

--- a/docs/v0.6/en/greptimecloud/getting-started/quick-start/python.md
+++ b/docs/v0.6/en/greptimecloud/getting-started/quick-start/python.md
@@ -1,0 +1,6 @@
+
+<!--@include: ../../../db-cloud-shared/quick-start/python.md-->
+
+```shell
+pipx run --no-cache greptime-cloud-quick-start -host <host> -db <dbname> -u <username> -p <password>
+```

--- a/docs/v0.6/en/greptimecloud/getting-started/quick-start/vector.md
+++ b/docs/v0.6/en/greptimecloud/getting-started/quick-start/vector.md
@@ -1,0 +1,22 @@
+
+The following configuration, written in the `vector.toml` file, collects [host_metrics](https://vector.dev/docs/reference/configuration/sources/host_metrics/) as a Vector source and uses GreptimeDB as the sink destination.
+
+```toml
+[sources.in]
+type = "host_metrics"
+scrape_interval_secs = 30
+
+[sinks.greptime]
+inputs = ["in"]
+type = "greptimedb"
+endpoint = "<host>:4001"
+dbname = "<dbname>"
+username = "<username>"
+password = "<password>"
+```
+
+Then start vector with the specified configuration file:
+
+```shell
+vector --config vector.toml
+```

--- a/docs/v0.6/en/greptimecloud/getting-started/vector.md
+++ b/docs/v0.6/en/greptimecloud/getting-started/vector.md
@@ -4,28 +4,7 @@
 <!--@include: ./create-service.md-->
 
 ## Write Data
-
-The following configuration, written in the `vector.toml` file, collects [host_metrics](https://vector.dev/docs/reference/configuration/sources/host_metrics/) as a Vector source and uses GreptimeDB as the sink destination.
-
-```toml
-[sources.in]
-type = "host_metrics"
-scrape_interval_secs = 30
-
-[sinks.greptime]
-inputs = ["in"]
-type = "greptimedb"
-endpoint = "<host>:4001"
-dbname = "<dbname>"
-username = "<username>"
-password = "<password>"
-```
-
-Then start vector with the specified configuration file:
-
-```shell
-vector --config vector.toml
-```
+<!--@include: ./quick-start/vector.md-->
 
 ## Visualize Data
 <!--@include: ./visualize-data.md-->

--- a/docs/v0.6/zh/greptimecloud/getting-started/go.md
+++ b/docs/v0.6/zh/greptimecloud/getting-started/go.md
@@ -4,11 +4,7 @@
 <!--@include: ./create-service.md-->
 
 ## 写入数据
-<!--@include: ../../db-cloud-shared/quick-start/go.md-->
-
-```shell
-go run github.com/GreptimeCloudStarters/quick-start-go@latest -host=<host> -db=<dbname> -username=<username> -password=<password>
-```
+<!--@include: ./quick-start/go.md-->
 
 ## 数据可视化
 <!--@include: ./visualize-data.md-->

--- a/docs/v0.6/zh/greptimecloud/getting-started/influxdb.md
+++ b/docs/v0.6/zh/greptimecloud/getting-started/influxdb.md
@@ -4,11 +4,7 @@
 <!--@include: ./create-service.md-->
 
 ## 写入数据
-<!--@include: ../../db-cloud-shared/quick-start/influxdb.md-->
-
-```shell
-curl -L https://raw.githubusercontent.com/GreptimeCloudStarters/quick-start-influxdb-line-protocol/main/quick-start.sh | bash -s -- -h <host> -d <dbname> -u <username> -p <password>
-```
+<!--@include: ./quick-start/influxdb.md-->
 
 ## 数据可视化
 <!--@include: ./visualize-data.md-->

--- a/docs/v0.6/zh/greptimecloud/getting-started/java.md
+++ b/docs/v0.6/zh/greptimecloud/getting-started/java.md
@@ -4,11 +4,7 @@
 <!--@include: ./create-service.md-->
 
 ## 写入数据
-<!--@include: ../../db-cloud-shared/quick-start/java.md-->
-
-```shell
-curl -L https://github.com/GreptimeCloudStarters/quick-start-java/releases/latest/download/greptime-quick-start-java-all.jar --output quick-start.jar && java -jar quick-start.jar -h <host> -db <dbname> -u <username> -p <password>
-```
+<!--@include: ./quick-start/java.md-->
 
 ## 数据可视化
 <!--@include: ./visualize-data.md-->

--- a/docs/v0.6/zh/greptimecloud/getting-started/mysql.md
+++ b/docs/v0.6/zh/greptimecloud/getting-started/mysql.md
@@ -4,11 +4,7 @@
 <!--@include: ./create-service.md-->
 
 ## 写入数据
-<!--@include: ../../db-cloud-shared/quick-start/mysql.md-->
-
-```shell
-curl -L https://raw.githubusercontent.com/GreptimeCloudStarters/quick-start-mysql/main/quick-start.sh | bash -s -- -h <host> -d <dbname> -u <username> -p <password>
-```
+<!--@include: ./quick-start/mysql.md-->
 
 ## 数据可视化
 <!--@include: ./visualize-data.md-->

--- a/docs/v0.6/zh/greptimecloud/getting-started/node.md
+++ b/docs/v0.6/zh/greptimecloud/getting-started/node.md
@@ -4,11 +4,7 @@
 <!--@include: ./create-service.md-->
 
 ## 写入数据
-<!--@include: ../../db-cloud-shared/quick-start/node.md-->
-
-```shell
-npx greptime-cloud-quick-start@latest --host=<host> --db=<dbname> --username=<username> --password=<password>
-```
+<!--@include: ./quick-start/node.md-->
 
 ## 数据可视化
 <!--@include: ./visualize-data.md-->

--- a/docs/v0.6/zh/greptimecloud/getting-started/python.md
+++ b/docs/v0.6/zh/greptimecloud/getting-started/python.md
@@ -4,11 +4,7 @@
 <!--@include: ./create-service.md-->
 
 ## 写入数据
-<!--@include: ../../db-cloud-shared/quick-start/python.md-->
-
-```shell
-pipx run --no-cache greptime-cloud-quick-start -host <host> -db <dbname> -u <username> -p <password>
-```
+<!--@include: ./quick-start/python.md-->
 
 ## 数据可视化
 <!--@include: ./visualize-data.md-->

--- a/docs/v0.6/zh/greptimecloud/getting-started/quick-start/go.md
+++ b/docs/v0.6/zh/greptimecloud/getting-started/quick-start/go.md
@@ -1,0 +1,6 @@
+
+<!--@include: ../../../db-cloud-shared/quick-start/go.md-->
+
+```shell
+go run github.com/GreptimeCloudStarters/quick-start-go@latest -host=<host> -db=<dbname> -username=<username> -password=<password>
+```

--- a/docs/v0.6/zh/greptimecloud/getting-started/quick-start/influxdb.md
+++ b/docs/v0.6/zh/greptimecloud/getting-started/quick-start/influxdb.md
@@ -1,0 +1,6 @@
+
+<!--@include: ../../../db-cloud-shared/quick-start/influxdb.md-->
+
+```shell
+curl -L https://raw.githubusercontent.com/GreptimeCloudStarters/quick-start-influxdb-line-protocol/main/quick-start.sh | bash -s -- -h <host> -d <dbname> -u <username> -p <password>
+```

--- a/docs/v0.6/zh/greptimecloud/getting-started/quick-start/java.md
+++ b/docs/v0.6/zh/greptimecloud/getting-started/quick-start/java.md
@@ -1,0 +1,6 @@
+
+<!--@include: ../../../db-cloud-shared/quick-start/java.md-->
+
+```shell
+curl -L https://github.com/GreptimeCloudStarters/quick-start-java/releases/latest/download/greptime-quick-start-java-all.jar --output quick-start.jar && java -jar quick-start.jar -h <host> -db <dbname> -u <username> -p <password>
+```

--- a/docs/v0.6/zh/greptimecloud/getting-started/quick-start/mysql.md
+++ b/docs/v0.6/zh/greptimecloud/getting-started/quick-start/mysql.md
@@ -1,0 +1,6 @@
+
+<!--@include: ../../../db-cloud-shared/quick-start/mysql.md-->
+
+```shell
+curl -L https://raw.githubusercontent.com/GreptimeCloudStarters/quick-start-mysql/main/quick-start.sh | bash -s -- -h <host> -d <dbname> -u <username> -p <password>
+```

--- a/docs/v0.6/zh/greptimecloud/getting-started/quick-start/node.md
+++ b/docs/v0.6/zh/greptimecloud/getting-started/quick-start/node.md
@@ -1,0 +1,6 @@
+
+<!--@include: ../../../db-cloud-shared/quick-start/node.md-->
+
+```shell
+npx greptime-cloud-quick-start@latest --host=<host> --db=<dbname> --username=<username> --password=<password>
+```

--- a/docs/v0.6/zh/greptimecloud/getting-started/quick-start/python.md
+++ b/docs/v0.6/zh/greptimecloud/getting-started/quick-start/python.md
@@ -1,0 +1,6 @@
+
+<!--@include: ../../../db-cloud-shared/quick-start/python.md-->
+
+```shell
+pipx run --no-cache greptime-cloud-quick-start -host <host> -db <dbname> -u <username> -p <password>
+```

--- a/docs/v0.6/zh/greptimecloud/getting-started/quick-start/vector.md
+++ b/docs/v0.6/zh/greptimecloud/getting-started/quick-start/vector.md
@@ -1,0 +1,22 @@
+
+将下方配置写在 `vector.toml` 文件中，配置内容为将 [host_metrics](https://vector.dev/docs/reference/configuration/sources/host_metrics/) 作为 Vector source ，将 GreptimeCloud 作为 Vector sink destination。
+
+```toml
+[sources.in]
+type = "host_metrics"
+scrape_interval_secs = 30
+
+[sinks.cloud]
+inputs = ["in"]
+type = "greptimedb"
+endpoint = "<host>:4001"
+dbname = "<dbname>"
+username = "<username>"
+password = "<password>"
+```
+
+然后使用配置文件启动 Vector：
+
+```shell
+vector --config vector.toml
+```

--- a/docs/v0.6/zh/greptimecloud/getting-started/vector.md
+++ b/docs/v0.6/zh/greptimecloud/getting-started/vector.md
@@ -4,28 +4,7 @@
 <!--@include: ./create-service.md-->
 
 ## 写入数据
-
-将下方配置写在 `vector.toml` 文件中，配置内容为将 [host_metrics](https://vector.dev/docs/reference/configuration/sources/host_metrics/) 作为 Vector source ，将 GreptimeCloud 作为 Vector sink destination。
-
-```toml
-[sources.in]
-type = "host_metrics"
-scrape_interval_secs = 30
-
-[sinks.cloud]
-inputs = ["in"]
-type = "greptimedb"
-endpoint = "<host>:4001"
-dbname = "<dbname>"
-username = "<username>"
-password = "<password>"
-```
-
-然后使用配置文件启动 Vector：
-
-```shell
-vector --config vector.toml
-```
+<!--@include: ./quick-start/vector.md-->
 
 ## 数据可视化
 <!--@include: ./visualize-data.md-->


### PR DESCRIPTION
## What's Changed in this PR

retrieve missing Quick Start documentation for GreptimeCloud

## Checklist

- [x] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
