### PR TITLE
fix: quick start command in GreptimeCloud

### DIFF
--- a/docs/v0.6/en/greptimecloud/getting-started/quick-start/go.md
+++ b/docs/v0.6/en/greptimecloud/getting-started/quick-start/go.md
@@ -2,5 +2,5 @@
 <!--@include: ../../../db-cloud-shared/quick-start/go.md-->
 
 ```shell
-go run github.com/GreptimeCloudStarters/quick-start-go@latest -host=<host> -db=<dbname> -username=<username> -password=<password>
+go run github.com/GreptimeCloudStarters/quick-start-go@latest -endpoint=https://<host>/v1/otlp/v1/metrics -db=<dbname> -username=<username> -password=<password>
 ```

--- a/docs/v0.6/en/greptimecloud/getting-started/quick-start/influxdb.md
+++ b/docs/v0.6/en/greptimecloud/getting-started/quick-start/influxdb.md
@@ -2,5 +2,5 @@
 <!--@include: ../../../db-cloud-shared/quick-start/influxdb.md-->
 
 ```shell
-curl -L https://raw.githubusercontent.com/GreptimeCloudStarters/quick-start-influxdb-line-protocol/main/quick-start.sh | bash -s -- -h <host> -d <dbname> -u <username> -p <password>
+curl -L https://raw.githubusercontent.com/GreptimeCloudStarters/quick-start-influxdb-line-protocol/main/quick-start.sh | bash -s -- -e https://<host>/v1/influxdb/write -d <dbname> -u <username> -p <password>
 ```

--- a/docs/v0.6/en/greptimecloud/getting-started/quick-start/java.md
+++ b/docs/v0.6/en/greptimecloud/getting-started/quick-start/java.md
@@ -2,5 +2,6 @@
 <!--@include: ../../../db-cloud-shared/quick-start/java.md-->
 
 ```shell
-curl -L https://github.com/GreptimeCloudStarters/quick-start-java/releases/latest/download/greptime-quick-start-java-all.jar --output quick-start.jar && java -jar quick-start.jar -h <host> -db <dbname> -u <username> -p <password>
+curl -L https://github.com/GreptimeCloudStarters/quick-start-java/releases/latest/download/greptime-quick-start-java-all.jar \
+--output quick-start.jar && java -jar quick-start.jar -e https://<host>/v1/otlp/v1/metrics -db <dbname> -u <username> -p <password>
 ```

--- a/docs/v0.6/en/greptimecloud/getting-started/quick-start/node.md
+++ b/docs/v0.6/en/greptimecloud/getting-started/quick-start/node.md
@@ -2,5 +2,5 @@
 <!--@include: ../../../db-cloud-shared/quick-start/node.md-->
 
 ```shell
-npx greptime-cloud-quick-start@latest --host=<host> --db=<dbname> --username=<username> --password=<password>
+npx greptime-cloud-quick-start@latest --endpoint=https://<host>/v1/otlp/v1/metrics --db=<dbname> --username=<username> --password=<password>
 ```

--- a/docs/v0.6/en/greptimecloud/getting-started/quick-start/python.md
+++ b/docs/v0.6/en/greptimecloud/getting-started/quick-start/python.md
@@ -2,5 +2,5 @@
 <!--@include: ../../../db-cloud-shared/quick-start/python.md-->
 
 ```shell
-pipx run --no-cache greptime-cloud-quick-start -host <host> -db <dbname> -u <username> -p <password>
+pipx run --no-cache greptime-cloud-quick-start -e https://<host>/v1/otlp/v1/metrics -db <dbname> -u <username> -p <password>
 ```

--- a/docs/v0.6/zh/greptimecloud/getting-started/quick-start/go.md
+++ b/docs/v0.6/zh/greptimecloud/getting-started/quick-start/go.md
@@ -2,5 +2,5 @@
 <!--@include: ../../../db-cloud-shared/quick-start/go.md-->
 
 ```shell
-go run github.com/GreptimeCloudStarters/quick-start-go@latest -host=<host> -db=<dbname> -username=<username> -password=<password>
+go run github.com/GreptimeCloudStarters/quick-start-go@latest -endpoint=https://<host>/v1/otlp/v1/metrics -db=<dbname> -username=<username> -password=<password>
 ```

--- a/docs/v0.6/zh/greptimecloud/getting-started/quick-start/influxdb.md
+++ b/docs/v0.6/zh/greptimecloud/getting-started/quick-start/influxdb.md
@@ -2,5 +2,5 @@
 <!--@include: ../../../db-cloud-shared/quick-start/influxdb.md-->
 
 ```shell
-curl -L https://raw.githubusercontent.com/GreptimeCloudStarters/quick-start-influxdb-line-protocol/main/quick-start.sh | bash -s -- -h <host> -d <dbname> -u <username> -p <password>
+curl -L https://raw.githubusercontent.com/GreptimeCloudStarters/quick-start-influxdb-line-protocol/main/quick-start.sh | bash -s -- -e https://<host>/v1/influxdb/write -d <dbname> -u <username> -p <password>
 ```

--- a/docs/v0.6/zh/greptimecloud/getting-started/quick-start/java.md
+++ b/docs/v0.6/zh/greptimecloud/getting-started/quick-start/java.md
@@ -2,5 +2,6 @@
 <!--@include: ../../../db-cloud-shared/quick-start/java.md-->
 
 ```shell
-curl -L https://github.com/GreptimeCloudStarters/quick-start-java/releases/latest/download/greptime-quick-start-java-all.jar --output quick-start.jar && java -jar quick-start.jar -h <host> -db <dbname> -u <username> -p <password>
+curl -L https://github.com/GreptimeCloudStarters/quick-start-java/releases/latest/download/greptime-quick-start-java-all.jar \
+--output quick-start.jar && java -jar quick-start.jar -e https://<host>/v1/otlp/v1/metrics -db <dbname> -u <username> -p <password>
 ```

--- a/docs/v0.6/zh/greptimecloud/getting-started/quick-start/node.md
+++ b/docs/v0.6/zh/greptimecloud/getting-started/quick-start/node.md
@@ -2,5 +2,5 @@
 <!--@include: ../../../db-cloud-shared/quick-start/node.md-->
 
 ```shell
-npx greptime-cloud-quick-start@latest --host=<host> --db=<dbname> --username=<username> --password=<password>
+npx greptime-cloud-quick-start@latest --endpoint=https://<host>/v1/otlp/v1/metrics --db=<dbname> --username=<username> --password=<password>
 ```

--- a/docs/v0.6/zh/greptimecloud/getting-started/quick-start/python.md
+++ b/docs/v0.6/zh/greptimecloud/getting-started/quick-start/python.md
@@ -2,5 +2,5 @@
 <!--@include: ../../../db-cloud-shared/quick-start/python.md-->
 
 ```shell
-pipx run --no-cache greptime-cloud-quick-start -host <host> -db <dbname> -u <username> -p <password>
+pipx run --no-cache greptime-cloud-quick-start -e https://<host>/v1/otlp/v1/metrics -db <dbname> -u <username> -p <password>
 ```


### PR DESCRIPTION
## What's Changed in this PR

Fix the quick start commands in GreptimeCloud

## Checklist

- [ ] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
