### PR TITLE
docs: new outline of SDK documentations

### DIFF
--- a/docs/v0.6/en/user-guide/client-libraries/go.md
+++ b/docs/v0.6/en/user-guide/client-libraries/go.md
@@ -44,7 +44,7 @@ cfg := greptime.NewCfg("127.0.0.1").
     // set authentication information
     WithAuth("username", "password")
 
-cli, _ := client.New(cfg)
+cli, _ := greptime.NewClient(cfg)
 ```
 %}
 
@@ -68,6 +68,7 @@ cpuMetric.AddFieldColumn("cpu_sys", types.FLOAT)
 // Insert example data
 // NOTE: The arguments must be in the same order as the columns in the defined schema: host, ts, cpu_user, cpu_sys
 err = cpuMetric.AddRow("127.0.0.1", time.Now(), 0.1, 0.12)
+err = cpuMetric.AddRow("127.0.0.1", time.Now(), 0.11, 0.13)
 if err != nil {
     // Handle error appropriately
 }

--- a/docs/v0.6/en/user-guide/client-libraries/go.md
+++ b/docs/v0.6/en/user-guide/client-libraries/go.md
@@ -25,8 +25,7 @@ Import the library in your code:
 
 ```go
 import (
-    "github.com/GreptimeTeam/greptimedb-ingester-go/client"
-    "github.com/GreptimeTeam/greptimedb-ingester-go/config"
+    greptime "github.com/GreptimeTeam/greptimedb-ingester-go"
     "github.com/GreptimeTeam/greptimedb-ingester-go/table"
     "github.com/GreptimeTeam/greptimedb-ingester-go/table/types"
 )
@@ -45,7 +44,7 @@ cfg := greptime.NewCfg("127.0.0.1").
     // set authentication information
     WithAuth("username", "password")
 
-client, _ := client.New(cfg)
+cli, _ := client.New(cfg)
 ```
 %}
 
@@ -122,22 +121,12 @@ log.Printf("affected rows: %d\n", resp.GetAffectedRows().GetValue())
 
 {template streaming-insert%
 
-To insert data using the streaming API, you must first create a stream client.
-
 ```go
-cfg := config.New("<host>").
-    WithAuth("<username>", "<password>").
-    WithDatabase(database)
-streamClient, err := client.NewStreamClient(cfg)
-```
-
-Then send the data to the server.
-
-```go
-err := streamClient.Send(context.Background(), cpuMetric, memMetric)
+err := cli.StreamWrite(context.Background(), cpuMetric, memMetric)
 if err != nil {
     // Handle error appropriately
 }
+affected, err := cli.CloseStream(ctx)
 ```
 
 %}
@@ -162,7 +151,7 @@ resp, _ = cli.Write(context.Background(), cpuMetric)
 %}
 
 
-{template orm-style-object%
+{template high-level-style-object%
 
 ```go
 type CpuMetric struct {
@@ -184,8 +173,10 @@ cpuMetrics := []CpuMetric{
         Ts:          time.Now(),
     }
 }
+```
 
-
+<!-- SDK TODO -->
+<!-- ```go
 type MemMetric struct {
     Host        string    `greptime:"tag;column:host;type:string"`
 	Memory      float64   `greptime:"field;column:mem_usage;type:float64"`
@@ -203,38 +194,29 @@ memMetrics := []MemMetric{
         Ts:          time.Now(),
     }
 }
-```
+``` -->
+
 %}
 
