### PR TITLE
docs: remove global ttl

### DIFF
--- a/docs/v0.4/en/user-guide/concepts/features-that-you-concern.md
+++ b/docs/v0.4/en/user-guide/concepts/features-that-you-concern.md
@@ -23,12 +23,7 @@ CREATE TABLE IF NOT EXISTS temperatures(
 ) engine=mito with(ttl='7d', regions=10);
 ```
 
-The TTL of temperatures is set to be seven days. If you want to set the global TTL of all tables, you can configure it in the configuration file:
-
-```toml
-[storage]
-global_ttl = "7d"
-```
+The TTL of temperatures is set to be seven days. 
 
 You can refer to the TTL option of the table create statement [here](/reference/sql/create).
 

--- a/docs/v0.4/zh/user-guide/concepts/features-that-you-concern.md
+++ b/docs/v0.4/zh/user-guide/concepts/features-that-you-concern.md
@@ -23,12 +23,7 @@ CREATE TABLE IF NOT EXISTS temperatures(
 ) engine=mito with(ttl='7d', regions=10);
 ```
 
-在上述 SQL 中 `temperatures` 表的 TTL 被设置为 7 天。如果你想为所有表设置全局 TTL，你可以在配置文件中配置它：
-
-```toml
-[storage]
-global_ttl = "7d"
-```
+在上述 SQL 中 `temperatures` 表的 TTL 被设置为 7 天。
 
 你可以在[这里](/reference/sql/create)参考表创建语句的 TTL 选项。
 

--- a/docs/v0.5/en/user-guide/concepts/features-that-you-concern.md
+++ b/docs/v0.5/en/user-guide/concepts/features-that-you-concern.md
@@ -19,12 +19,7 @@ CREATE TABLE IF NOT EXISTS temperatures(
 ) engine=mito with(ttl='7d', regions=10);
 ```
 
-The TTL of temperatures is set to be seven days. If you want to set the global TTL of all tables, you can configure it in the configuration file:
-
-```toml
-[storage]
-global_ttl = "7d"
-```
+The TTL of temperatures is set to be seven days. 
 
 You can refer to the TTL option of the table create statement [here](/reference/sql/create).
 

--- a/docs/v0.5/zh/user-guide/concepts/features-that-you-concern.md
+++ b/docs/v0.5/zh/user-guide/concepts/features-that-you-concern.md
@@ -19,12 +19,7 @@ CREATE TABLE IF NOT EXISTS temperatures(
 ) engine=mito with(ttl='7d', regions=10);
 ```
 
-在上述 SQL 中 `temperatures` 表的 TTL 被设置为 7 天。如果你想为所有表设置全局 TTL，你可以在配置文件中配置它：
-
-```toml
-[storage]
-global_ttl = "7d"
-```
+在上述 SQL 中 `temperatures` 表的 TTL 被设置为 7 天。
 
 你可以在[这里](/reference/sql/create)参考表创建语句的 TTL 选项。
 

--- a/docs/v0.6/en/user-guide/concepts/features-that-you-concern.md
+++ b/docs/v0.6/en/user-guide/concepts/features-that-you-concern.md
@@ -19,12 +19,7 @@ CREATE TABLE IF NOT EXISTS temperatures(
 ) engine=mito with(ttl='7d', regions=10);
 ```
 
-The TTL of temperatures is set to be seven days. If you want to set the global TTL of all tables, you can configure it in the configuration file:
-
-```toml
-[storage]
-global_ttl = "7d"
-```
+The TTL of temperatures is set to be seven days. 
 
 You can refer to the TTL option of the table create statement [here](/reference/sql/create).
 

--- a/docs/v0.6/zh/user-guide/concepts/features-that-you-concern.md
+++ b/docs/v0.6/zh/user-guide/concepts/features-that-you-concern.md
@@ -19,12 +19,7 @@ CREATE TABLE IF NOT EXISTS temperatures(
 ) engine=mito with(ttl='7d', regions=10);
 ```
 
-在上述 SQL 中 `temperatures` 表的 TTL 被设置为 7 天。如果你想为所有表设置全局 TTL，你可以在配置文件中配置它：
-
-```toml
-[storage]
-global_ttl = "7d"
-```
+在上述 SQL 中 `temperatures` 表的 TTL 被设置为 7 天。
 
 你可以在[这里](/reference/sql/create)参考表创建语句的 TTL 选项。
 

--- a/docs/v0.7/en/user-guide/concepts/features-that-you-concern.md
+++ b/docs/v0.7/en/user-guide/concepts/features-that-you-concern.md
@@ -19,12 +19,7 @@ CREATE TABLE IF NOT EXISTS temperatures(
 ) engine=mito with(ttl='7d', regions=10);
 ```
 
-The TTL of temperatures is set to be seven days. If you want to set the global TTL of all tables, you can configure it in the configuration file:
-
-```toml
-[storage]
-global_ttl = "7d"
-```
+The TTL of temperatures is set to be seven days. 
 
 You can refer to the TTL option of the table create statement [here](/reference/sql/create).
 

--- a/docs/v0.7/zh/user-guide/concepts/features-that-you-concern.md
+++ b/docs/v0.7/zh/user-guide/concepts/features-that-you-concern.md
@@ -19,12 +19,7 @@ CREATE TABLE IF NOT EXISTS temperatures(
 ) engine=mito with(ttl='7d', regions=10);
 ```
 
-在上述 SQL 中 `temperatures` 表的 TTL 被设置为 7 天。如果你想为所有表设置全局 TTL，你可以在配置文件中配置它：
-
-```toml
-[storage]
-global_ttl = "7d"
-```
+在上述 SQL 中 `temperatures` 表的 TTL 被设置为 7 天。
 
 你可以在[这里](/reference/sql/create)参考表创建语句的 TTL 选项。
 


### PR DESCRIPTION
## What's Changed in this PR

This PR removes global_ttl option related sections since this config item is no longer valid since v0.4

- closes #880 
## Checklist

- [x] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
