### PR TITLE
docs: update range query docs

### DIFF
--- a/docs/v0.7/en/reference/sql/range.md
+++ b/docs/v0.7/en/reference/sql/range.md
@@ -369,9 +369,9 @@ Get after running
 +---------------------+-----------------------------------+
 ```
 
-## `ORDER BY` option
+## `ORDER BY` option in aggregate functions
 
-Range queries support the use of `order by` expressions within specific aggregate functions to sort data on the same time slot. Taking the `first_value` and `last_value` aggregate functions as an example, users can use `order by` to sort the aggregated data to correctly select the first value and the last value. By default, the `first_value` and `last_value` functions sort data in ascending order using timestamps.
+Range queries support the use of `order by` expressions in the parameters of the `first_value` and `last_value` aggregate functions. By default, the data is sorted in ascending order based on the time index column.
 
 Take this table as an example:
 
@@ -385,7 +385,7 @@ Take this table as an example:
 +---------------------+-------+------+-------+
 ```
 
-Users can not specify the `order by` expression, and the effect is equivalent to using the `ts` column to sort in ascending order.
+When the `order by` expression is not specified in the function parameter, the default behavior is to sort the data in ascending order based on the time index column.
 
 ```sql
 SELECT ts, first_value(val) RANGE '5s', last_value(val) RANGE '5s' FROM host ALIGN '5s';
@@ -403,7 +403,7 @@ Get after query
 +---------------------+--------------------------------+-------------------------------+
 ```
 
-Users can also specify their own sorting rules without using the default sorting options, such as using `addon` sorting:
+You can specify your own sorting rules. For example, the following SQL sorts the data by the `addon` column in ascending order:
 
 ```sql
 SELECT ts, first_value(val ORDER BY addon ASC) RANGE '5s', last_value(val ORDER BY addon ASC) RANGE '5s' FROM host ALIGN '5s';

--- a/docs/v0.7/zh/reference/sql/range.md
+++ b/docs/v0.7/zh/reference/sql/range.md
@@ -366,9 +366,9 @@ FROM host ALIGN '5s' BY ();
 +---------------------+-----------------------------------+
 ```
 
-## `ORDER BY` 选项
+## 聚合函数中的 `ORDER BY` 选项
 
-Range 查询支持在特定聚合函数内使用 `order by` 表达式，来对同一个时间片上的数据进行排序。以 `first_value` 和 `last_value` 聚合函数为例，用户可以使用 `order by` 对聚合的内容进行排序，从而正确的选出第一个值和最后一个值。在默认情况下，`first_value` 和 `last_value` 函数使用时间戳升序排列数据。
+Range 查询支持在聚合函数 `first_value` 和 `last_value` 中使用 `order by` 表达式，默认情况下，聚合函数使用时间列升序排列数据。
 
 以该数据表为例：
 
@@ -383,7 +383,7 @@ Range 查询支持在特定聚合函数内使用 `order by` 表达式，来对�
 +---------------------+-------+------+-------+
 ```
 
-用户可以不指定 `order by` 表达式，效果等价于使用 `ts` 列升序排列。
+如果不指定 `order by` 表达式，默认使用 `ts` 列升序排列。
 
 ```sql
 SELECT ts, first_value(val) RANGE '5s', last_value(val) RANGE '5s' FROM host ALIGN '5s';
@@ -401,7 +401,7 @@ SELECT ts, first_value(val order by ts ASC) RANGE '5s', last_value(val order by 
 +---------------------+--------------------------------+-------------------------------+
 ```
 
-用户也可以不使用默认的排序选项自己指定排序规则，比如使用 `addon` 排序：
+也可以自定义排序规则，比如使用 `addon` 排序：
 
 ```sql
 SELECT ts, first_value(val ORDER BY addon ASC) RANGE '5s', last_value(val ORDER BY addon ASC) RANGE '5s' FROM host ALIGN '5s';

--- a/docs/v0.7/zh/reference/sql/range.md
+++ b/docs/v0.7/zh/reference/sql/range.md
@@ -368,7 +368,7 @@ FROM host ALIGN '5s' BY ();
 
 ## 聚合函数中的 `ORDER BY` 选项
 
-Range 查询支持在聚合函数 `first_value` 和 `last_value` 中使用 `order by` 表达式，默认情况下，聚合函数使用时间列升序排列数据。
+Range 查询支持在聚合函数 `first_value` 和 `last_value` 中使用 `order by` 表达式，默认情况下，聚合函数使用时间索引列升序排列数据。
 
 以该数据表为例：
 


### PR DESCRIPTION
## What's Changed in this PR

update range query docs
- new fill behavior
- Range SQL structure
- `first_value`/`last_value` use `ts` as default `order by` 

related pr: https://github.com/GreptimeTeam/greptimedb/pull/3489

## Checklist

- [x] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.

Closes https://github.com/GreptimeTeam/docs/issues/832