-{template orm-style-insert-data%
+{template high-level-style-insert-data%
 
 ```go
-resp, err := cli.Create(context.Background(), cpuMetrics, memMetrics)
+resp, err := cli.WriteObject(context.Background(), cpuMetrics)
 log.Printf("affected rows: %d\n", resp.GetAffectedRows().GetValue())
 ```
 
 %}
 
-{template orm-style-streaming-insert%
-
-To insert data using the streaming API, you must first create a stream client.
+{template high-level-style-streaming-insert%
 
 ```go
-cfg := config.New("<host>").
-    WithAuth("<username>", "<password>").
-    WithDatabase(database)
-streamClient, err := client.NewStreamClient(cfg)
-```
-
-Then send the data to the server.
-
-```go
-err := streamClient.Create(context.Background(), cpuMetrics, memMetrics)
+err := cli.StreamWriteObject(context.Background(), cpuMetrics)
+affected, err := cli.CloseStream(ctx)
 ```
 
 %}
 
-{template orm-style-update-data%
+{template high-level-style-update-data%
 
 ```go
 ts = time.Now()
@@ -247,7 +229,7 @@ cpuMetrics := []CpuMetric{
     }
 }
 // insert a row data
-resp, err := cli.Create(context.Background(), cpuMetrics)
+resp, err := cli.WriteObject(context.Background(), cpuMetrics)
 
 // update the row data
 newCpuMetrics := []CpuMetric{
@@ -259,7 +241,7 @@ newCpuMetrics := []CpuMetric{
     }
 }
 // overwrite the existing data
-resp, err := cli.Create(context.Background(), newCpuMetrics)
+resp, err := cli.WriteObject(context.Background(), newCpuMetrics)
 
 ```
 

--- a/docs/v0.6/en/user-guide/client-libraries/go.md
+++ b/docs/v0.6/en/user-guide/client-libraries/go.md
@@ -267,26 +267,26 @@ resp, err := cli.Create(context.Background(), newCpuMetrics)
 
 {template more-ingestion-examples%
 
-For fully runnable code snippets and explanations for common methods, see the [Examples](https://pkg.go.dev/github.com/GreptimeTeam/greptimedb-client-go#example-package).
+For fully runnable code snippets and explanations for common methods, see the [Examples](https://github.com/GreptimeTeam/greptimedb-ingester-go/tree/main/examples).
 
 %}
 
 {template ingester-lib-reference%
 
-- [API Documentation](https://pkg.go.dev/github.com/GreptimeTeam/greptimedb-client-go)
+- [API Documentation](https://pkg.go.dev/github.com/GreptimeTeam/greptimedb-ingester-go)
 
 %}
 
 
 {template recommended-query-library%
 
-We recommend using the [Gorm](https://gorm.io/) library, which is popular and developer-friendly.
+We recommend using the [GORM](https://gorm.io/) library, which is popular and developer-friendly.
 
 %}
 
 {template query-library-installation%
 
-Use the following command to install the Gorm library:
+Use the following command to install the GORM library:
 
 ```shell
 go get -u gorm.io/gorm
@@ -343,7 +343,7 @@ m.DB = db
 
 {template query-library-raw-sql%
 
-The following code declares a Gorm object model:
+The following code declares a GORM object model:
 
 ```go
 type CpuMetric struct {
@@ -354,7 +354,7 @@ type CpuMetric struct {
 }
 ```
 
-If you are using the ORM API to insert data, you can declare the model with both Gorm and Greptime tags.
+If you are using the [ORM API](#orm-api) to insert data, you can declare the model with both GORM and Greptime tags.
 
 ```go
 type CpuMetric struct {

--- a/docs/v0.6/en/user-guide/client-libraries/go.md
+++ b/docs/v0.6/en/user-guide/client-libraries/go.md
@@ -132,25 +132,6 @@ affected, err := cli.CloseStream(ctx)
 
 %}
 
-{template update-rows%
-
-```go
-ts := time.Now()
-_ = cpuMetric.AddRow("127.0.0.1", ts, 0.1, 0.12)
-// insert a row data
-resp, _ := cli.Write(context.Background(), cpuMetric)
-
-// update the row data
-// The same tag `127.0.0.1`
-// The same time index `ts`
-// The new value: cpu_user = `0.80`, cpu_sys = `0.11`
-_ = cpuMetric.AddRow("127.0.0.1", ts, 0.80, 0.11)
-// overwrite the existing data
-resp, _ = cli.Write(context.Background(), cpuMetric)
-```
-
-%}
-
 
 {template high-level-style-object%
 
@@ -213,37 +194,6 @@ log.Printf("affected rows: %d\n", resp.GetAffectedRows().GetValue())
 ```go
 err := cli.StreamWriteObject(context.Background(), cpuMetrics)
 affected, err := cli.CloseStream(ctx)
-```
-
-%}
-
-{template high-level-style-update-data%
-
-```go
-ts = time.Now()
-cpuMetrics := []CpuMetric{
-    {
-        Host:        "127.0.0.1",
-        CpuUser:     0.10,
-        CpuSys:      0.12,
-        Ts:          ts,
-    }
-}
-// insert a row data
-resp, err := cli.WriteObject(context.Background(), cpuMetrics)
-
-// update the row data
-newCpuMetrics := []CpuMetric{
-    {
-        Host:        "127.0.0.1",    // The same tag `127.0.0.1`
-        CpuUser:     0.80,       // The new value: cpu_user = `0.80`
-        CpuSys:      0.11,    // The new value: cpu_sys = `0.11`
-        Ts:          ts,     // The same time index `ts`
-    }
-}
-// overwrite the existing data
-resp, err := cli.WriteObject(context.Background(), newCpuMetrics)
-
 ```
 
 %}
@@ -360,7 +310,7 @@ Use raw SQL to query data:
 
 ```go
 var cpuMetric CpuMetric
-db.Raw("SELECT * FROM cpu_metric WHERE ts > ?", 1701360000000).Scan(&result)
+db.Raw("SELECT * FROM cpu_metric LIMIT 10").Scan(&result)
 
 ```
 

--- a/docs/v0.6/en/user-guide/client-libraries/go.md
+++ b/docs/v0.6/en/user-guide/client-libraries/go.md
@@ -343,7 +343,7 @@ m.DB = db
 
 {template query-library-raw-sql%
 
-#### Declare model
+The following code declares a Gorm object model:
 
 ```go
 type CpuMetric struct {
@@ -365,7 +365,7 @@ type CpuMetric struct {
 }
 ```
 
-#### Declare table name
+Declare the table name as follows:
 
 ```go
 func (CpuMetric) TableName() string {
@@ -373,7 +373,7 @@ func (CpuMetric) TableName() string {
 }
 ```
 
-#### Query data
+Use raw SQL to query data:
 
 ```go
 var cpuMetric CpuMetric

--- a/docs/v0.6/en/user-guide/client-libraries/go.md
+++ b/docs/v0.6/en/user-guide/client-libraries/go.md
@@ -127,6 +127,12 @@ err := cli.StreamWrite(context.Background(), cpuMetric, memMetric)
 if err != nil {
     // Handle error appropriately
 }
+```
+
+Close the stream writing after all data has been written.
+In general, you do not need to close the stream writing when continuously writing data.
+
+```go
 affected, err := cli.CloseStream(ctx)
 ```
 
@@ -193,6 +199,12 @@ log.Printf("affected rows: %d\n", resp.GetAffectedRows().GetValue())
 
 ```go
 err := cli.StreamWriteObject(context.Background(), cpuMetrics)
+```
+
+Close the stream writing after all data has been written.
+In general, you do not need to close the stream writing when continuously writing data.
+
+```go
 affected, err := cli.CloseStream(ctx)
 ```
 

--- a/docs/v0.6/en/user-guide/client-libraries/go.md
+++ b/docs/v0.6/en/user-guide/client-libraries/go.md
@@ -54,16 +54,9 @@ client, _ := greptime.NewClient(cfg)
 
 %}
 
-
-
-{template row-object%
+{template greptimedb-style-object%
 
 The Go ingester SDK uses `Series` to represent a row data item. Multiple `Series` can be added to a `Metric` object and then written to GreptimeDB.
-
-%}
-
-
-{template create-a-rows%
 
 ```go
 seriesHost1 := greptime.Series{}
@@ -93,8 +86,7 @@ metric.AddSeries(seriesHost1, seriesHost2)
 
 %}
 
-
-{template save-rows%
+{template insert-rows%
 
 ```go
 seriesHost1 := greptime.Series{}
@@ -124,6 +116,12 @@ if err != nil {
 }
 fmt.Printf("AffectedRows: %d\n", res.GetAffectedRows().Value)
 ```
+
+%}
+
+{template streaming-insert%
+
+<!-- TODO -->
 
 %}
 
@@ -159,6 +157,22 @@ insertsRequest := greptime.InsertsRequest{}
 insertsRequest.Append(monitorReq)
 res, _ := client.Insert(context.Background(), insertsRequest)
 ```
+%}
+
+{template orm-style-object%
+<!-- TODO -->
+%}
+
+{template orm-style-insert-data%
+<!-- TODO -->
+%}
+
+{template orm-style-streaming-insert%
+<!-- TODO -->
+%}
+
+{template orm-style-update-data%
+<!-- TODO -->
 %}
 
 {template more-ingestion-examples%

--- a/docs/v0.6/en/user-guide/client-libraries/java.md
+++ b/docs/v0.6/en/user-guide/client-libraries/java.md
@@ -176,7 +176,12 @@ writer.write(memMetric);
 
 // You can perform operations on the stream, such as deleting the first 5 rows.
 writer.write(cpuMetric.subRange(0, 5), WriteOp.Delete);
+```
 
+Close the stream writing after all data has been written.
+In general, you do not need to close the stream writing when continuously writing data.
+
+```java
 // complete the stream
 CompletableFuture<WriteOk> future = writer.completed();
 WriteOk result = future.get();
@@ -307,7 +312,12 @@ writer.write(memories);
 
 // You can perform operations on the stream, such as deleting the first 5 rows.
 writer.write(cpus.subList(0, 5), WriteOp.Delete);
+```
 
+Close the stream writing after all data has been written.
+In general, you do not need to close the stream writing when continuously writing data.
+
+```java
 // complete the stream
 CompletableFuture<WriteOk> future = writer.completed();
 WriteOk result = future.get();

--- a/docs/v0.6/en/user-guide/client-libraries/java.md
+++ b/docs/v0.6/en/user-guide/client-libraries/java.md
@@ -203,7 +203,8 @@ long ts = 1703832681000L;
 myMetricCpuSchema.addRow("host1", ts, 0.80, 0.11);
 
 // overwrite the existing data
-Result<WriteOk, Err> updateResult = greptimeDB.write(myMetricCpuSchema).get();
+CompletableFuture<Result<WriteOk, Err>> future = greptimeDB.write(myMetricCpuSchema);
+Result<WriteOk, Err> result = future.get();
 ```
 
 %}

--- a/docs/v0.6/en/user-guide/client-libraries/java.md
+++ b/docs/v0.6/en/user-guide/client-libraries/java.md
@@ -71,22 +71,29 @@ For customizing the connection options, please refer to [API Documentation](#ing
 
 %}
 
-{template greptimedb-style-object%
+
+{template low-level-object%
 
 ```java
-// Creates schemas
+// Construct the table schema for CPU metrics
 TableSchema cpuMetricSchema = TableSchema.newBuilder("cpu_metric")
-        .addTag("host", DataType.String)
-        .addTimestamp("ts", DataType.TimestampMillisecond)
-        .addField("cpu_user", DataType.Float64)
-        .addField("cpu_sys", DataType.Float64)
+        .addTag("host", DataType.String) // Identifier for the host
+        .addTimestamp("ts", DataType.TimestampMillisecond) // Timestamp in milliseconds
+        .addField("cpu_user", DataType.Float64) // CPU usage by user processes
+        .addField("cpu_sys", DataType.Float64) // CPU usage by system processes
         .build();
+
+// Create the table from the defined schema
 Table cpuMetric = Table.from(cpuMetricSchema);
 
-String host = "127.0.0.1";
-long ts = System.currentTimeMillis();
-double cpuUser = 0.1;
-double cpuSys = 0.12;
+// Example data for a single row
+String host = "127.0.0.1"; // Host identifier
+long ts = System.currentTimeMillis(); // Current timestamp
+double cpuUser = 0.1; // CPU usage by user processes (in percentage)
+double cpuSys = 0.12; // CPU usage by system processes (in percentage)
+
+// Insert the row into the table
+// NOTE: The arguments must be in the same order as the columns in the defined schema: host, ts, cpu_user, cpu_sys
 cpuMetric.addRow(host, ts, cpuUser, cpuSys);
 ```
 
@@ -182,7 +189,7 @@ LOG.info("Write result: {}", result);
 
 ```java
 Table cpuMetric = Table.from(myMetricCpuSchema);
-// save a row data
+// insert a row data
 long ts = 1703832681000L;
 cpuMetric.addRow("host1", ts, 0.23, 0.12);
 Result<WriteOk, Err> putResult = greptimeDB.write(cpuMetric).get();
@@ -191,9 +198,9 @@ Result<WriteOk, Err> putResult = greptimeDB.write(cpuMetric).get();
 Table newCpuMetric = Table.from(myMetricCpuSchema);
 // The same tag `host1`
 // The same time index `1703832681000`
-// The new value: cpu_user = `0.80`, cpu_sys = `0.81`
+// The new value: cpu_user = `0.80`, cpu_sys = `0.11`
 long ts = 1703832681000L;
-myMetricCpuSchema.addRow("host1", ts, 0.80, 0.81);
+myMetricCpuSchema.addRow("host1", ts, 0.80, 0.11);
 
 // overwrite the existing data
 Result<WriteOk, Err> updateResult = greptimeDB.write(myMetricCpuSchema).get();
@@ -312,7 +319,7 @@ cpu.setTs(1703832681000L);
 cpu.setCpuUser(0.23);
 cpu.setCpuSys(0.12);
 
-// save a row data
+// insert a row data
 Result<WriteOk, Err> putResult = greptimeDB.writePOJOs(cpu).get();
 
 // update the row data
@@ -321,9 +328,9 @@ Cpu newCpu = new Cpu();
 newCpu.setHost("host1");
 // The same time index `1703832681000`
 newCpu.setTs(1703832681000L);
-// The new value: cpu_user = `0.80`, cpu_sys = `0.81`
+// The new value: cpu_user = `0.80`, cpu_sys = `0.11`
 cpu.setCpuUser(0.80);
-cpu.setCpuSys(0.81);
+cpu.setCpuSys(0.11);
 
 // overwrite the existing data
 Result<WriteOk, Err> updateResult = greptimeDB.writePOJOs(newCpu).get();

--- a/docs/v0.6/en/user-guide/client-libraries/java.md
+++ b/docs/v0.6/en/user-guide/client-libraries/java.md
@@ -187,6 +187,11 @@ LOG.info("Write result: {}", result);
 
 {template update-rows%
 
+#### Update data
+
+Please refer to [update data](/user-guide/write-data/overview.md#update-data) for the updating mechanism.
+In the following code, we first save a row and then use the same tag and time index to identify the row for updating.
+
 ```java
 Table cpuMetric = Table.from(myMetricCpuSchema);
 // insert a row data
@@ -312,6 +317,11 @@ LOG.info("Write result: {}", result);
 %}
 
 {template high-level-style-update-data%
+
+#### Update data
+
+Please refer to [update data](/user-guide/write-data/overview.md#update-data) for the updating mechanism.
+In the following code, we first save a row and then use the same tag and time index to identify the row for updating.
 
 ```java
 Cpu cpu = new Cpu();

--- a/docs/v0.6/en/user-guide/client-libraries/java.md
+++ b/docs/v0.6/en/user-guide/client-libraries/java.md
@@ -208,7 +208,7 @@ Result<WriteOk, Err> updateResult = greptimeDB.write(myMetricCpuSchema).get();
 
 %}
 
-{template orm-style-object%
+{template high-level-style-object%
 
 GreptimeDB Java Ingester SDK allows us to use basic POJO objects for writing. This approach requires the use of Greptime's own annotations, but they are easy to use.
 
@@ -268,7 +268,7 @@ for (int i = 0; i < 10; i++) {
 %}
 
 
-{template orm-style-insert-data%
+{template high-level-style-insert-data%
 
 
 Write data with POJO objects:
@@ -276,7 +276,7 @@ Write data with POJO objects:
 ```java
 // Saves data
 
-CompletableFuture<Result<WriteOk, Err>> puts = greptimeDB.writePOJOs(cpus, memories);
+CompletableFuture<Result<WriteOk, Err>> puts = greptimeDB.writeObjects(cpus, memories);
 
 Result<WriteOk, Err> result = puts.get();
 
@@ -290,10 +290,10 @@ if (result.isOk()) {
 %}
 
 
-{template orm-style-streaming-insert%
+{template high-level-style-streaming-insert%
 
 ```java
-StreamWriter<List<?>, WriteOk> writer = greptimeDB.streamWriterPOJOs();
+StreamWriter<List<?>, WriteOk> writer = greptimeDB.objectsStreamWriter();
 
 // write data into stream
 writer.write(cpus);
@@ -310,7 +310,7 @@ LOG.info("Write result: {}", result);
 
 %}
 
-{template orm-style-update-data%
+{template high-level-style-update-data%
 
 ```java
 Cpu cpu = new Cpu();
@@ -320,7 +320,7 @@ cpu.setCpuUser(0.23);
 cpu.setCpuSys(0.12);
 
 // insert a row data
-Result<WriteOk, Err> putResult = greptimeDB.writePOJOs(cpu).get();
+Result<WriteOk, Err> putResult = greptimeDB.writeObjects(cpu).get();
 
 // update the row data
 Cpu newCpu = new Cpu();
@@ -333,7 +333,7 @@ cpu.setCpuUser(0.80);
 cpu.setCpuSys(0.11);
 
 // overwrite the existing data
-Result<WriteOk, Err> updateResult = greptimeDB.writePOJOs(newCpu).get();
+Result<WriteOk, Err> updateResult = greptimeDB.writeObjects(newCpu).get();
 ```
 
 %}

--- a/docs/v0.6/en/user-guide/client-libraries/template.md
+++ b/docs/v0.6/en/user-guide/client-libraries/template.md
@@ -33,6 +33,8 @@ The types of column values could be `String`, `Float`, `Int`, `Timestamp`, etc. 
 The GreptimeDB low-level API provides a straightforward method to write data to GreptimeDB 
 by adding rows to the table object with a predefined schema.
 
+#### Create row objects
+
 This following code snippet begins by constructing a table named `cpu_metric`,
 which includes columns `host`, `cpu_user`, `cpu_sys`, and `ts`. 
 Subsequently, it inserts a single row into the table.
@@ -76,6 +78,8 @@ The ORM style object allows you to create, insert, and update data in a more obj
 providing developers with a friendlier experience.
 However, it is not as efficient as the low-level object.
 This is because the ORM style object may consume more resources and time when converting the objects.
+
+#### Create row objects
 
 {template orm-style-object%%}
 

--- a/docs/v0.6/en/user-guide/client-libraries/template.md
+++ b/docs/v0.6/en/user-guide/client-libraries/template.md
@@ -63,11 +63,6 @@ Streaming insert is useful when you want to insert a large amount of data such a
 
 {template streaming-insert%%}
 
-#### Update data
-
-Please refer to [update data](/user-guide/write-data/overview.md#update-data) for the updating mechanism.
-In the following code, we first save a row and then use the same tag and time index to identify the row for updating.
-
 {template update-rows%%}
 
 <!-- TODO ### Delete Metrics -->
@@ -93,11 +88,6 @@ This is because the ORM style object may consume more resources and time when co
 Streaming insert is useful when you want to insert a large amount of data such as importing historical data.
 
 {template high-level-style-streaming-insert%%}
-
-#### Update data
-
-Please refer to [update data](/user-guide/write-data/overview.md#update-data) for the updating mechanism.
-In the following code, we first save a row and then use the same tag and time index to identify the row for updating.
 
 {template high-level-style-update-data%%}
 

--- a/docs/v0.6/en/user-guide/client-libraries/template.md
+++ b/docs/v0.6/en/user-guide/client-libraries/template.md
@@ -23,43 +23,77 @@ Here we set the username and password when using the library to connect to Grept
 
 {template ingester-lib-connect%%}
 
-### Row object
+### Data model
 
 Each row item in a table consists of three types of columns: `Tag`, `Timestamp`, and `Field`. For more information, see [Data Model](/user-guide/concepts/data-model.md).
 The types of column values could be `String`, `Float`, `Int`, `Timestamp`, etc. For more information, see [Data Types](/reference/sql/data-types.md).
 
-{template row-object%%}
+### GreptimeDB style object
 
-### Create rows
+The GreptimeDB style object allows you to add rows to the table object with a predefined schema.
 
-The following example shows how to create a row contains `Tag`, `Timestamp`, and `Field` columns. The `Tag` column is a `String` type, the `Timestamp` column is a `Timestamp` type, and the `Field` column is a `Float` type.
+The following code first creates a table with columns `host`, `ts`, `cpu_user`,
+and `cpu_sys`. Then, it adds a row to the table.
+A row contains columns for `Tag`, `Timestamp`,
+and `Field`. The `Tag` column is of type `String`,
+the `Timestamp` column is of type `Timestamp`,
+and the `Field` column is of type `Float`.
 
-{template create-a-row%%}
+{template greptimedb-style-object%%}
 
 To improve the efficiency of writing data, you can create multiple rows at once to write to GreptimeDB.
 
 {template create-rows%%}
 
-### Save rows
+#### Insert data
 
-The following example shows how to save rows to tables in GreptimeDB.
+The following example shows how to insert rows to tables in GreptimeDB.
 
-{template save-rows%%}
+{template insert-rows%%}
 
-### Update rows
+#### Streaming insert
+
+Streaming insert is useful when you want to insert a large amount of data such as importing historical data.
+
+{template streaming-insert%%}
+
+#### Update data
 
 Please refer to [update data](/user-guide/write-data/overview.md#update-data) for the updating mechanism.
-The following example shows saving a row and then updating the row.
+In the following code, we first save a row and then use the same tag and time index to identify the row for updating.
 
 {template update-rows%%}
 
 <!-- TODO ### Delete Metrics -->
 
-{template ingester-lib-debug-logs%%}
+### ORM style object
+
+The ORM style object allows you to create, insert, and update data in a more object-oriented way.
+
+{template orm-style-object%%}
+
+#### Insert data
+
+{template orm-style-insert-data%%}
+
+#### Streaming insert
+
+Streaming insert is useful when you want to insert a large amount of data such as importing historical data.
+
+{template orm-style-streaming-insert%%}
+
+#### Update data
+
+Please refer to [update data](/user-guide/write-data/overview.md#update-data) for the updating mechanism.
+In the following code, we first save a row and then use the same tag and time index to identify the row for updating.
+
+{template orm-style-update-data%%}
 
 ### More examples
 
 {template more-ingestion-examples%%}
+
+{template ingester-lib-debug-logs%%}
 
 ### Ingester library reference
 

--- a/docs/v0.6/en/user-guide/client-libraries/template.md
+++ b/docs/v0.6/en/user-guide/client-libraries/template.md
@@ -69,6 +69,8 @@ In the following code, we first save a row and then use the same tag and time in
 ### ORM style object
 
 The ORM style object allows you to create, insert, and update data in a more object-oriented way.
+However, it is not as efficient as the GreptimeDB style object.
+This is because the ORM style object may consume more resources and time when converting the objects.
 
 {template orm-style-object%%}
 

--- a/docs/v0.6/en/user-guide/client-libraries/template.md
+++ b/docs/v0.6/en/user-guide/client-libraries/template.md
@@ -28,18 +28,22 @@ Here we set the username and password when using the library to connect to Grept
 Each row item in a table consists of three types of columns: `Tag`, `Timestamp`, and `Field`. For more information, see [Data Model](/user-guide/concepts/data-model.md).
 The types of column values could be `String`, `Float`, `Int`, `Timestamp`, etc. For more information, see [Data Types](/reference/sql/data-types.md).
 
-### GreptimeDB style object
+### Low-level API
 
-The GreptimeDB style object allows you to add rows to the table object with a predefined schema.
+The GreptimeDB low-level API provides a straightforward method to write data to GreptimeDB 
+by adding rows to the table object with a predefined schema.
 
-The following code first creates a table with columns `host`, `ts`, `cpu_user`,
-and `cpu_sys`. Then, it adds a row to the table.
-A row contains columns for `Tag`, `Timestamp`,
-and `Field`. The `Tag` column is of type `String`,
-the `Timestamp` column is of type `Timestamp`,
-and the `Field` column is of type `Float`.
+This following code snippet begins by constructing a table named `cpu_metric`,
+which includes columns `host`, `cpu_user`, `cpu_sys`, and `ts`. 
+Subsequently, it inserts a single row into the table.
 
-{template greptimedb-style-object%%}
+The table consists of three types of columns:
+
+- `Tag`: The `host` column, with values of type `String`.
+- `Field`: The `cpu_user` and `cpu_sys` columns, with values of type `Float`.
+- `Timestamp`: The `ts` column, with values of type `Timestamp`.
+
+{template low-level-object%%}
 
 To improve the efficiency of writing data, you can create multiple rows at once to write to GreptimeDB.
 
@@ -66,10 +70,11 @@ In the following code, we first save a row and then use the same tag and time in
 
 <!-- TODO ### Delete Metrics -->
 
-### ORM style object
+### ORM API
 
-The ORM style object allows you to create, insert, and update data in a more object-oriented way.
-However, it is not as efficient as the GreptimeDB style object.
+The ORM style object allows you to create, insert, and update data in a more object-oriented way,
+providing developers with a friendlier experience.
+However, it is not as efficient as the low-level object.
 This is because the ORM style object may consume more resources and time when converting the objects.
 
 {template orm-style-object%%}
@@ -123,7 +128,7 @@ The following example shows how to connect to GreptimeDB:
 ### Raw SQL
 
 We recommend you using raw SQL to experience the full features of GreptimeDB.
-The following example shows how to use raw SQL to query data:
+The following example shows how to use raw SQL to query data.
 
 {template query-library-raw-sql%%}
 

--- a/docs/v0.6/en/user-guide/client-libraries/template.md
+++ b/docs/v0.6/en/user-guide/client-libraries/template.md
@@ -72,33 +72,34 @@ In the following code, we first save a row and then use the same tag and time in
 
 <!-- TODO ### Delete Metrics -->
 
-### ORM API
+### High-level API
 
-The ORM style object allows you to create, insert, and update data in a more object-oriented way,
+The high-level API uses an ORM style object to write data to GreptimeDB.
+It allows you to create, insert, and update data in a more object-oriented way,
 providing developers with a friendlier experience.
-However, it is not as efficient as the low-level object.
+However, it is not as efficient as the low-level API.
 This is because the ORM style object may consume more resources and time when converting the objects.
 
 #### Create row objects
 
-{template orm-style-object%%}
+{template high-level-style-object%%}
 
 #### Insert data
 
-{template orm-style-insert-data%%}
+{template high-level-style-insert-data%%}
 
 #### Streaming insert
 
 Streaming insert is useful when you want to insert a large amount of data such as importing historical data.
 
-{template orm-style-streaming-insert%%}
+{template high-level-style-streaming-insert%%}
 
 #### Update data
 
 Please refer to [update data](/user-guide/write-data/overview.md#update-data) for the updating mechanism.
 In the following code, we first save a row and then use the same tag and time index to identify the row for updating.
 
-{template orm-style-update-data%%}
+{template high-level-style-update-data%%}
 
 ### More examples
 

--- a/docs/v0.6/zh/user-guide/client-libraries/go.md
+++ b/docs/v0.6/zh/user-guide/client-libraries/go.md
@@ -124,30 +124,16 @@ err := cli.StreamWrite(context.Background(), cpuMetric, memMetric)
 if err != nil {
     // 处理错误
 }
+```
+
+在所有数据写入完毕后关闭流式写入。
+一般情况下，连续写入数据时不需要关闭流式写入。
+
+```go
 affected, err := cli.CloseStream(ctx)
 ```
 
 %}
-
-{template update-rows%
-
-```go
-ts := time.Now()
-_ = cpuMetric.AddRow("127.0.0.1", ts, 0.1, 0.12)
-// 插入一条行数据
-resp, _ := cli.Write(context.Background(), cpuMetric)
-
-// 更新该行数据
-// 同样的标签 `127.0.0.1`
-// 同样的时间索引 `ts`
-// 新值：cpu_user = `0.80`, cpu_sys = `0.11`
-_ = cpuMetric.AddRow("127.0.0.1", ts, 0.80, 0.11)
-// 覆盖现有数据
-resp, _ = cli.Write(context.Background(), cpuMetric)
-```
-
-%}
-
 
 {template high-level-style-object%
 
@@ -210,36 +196,11 @@ log.Printf("affected rows: %d\n", resp.GetAffectedRows().GetValue())
 err := streamClient.StreamWriteObject(context.Background(), cpuMetrics, memMetrics)
 ```
 
-%}
-
-{template high-level-style-update-data%
+在所有数据写入完毕后关闭流式写入。
+一般情况下，连续写入数据时不需要关闭流式写入。
 
 ```go
-ts = time.Now()
-cpuMetrics := []CpuMetric{
-    {
-        Host:        "127.0.0.1",
-        CpuUser:     0.10,
-        CpuSys:      0.12,
-        Ts:          ts,
-    }
-}
-// 插入一条行数据
-resp, err := cli.WriteObject(context.Background(), cpuMetrics)
-
-// 更新该条行数据
-newCpuMetrics := []CpuMetric{
-    {
-        Host:        "127.0.0.1",    // 同样的标签 `127.0.0.1`
-        CpuUser:     0.80,       // 新值：cpu_user = `0.80`
-        CpuSys:      0.11,    // 新值：cpu_sys = `0.11`
-        Ts:          ts,     // 同样的索引 `ts`
-    }
-}
-
-// 覆盖现有数据
-resp, err := cli.WriteObject(context.Background(), newCpuMetrics)
-
+affected, err := cli.CloseStream(ctx)
 ```
 
 %}

--- a/docs/v0.6/zh/user-guide/client-libraries/go.md
+++ b/docs/v0.6/zh/user-guide/client-libraries/go.md
@@ -41,7 +41,7 @@ cfg := greptime.NewCfg("127.0.0.1").
     // 设置鉴权信息
     WithAuth("username", "password")
 
-cli, _ := client.New(cfg)
+cli, _ := greptime.NewClient(cfg)
 ```
 %}
 
@@ -65,6 +65,7 @@ cpuMetric.AddFieldColumn("cpu_sys", types.FLOAT)
 // 插入示例数据
 // 注意：参数必须按照定义的表结构中的列的顺序排列：host, ts, cpu_user, cpu_sys
 err = cpuMetric.AddRow("127.0.0.1", time.Now(), 0.1, 0.12)
+err = cpuMetric.AddRow("127.0.0.1", time.Now(), 0.11, 0.13)
 if err != nil {
     // 处理错误
 }

--- a/docs/v0.6/zh/user-guide/client-libraries/go.md
+++ b/docs/v0.6/zh/user-guide/client-libraries/go.md
@@ -37,11 +37,9 @@ import (
 
 ```go
 cfg := greptime.NewCfg("127.0.0.1").
-    // change the database name to your database name
+    // 将数据库名称更改为你的数据库名称
     WithDatabase("public").
-    // default port
-    WithPort(4001).
-    // set authentication information
+    // 设置鉴权信息
     WithAuth("username", "password")
 
 client, _ := client.New(cfg)
@@ -51,25 +49,25 @@ client, _ := client.New(cfg)
 {template low-level-object%
 
 ```go
-// Construct the table schema for CPU metrics
+// 为 CPU 指标构建表结构
 cpuMetric, err := table.New("cpu_metric")
 if err != nil {
-    // Handle error appropriately
+    // 处理错误
 }
 
-// Add a 'Tag' column for host identifiers
+// 添加一个 'Tag' 列，用于主机标识符
 cpuMetric.AddTagColumn("host", types.STRING)
-// Add a 'Timestamp' column for recording the time of data collection
+// 添加一个 'Timestamp' 列，用于记录数据收集的时间
 cpuMetric.AddTimestampColumn("ts", types.TIMESTAMP_MILLISECOND)
-// Add 'Field' columns for user and system CPU usage measurements
+// 添加 'Field' 列，用于测量用户和系统 CPU 使用率
 cpuMetric.AddFieldColumn("cpu_user", types.FLOAT)
 cpuMetric.AddFieldColumn("cpu_sys", types.FLOAT)
 
-// Insert example data
-// NOTE: The arguments must be in the same order as the columns in the defined schema: host, ts, cpu_user, cpu_sys
+// 插入示例数据
+// 注意：参数必须按照定义的表结构中的列的顺序排列：host, ts, cpu_user, cpu_sys
 err = cpuMetric.AddRow("127.0.0.1", time.Now(), 0.1, 0.12)
 if err != nil {
-    // Handle error appropriately
+    // 处理错误
 }
 
 ```
@@ -81,7 +79,7 @@ if err != nil {
 ```go
 cpuMetric, err := table.New("cpu_metric")
 if err != nil {
-    // Handle error appropriately
+    // 处理错误
 }
 cpuMetric.AddTagColumn("host", types.STRING)
 cpuMetric.AddTimestampColumn("ts", types.TIMESTAMP_MILLISECOND)
@@ -89,19 +87,19 @@ cpuMetric.AddFieldColumn("cpu_user", types.FLOAT)
 cpuMetric.AddFieldColumn("cpu_sys", types.FLOAT)
 err = cpuMetric.AddRow("127.0.0.1", time.Now(), 0.1, 0.12)
 if err != nil {
-    // Handle error appropriately
+    // 处理错误
 }
 
 memMetric, err := table.New("mem_metric")
 if err != nil {
-    // Handle error appropriately
+    // 处理错误
 }
 memMetric.AddTagColumn("host", types.STRING)
 memMetric.AddTimestampColumn("ts", types.TIMESTAMP_MILLISECOND)
 memMetric.AddFieldColumn("mem_usage", types.FLOAT)
 err = memMetric.AddRow("127.0.0.1", time.Now(), 112)
 if err != nil {
-    // Handle error appropriately
+    // 处理错误
 }
 ```
 
@@ -112,7 +110,7 @@ if err != nil {
 ```go
 resp, err := cli.Write(context.Background(), cpuMetric, memMetric)
 if err != nil {
-    // Handle error appropriately
+    // 处理错误
 }
 log.Printf("affected rows: %d\n", resp.GetAffectedRows().GetValue())
 ```
@@ -135,7 +133,7 @@ streamClient, err := client.NewStreamClient(cfg)
 ```go
 err := streamClient.Send(context.Background(), cpuMetric, memMetric)
 if err != nil {
-    // Handle error appropriately
+    // 处理错误
 }
 ```
 
@@ -146,15 +144,15 @@ if err != nil {
 ```go
 ts := time.Now()
 _ = cpuMetric.AddRow("127.0.0.1", ts, 0.1, 0.12)
-// insert a row data
+// 插入一条行数据
 resp, _ := cli.Write(context.Background(), cpuMetric)
 
-// update the row data
-// The same tag `127.0.0.1`
-// The same time index `ts`
-// The new value: cpu_user = `0.80`, cpu_sys = `0.11`
+// 更新该行数据
+// 同样的标签 `127.0.0.1`
+// 同样的时间索引 `ts`
+// 新值：cpu_user = `0.80`, cpu_sys = `0.11`
 _ = cpuMetric.AddRow("127.0.0.1", ts, 0.80, 0.11)
-// overwrite the existing data
+// 覆盖现有数据
 resp, _ = cli.Write(context.Background(), cpuMetric)
 ```
 
@@ -245,19 +243,20 @@ cpuMetrics := []CpuMetric{
         Ts:          ts,
     }
 }
-// insert a row data
+// 插入一条行数据
 resp, err := cli.Create(context.Background(), cpuMetrics)
 
-// update the row data
+// 更新该条行数据
 newCpuMetrics := []CpuMetric{
     {
-        Host:        "127.0.0.1",    // The same tag `127.0.0.1`
-        CpuUser:     0.80,       // The new value: cpu_user = `0.80`
-        CpuSys:      0.11,    // The new value: cpu_sys = `0.11`
-        Ts:          ts,     // The same time index `ts`
+        Host:        "127.0.0.1",    // 同样的标签 `127.0.0.1`
+        CpuUser:     0.80,       // 新值：cpu_user = `0.80`
+        CpuSys:      0.11,    // 新值：cpu_sys = `0.11`
+        Ts:          ts,     // 同样的索引 `ts`
     }
 }
-// overwrite the existing data
+
+// 覆盖现有数据
 resp, err := cli.Create(context.Background(), newCpuMetrics)
 
 ```
@@ -324,7 +323,7 @@ type Mysql struct {
 
 m := &Mysql{
     Host:     "127.0.0.1",
-    Port:     "4002", // default port for MySQL
+    Port:     "4002", // MySQL 协议的默认端口
     User:     "username",
     Password: "password",
     Database: "public",
@@ -335,7 +334,7 @@ dsn := fmt.Sprintf("tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=Local",
 dsn = fmt.Sprintf("%s:%s@%s", m.User, m.Password, dsn)
 db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
 if err != nil {
-    //error handling 
+    // 错误处理
 }
 m.DB = db
 ```

--- a/docs/v0.6/zh/user-guide/client-libraries/go.md
+++ b/docs/v0.6/zh/user-guide/client-libraries/go.md
@@ -318,7 +318,7 @@ func (CpuMetric) TableName() string {
 
 ```go
 var cpuMetric CpuMetric
-db.Raw("SELECT * FROM cpu_metric WHERE ts > ?", 1701360000000).Scan(&result)
+db.Raw("SELECT * FROM cpu_metric LIMIT 10").Scan(&result)
 
 ```
 

--- a/docs/v0.6/zh/user-guide/client-libraries/java.md
+++ b/docs/v0.6/zh/user-guide/client-libraries/java.md
@@ -179,6 +179,11 @@ LOG.info("Write result: {}", result);
 
 {template update-rows%
 
+#### 更新数据
+
+关于更新机制，请参考 [更新数据](/user-guide/write-data/overview.md#更新数据)。
+下方代码首先保存了一行数据，然后使用相同的标签和时间索引来更新特定的行数据。
+
 ```java
 Table cpuMetric = Table.from(myMetricCpuSchema);
 // 插入一行数据
@@ -303,6 +308,11 @@ LOG.info("Write result: {}", result);
 %}
 
 {template high-level-style-update-data%
+
+#### 更新数据
+
+关于更新机制，请参考 [更新数据](/user-guide/write-data/overview.md#更新数据)。
+下方代码首先保存了一行数据，然后使用相同的标签和时间索引来更新特定的行数据。
 
 ```java
 Cpu cpu = new Cpu();

--- a/docs/v0.6/zh/user-guide/client-libraries/java.md
+++ b/docs/v0.6/zh/user-guide/client-libraries/java.md
@@ -168,7 +168,12 @@ writer.write(memMetric);
 
 // 你可以对流执行操作，例如删除前 5 行
 writer.write(cpuMetric.subRange(0, 5), WriteOp.Delete);
+```
 
+在所有数据写入完毕后关闭流式写入。
+一般情况下，连续写入数据时不需要关闭流式写入。
+
+```java
 // 完成流式写入
 CompletableFuture<WriteOk> future = writer.completed();
 WriteOk result = future.get();
@@ -298,7 +303,12 @@ writer.write(memories);
 
 // 你可以对流执行操作，例如删除前 5 行
 writer.write(cpus.subList(0, 5), WriteOp.Delete);
+```
 
+在所有数据写入完毕后关闭流式写入。
+一般情况下，连续写入数据时不需要关闭流式写入。
+
+```java
 // 完成流式写入
 CompletableFuture<WriteOk> future = writer.completed();
 WriteOk result = future.get();

--- a/docs/v0.6/zh/user-guide/client-libraries/java.md
+++ b/docs/v0.6/zh/user-guide/client-libraries/java.md
@@ -201,7 +201,7 @@ Result<WriteOk, Err> updateResult = greptimeDB.write(myMetricCpuSchema).get();
 %}
 
 
-{template orm-style-object%
+{template high-level-style-object%
 
 GreptimeDB Java Ingester SDK 允许我们使用基本的 POJO 对象进行写入。虽然这种方法需要使用 Greptime 的注解，但它们很容易使用。
 
@@ -261,7 +261,7 @@ for (int i = 0; i < 10; i++) {
 %}
 
 
-{template orm-style-insert-data%
+{template high-level-style-insert-data%
 
 写入 POJO 对象：
 
@@ -281,7 +281,7 @@ if (result.isOk()) {
 
 %}
 
-{template orm-style-streaming-insert%
+{template high-level-style-streaming-insert%
 
 ```java
 StreamWriter<List<?>, WriteOk> writer = greptimeDB.streamWriterPOJOs();
@@ -301,7 +301,7 @@ LOG.info("Write result: {}", result);
 
 %}
 
-{template orm-style-update-data%
+{template high-level-style-update-data%
 
 ```java
 Cpu cpu = new Cpu();

--- a/docs/v0.6/zh/user-guide/client-libraries/java.md
+++ b/docs/v0.6/zh/user-guide/client-libraries/java.md
@@ -48,11 +48,11 @@ GreptimeDB 提供的 Java ingester SDK 是一个轻量级库，具有以下特�
 请注意每个选项的注释，它们提供了对其各自角色的详细解释。
 
 ```java
-// GreptimeDB 默认数据库名称为 "public"，默认目录为 "greptime"，
+// GreptimeDB 默认 database 为 "public"，默认 catalog 为 "greptime"，
 // 我们可以将其作为测试数据库使用
 String database = "public";
 // 默认情况下，GreptimeDB 使用 gRPC 协议在监听端口 4001。
-// 我们可以提供多个指向同一 GreptimeDB 集群的 endpoints。
+// 我们可以提供多个指向同一 GreptimeDB 集群的 endpoints，
 // 客户端将根据负载均衡策略调用这些 endpoints。
 String[] endpoints = {"127.0.0.1:4001"};
 // 设置鉴权信息
@@ -88,7 +88,7 @@ long ts = System.currentTimeMillis(); // 当前时间戳
 double cpuUser = 0.1; // 用户进程的 CPU 使用率（百分比）
 double cpuSys = 0.12; // 系统进程的 CPU 使用率（百分比）
 
-// 将行插入表中
+// 将一行数据插入表中
 // 注意：参数必须按照定义的表结构的列顺序排列：host, ts, cpu_user, cpu_sys
 cpuMetric.addRow(host, ts, cpuUser, cpuSys);
 ```
@@ -140,7 +140,7 @@ for (int i = 0; i < 10; i++) {
 ```java
 // 插入数据
 
-// 考虑到性能问题，SDK 设计为纯异步的。
+// 考虑到尽可能提升性能和降低资源占用，SDK 设计为纯异步的。
 // 返回值是一个 future 对象。如果你想立即获取结果，可以调用 `future.get()`。
 CompletableFuture<Result<WriteOk, Err>> future = greptimeDB.write(cpuMetric, memMetric);
 
@@ -195,7 +195,8 @@ long ts = 1703832681000L;
 myMetricCpuSchema.addRow("host1", ts, 0.80, 0.11);
 
 // 覆盖现有数据
-Result<WriteOk, Err> updateResult = greptimeDB.write(myMetricCpuSchema).get();
+CompletableFuture<Result<WriteOk, Err>> future = greptimeDB.write(myMetricCpuSchema);
+Result<WriteOk, Err> result = future.get();
 ```
 
 %}

--- a/docs/v0.6/zh/user-guide/client-libraries/java.md
+++ b/docs/v0.6/zh/user-guide/client-libraries/java.md
@@ -48,19 +48,19 @@ GreptimeDB 提供的 Java ingester SDK 是一个轻量级库，具有以下特�
 请注意每个选项的注释，它们提供了对其各自角色的详细解释。
 
 ```java
-// GreptimeDB has a default database named "public" in the default catalog "greptime",
-// we can use it as the test database
+// GreptimeDB 默认数据库名称为 "public"，默认目录为 "greptime"，
+// 我们可以将其作为测试数据库使用
 String database = "public";
-// By default, GreptimeDB listens on port 4001 using the gRPC protocol.
-// We can provide multiple endpoints that point to the same GreptimeDB cluster.
-// The client will make calls to these endpoints based on a load balancing strategy.
+// 默认情况下，GreptimeDB 使用 gRPC 协议在监听端口 4001。
+// 我们可以提供多个指向同一 GreptimeDB 集群的 endpoints。
+// 客户端将根据负载均衡策略调用这些 endpoints。
 String[] endpoints = {"127.0.0.1:4001"};
-// Sets authentication information.
+// 设置鉴权信息
 AuthInfo authInfo = new AuthInfo("username", "password");
 GreptimeOptions opts = GreptimeOptions.newBuilder(endpoints, database)
-        // If the database does not require authentication, we can use AuthInfo.noAuthorization() as the parameter.
+        // 如果数据库不需要鉴权，我们可以使用 AuthInfo.noAuthorization() 作为参数。
         .authInfo(authInfo)
-        // A good start ^_^
+        // 好的开始 ^_^
         .build();
 
 GreptimeDB client = GreptimeDB.create(opts);
@@ -71,25 +71,25 @@ GreptimeDB client = GreptimeDB.create(opts);
 {template low-level-object%
 
 ```java
-// Construct the table schema for CPU metrics
+// 为 CPU 指标构建表结构
 TableSchema cpuMetricSchema = TableSchema.newBuilder("cpu_metric")
-        .addTag("host", DataType.String) // Identifier for the host
-        .addTimestamp("ts", DataType.TimestampMillisecond) // Timestamp in milliseconds
-        .addField("cpu_user", DataType.Float64) // CPU usage by user processes
-        .addField("cpu_sys", DataType.Float64) // CPU usage by system processes
+        .addTag("host", DataType.String) // 主机的标识符
+        .addTimestamp("ts", DataType.TimestampMillisecond) // 毫秒级的时间戳
+        .addField("cpu_user", DataType.Float64) // 用户进程的 CPU 使用率
+        .addField("cpu_sys", DataType.Float64) // 系统进程的 CPU 使用率
         .build();
 
-// Create the table from the defined schema
+// 根据定义的模式创建表
 Table cpuMetric = Table.from(cpuMetricSchema);
 
-// Example data for a single row
-String host = "127.0.0.1"; // Host identifier
-long ts = System.currentTimeMillis(); // Current timestamp
-double cpuUser = 0.1; // CPU usage by user processes (in percentage)
-double cpuSys = 0.12; // CPU usage by system processes (in percentage)
+// 单行的示例数据
+String host = "127.0.0.1"; // 主机标识符
+long ts = System.currentTimeMillis(); // 当前时间戳
+double cpuUser = 0.1; // 用户进程的 CPU 使用率（百分比）
+double cpuSys = 0.12; // 系统进程的 CPU 使用率（百分比）
 
-// Insert the row into the table
-// NOTE: The arguments must be in the same order as the columns in the defined schema: host, ts, cpu_user, cpu_sys
+// 将行插入表中
+// 注意：参数必须按照定义的表结构的列顺序排列：host, ts, cpu_user, cpu_sys
 cpuMetric.addRow(host, ts, cpuUser, cpuSys);
 ```
 
@@ -98,7 +98,7 @@ cpuMetric.addRow(host, ts, cpuUser, cpuSys);
 {template create-rows%
 
 ```java
-// Creates schemas
+// 创建表结构
 TableSchema cpuMetricSchema = TableSchema.newBuilder("cpu_metric")
         .addTag("host", DataType.String)
         .addTimestamp("ts", DataType.TimestampMillisecond)
@@ -115,7 +115,7 @@ TableSchema memMetricSchema = TableSchema.newBuilder("mem_metric")
 Table cpuMetric = Table.from(cpuMetricSchema);
 Table memMetric = Table.from(memMetricSchema);
 
-// Adds row data items
+// 添加行数据
 for (int i = 0; i < 10; i++) {
     String host = "127.0.0." + i;
     long ts = System.currentTimeMillis();
@@ -138,11 +138,10 @@ for (int i = 0; i < 10; i++) {
 {template insert-rows%
 
 ```java
-// Saves data
+// 插入数据
 
-// For performance reasons, the SDK is designed to be purely asynchronous.
-// The return value is a future object. If you want to immediately obtain
-// the result, you can call `future.get()`.
+// 考虑到性能问题，SDK 设计为纯异步的。
+// 返回值是一个 future 对象。如果你想立即获取结果，可以调用 `future.get()`。
 CompletableFuture<Result<WriteOk, Err>> future = greptimeDB.write(cpuMetric, memMetric);
 
 Result<WriteOk, Err> result = future.get();
@@ -163,14 +162,14 @@ if (result.isOk()) {
 ```java
 StreamWriter<Table, WriteOk> writer = greptimeDB.streamWriter();
 
-// write data into stream
+// 写入数据到流中
 writer.write(cpuMetric);
 writer.write(memMetric);
 
-// You can perform operations on the stream, such as deleting the first 5 rows.
+// 你可以对流执行操作，例如删除前 5 行
 writer.write(cpuMetric.subRange(0, 5), WriteOp.Delete);
 
-// complete the stream
+// 完成流式写入
 CompletableFuture<WriteOk> future = writer.completed();
 WriteOk result = future.get();
 LOG.info("Write result: {}", result);
@@ -182,20 +181,20 @@ LOG.info("Write result: {}", result);
 
 ```java
 Table cpuMetric = Table.from(myMetricCpuSchema);
-// insert a row data
+// 插入一行数据
 long ts = 1703832681000L;
 cpuMetric.addRow("host1", ts, 0.23, 0.12);
 Result<WriteOk, Err> putResult = greptimeDB.write(cpuMetric).get();
 
-// update the row data
+// 更新行数据
 Table newCpuMetric = Table.from(myMetricCpuSchema);
-// The same tag `host1`
-// The same time index `1703832681000`
-// The new value: cpu_user = `0.80`, cpu_sys = `0.11`
+// 相同的标签 `host1`
+// 相同的时间索引 `1703832681000`
+// 新的值：cpu_user = `0.80`, cpu_sys = `0.11`
 long ts = 1703832681000L;
 myMetricCpuSchema.addRow("host1", ts, 0.80, 0.11);
 
-// overwrite the existing data
+// 覆盖现有数据
 Result<WriteOk, Err> updateResult = greptimeDB.write(myMetricCpuSchema).get();
 ```
 
@@ -238,7 +237,7 @@ public class Memory {
     // ...
 }
 
-// Add rows
+// 添加行
 List<Cpu> cpus = new ArrayList<>();
 for (int i = 0; i < 10; i++) {
     Cpu c = new Cpu();
@@ -267,7 +266,7 @@ for (int i = 0; i < 10; i++) {
 写入 POJO 对象：
 
 ```java
-// Saves data
+// 插入数据
 
 CompletableFuture<Result<WriteOk, Err>> puts = greptimeDB.writePOJOs(cpus, memories);
 
@@ -287,14 +286,14 @@ if (result.isOk()) {
 ```java
 StreamWriter<List<?>, WriteOk> writer = greptimeDB.streamWriterPOJOs();
 
-// write data into stream
+// 写入数据到流中
 writer.write(cpus);
 writer.write(memories);
 
-// You can perform operations on the stream, such as deleting the first 5 rows.
+// 你可以对流执行操作，例如删除前 5 行
 writer.write(cpus.subList(0, 5), WriteOp.Delete);
 
-// complete the stream
+// 完成流式写入
 CompletableFuture<WriteOk> future = writer.completed();
 WriteOk result = future.get();
 LOG.info("Write result: {}", result);
@@ -311,20 +310,20 @@ cpu.setTs(1703832681000L);
 cpu.setCpuUser(0.23);
 cpu.setCpuSys(0.12);
 
-// insert a row data
+// 插入一行数据
 Result<WriteOk, Err> putResult = greptimeDB.writePOJOs(cpu).get();
 
-// update the row data
+// 更新该行数据
 Cpu newCpu = new Cpu();
-// The same tag `host1`
+// 相同的标签 `host1`
 newCpu.setHost("host1");
-// The same time index `1703832681000`
+// 相同的时间索引 `1703832681000`
 newCpu.setTs(1703832681000L);
-// The new value: cpu_user = `0.80`, cpu_sys = `0.11`
+// 新的值: cpu_user = `0.80`, cpu_sys = `0.11`
 cpu.setCpuUser(0.80);
 cpu.setCpuSys(0.11);
 
-// overwrite the existing data
+// 覆盖现有数据
 Result<WriteOk, Err> updateResult = greptimeDB.writePOJOs(newCpu).get();
 ```
 
@@ -369,7 +368,7 @@ Java 数据库连接（JDBC）是 JavaSoft 规范的标准应用程序编程接�
 如果你使用的是 [Maven](https://maven.apache.org/)，请将以下内容添加到 pom.xml 的依赖项列表中：
 
 ```xml
-<!-- MySQL usage dependency -->
+<!-- MySQL 依赖 -->
 <dependency>
     <groupId>mysql</groupId>
     <artifactId>mysql-connector-java</artifactId>

--- a/docs/v0.6/zh/user-guide/client-libraries/template.md
+++ b/docs/v0.6/zh/user-guide/client-libraries/template.md
@@ -60,11 +60,6 @@ GreptimeDB 的低层级 API 通过向具有预定义模式的 `table` 对象添�
 
 {template streaming-insert%%}
 
-#### 更新数据
-
-关于更新机制，请参考 [更新数据](/user-guide/write-data/overview.md#更新数据)。
-下方代码首先保存了一行数据，然后使用相同的标签和时间索引来更新特定的行数据。
-
 {template update-rows%%}
 
 <!-- TODO ### Delete Metrics -->
@@ -89,11 +84,6 @@ SDK 的高层级 API 使用 ORM 风格的对象写入数据，
 当你需要插入大量数据时，例如导入历史数据，流式插入是非常有用的。
 
 {template high-level-style-streaming-insert%%}
-
-#### 更新数据
-
-关于更新机制，请参考 [更新数据](/user-guide/write-data/overview.md#更新数据)。
-下方代码首先保存了一行数据，然后使用相同的标签和时间索引来更新特定的行数据。
 
 {template high-level-style-update-data%%}
 

--- a/docs/v0.6/zh/user-guide/client-libraries/template.md
+++ b/docs/v0.6/zh/user-guide/client-libraries/template.md
@@ -22,43 +22,85 @@ GreptimeDB 提供了一个 ingester 库来帮助你写入数据。
 
 {template ingester-lib-connect%%}
 
-### 行对象
+### 数据模型
 
 表中的每条行数据包含三种类型的列：`Tag`、`Timestamp` 和 `Field`。更多信息请参考 [数据模型](/user-guide/concepts/data-model.md)。
 列值的类型可以是 `String`、`Float`、`Int`、`Timestamp` 等。更多信息请参考 [数据类型](/reference/sql/data-types.md)。
 
-{template row-object%%}
+### 低级 API
 
-### 创建行数据
+GreptimeDB 的低级 API 通过向具有预定义模式的 `table` 对象添加 `row` 来写入数据。
 
-下面的例子展示了如何创建包含 `Tag`、`Timestamp` 和 `Field` 列的行。`Tag` 列是 `String` 类型，`Timestamp` 列是 `Timestamp` 类型，`Field` 列是 `Float` 类型。
+#### 创建行数据
 
-{template create-a-row%%}
+以下代码片段首先构建了一个名为 `cpu_metric` 的表，其中包括 `host`、`cpu_user`、`cpu_sys` 和 `ts` 列。
+随后，它向表中插入了一行数据。
 
-为了提高写入数据的效率，你可以一次创建多行数据写入 GreptimeDB。
+该表包含三种类型的列：
+
+- `Tag`：`host` 列，值类型为 `String`。
+- `Field`：`cpu_user` 和 `cpu_sys` 列，值类型为 `Float`。
+- `Timestamp`：`ts` 列，值类型为 `Timestamp`。
+
+{template low-level-object%%}
+
+为了提高写入数据的效率，你可以一次创建多行数据以便写入到 GreptimeDB。
 
 {template create-rows%%}
 
-### 保存行数据
+#### 插入数据
 
-下方的例子展示了如何将行数据保存到 GreptimeDB 中。
+下方示例展示了如何向 GreptimeDB 的表中插入行数据。
 
-{template save-rows%%}
+{template insert-rows%%}
 
-### 更新行数据
+#### 流式插入
 
-请参考 [更新数据](/user-guide/write-data/overview.md#更新数据)了解更新机制。
-下面的例子展示了先保存一行数据，然后更新这行数据。
+当你需要插入大量数据时，例如导入历史数据，流式插入是非常有用的。
+
+{template streaming-insert%%}
+
+#### 更新数据
+
+关于更新机制，请参考 [更新数据](/user-guide/write-data/overview.md#更新数据)。
+下方代码首先保存了一行数据，然后使用相同的标签和时间索引来更新特定的行数据。
 
 {template update-rows%%}
 
 <!-- TODO ### Delete Metrics -->
 
-{template ingester-lib-debug-logs%%}
+### ORM API
+
+ORM 风格的对象允许你以更面向对象的方式创建、插入和更新数据，为开发者提供了更友好的体验。
+然而，它不如低级对象那样高效。
+这是因为 ORM 风格的对象在转换对象时可能会消耗更多的资源和时间。
+
+#### 创建行数据
+
+{template orm-style-object%%}
+
+#### 插入数据
+
+{template orm-style-insert-data%%}
+
+#### 流式插入
+
+当你需要插入大量数据时，例如导入历史数据，流式插入是非常有用的。
+
+{template orm-style-streaming-insert%%}
+
+#### 更新数据
+
+关于更新机制，请参考 [更新数据](/user-guide/write-data/overview.md#更新数据)。
+下方代码首先保存了一行数据，然后使用相同的标签和时间索引来更新特定的行数据。
+
+{template orm-style-update-data%%}
 
 ### 更多示例
 
 {template more-ingestion-examples%%}
+
+{template ingester-lib-debug-logs%%}
 
 ### Ingester 库参考
 
@@ -77,7 +119,7 @@ GreptimeDB 使用 SQL 作为主要查询语言，兼容 MySQL 和 PostgreSQL。
 
 {template query-library-installation%%}
 
-### 连接到数据库
+### 连接数据库
 
 下方的例子展示了如何连接到 GreptimeDB：
 

--- a/docs/v0.6/zh/user-guide/client-libraries/template.md
+++ b/docs/v0.6/zh/user-guide/client-libraries/template.md
@@ -27,9 +27,9 @@ GreptimeDB 提供了一个 ingester 库来帮助你写入数据。
 表中的每条行数据包含三种类型的列：`Tag`、`Timestamp` 和 `Field`。更多信息请参考 [数据模型](/user-guide/concepts/data-model.md)。
 列值的类型可以是 `String`、`Float`、`Int`、`Timestamp` 等。更多信息请参考 [数据类型](/reference/sql/data-types.md)。
 
-### 低级 API
+### 低层级 API
 
-GreptimeDB 的低级 API 通过向具有预定义模式的 `table` 对象添加 `row` 来写入数据。
+GreptimeDB 的低层级 API 通过向具有预定义模式的 `table` 对象添加 `row` 来写入数据。
 
 #### 创建行数据
 
@@ -69,32 +69,33 @@ GreptimeDB 的低级 API 通过向具有预定义模式的 `table` 对象添加 
 
 <!-- TODO ### Delete Metrics -->
 
-### ORM API
+### 高层级 API
 
-ORM 风格的对象允许你以更面向对象的方式创建、插入和更新数据，为开发者提供了更友好的体验。
-然而，它不如低级对象那样高效。
+SDK 的高层级 API 使用 ORM 风格的对象写入数据，
+它允许你以更面向对象的方式创建、插入和更新数据，为开发者提供了更友好的体验。
+然而，高层级 API 不如低层级 API 高效。
 这是因为 ORM 风格的对象在转换对象时可能会消耗更多的资源和时间。
 
 #### 创建行数据
 
-{template orm-style-object%%}
+{template high-level-style-object%%}
 
 #### 插入数据
 
-{template orm-style-insert-data%%}
+{template high-level-style-insert-data%%}
 
 #### 流式插入
 
 当你需要插入大量数据时，例如导入历史数据，流式插入是非常有用的。
 
-{template orm-style-streaming-insert%%}
+{template high-level-style-streaming-insert%%}
 
 #### 更新数据
 
 关于更新机制，请参考 [更新数据](/user-guide/write-data/overview.md#更新数据)。
 下方代码首先保存了一行数据，然后使用相同的标签和时间索引来更新特定的行数据。
 
-{template orm-style-update-data%%}
+{template high-level-style-update-data%%}
 
 ### 更多示例
 


### PR DESCRIPTION
## What's Changed in this PR

Since each SDK supports two code object styles, the outline of the SDK documentation template needs to be changed.
**This change requires each SDK to support two styles of object creation code**, I'm not sure it is the best practice.
@killme2008 @fengjiachun @yuanbohan 

Before:

```
- Create data
- Insert data
- Update data
```

Now:

```
- Low-level API
  - Create data
  - Insert data
  - Update data
 -High-level API
  - Create data
  - Insert data
  - Update data
```

## Checklist

- [x] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
