### PR TITLE
docs: deprecate 4004 port

### DIFF
--- a/docs/v0.7/en/getting-started/quick-start/prerequisites.md
+++ b/docs/v0.7/en/getting-started/quick-start/prerequisites.md
@@ -22,7 +22,6 @@ services:
       - 4001:4001
       - 4002:4002
       - 4003:4003
-      - 4004:4004
       - 4242:4242
     command: "standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003 --opentsdb-addr 0.0.0.0:4242"
     volumes:

--- a/docs/v0.7/en/getting-started/quick-start/prometheus.md
+++ b/docs/v0.7/en/getting-started/quick-start/prometheus.md
@@ -47,7 +47,6 @@ services:
       - 4001:4001
       - 4002:4002
       - 4003:4003
-      - 4004:4004
       - 4242:4242
     command: "standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003 --opentsdb-addr 0.0.0.0:4242"
     volumes:

--- a/docs/v0.7/en/getting-started/quick-start/vector.md
+++ b/docs/v0.7/en/getting-started/quick-start/vector.md
@@ -43,7 +43,6 @@ services:
       - 4001:4001
       - 4002:4002
       - 4003:4003
-      - 4004:4004
       - 4242:4242
     command: "standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003 --opentsdb-addr 0.0.0.0:4242"
     volumes:

--- a/docs/v0.7/zh/getting-started/quick-start/prerequisites.md
+++ b/docs/v0.7/zh/getting-started/quick-start/prerequisites.md
@@ -22,7 +22,6 @@ services:
       - 4001:4001
       - 4002:4002
       - 4003:4003
-      - 4004:4004
       - 4242:4242
     command: "standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003 --opentsdb-addr 0.0.0.0:4242"
     volumes:

--- a/docs/v0.7/zh/getting-started/quick-start/prometheus.md
+++ b/docs/v0.7/zh/getting-started/quick-start/prometheus.md
@@ -47,7 +47,6 @@ services:
       - 4001:4001
       - 4002:4002
       - 4003:4003
-      - 4004:4004
       - 4242:4242
     command: "standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003 --opentsdb-addr 0.0.0.0:4242"
     volumes:

--- a/docs/v0.7/zh/getting-started/quick-start/vector.md
+++ b/docs/v0.7/zh/getting-started/quick-start/vector.md
@@ -42,7 +42,6 @@ services:
       - 4001:4001
       - 4002:4002
       - 4003:4003
-      - 4004:4004
       - 4242:4242
     command: "standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003 --opentsdb-addr 0.0.0.0:4242"
     volumes:


### PR DESCRIPTION
## What's Changed in this PR

`4004` port in standalone and frontend is no longer used. Remove them from `v0.7` document.

## Checklist

- [ ] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
