### PR TITLE
docs: update config and table options docs

### DIFF
--- a/docs/v0.7/en/reference/sql/create.md
+++ b/docs/v0.7/en/reference/sql/create.md
@@ -85,8 +85,13 @@ Users can add table options by using `WITH`. The valid options contain the follo
 | ------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ttl`               | The storage time of the table data            | String value, such as `'60m'`, `'1h'` for one hour, `'14d'` for 14 days etc. Supported time units are: `s` / `m` / `h` / `d`                                                 |
 | `regions`           | The region number of the table                | Integer value, such as 1, 5, 10 etc.                                                                                                                                         |
-| `write_buffer_size` | Memtable size of the table                    | String value representing a valid size, such as `32MB`, `128MB`, etc. The default value of this option is `32MB`. Supported units are: `MB` / `GB`.                          |
 | `storage`           | The name of the table storage engine provider | String value, such as `S3`, `Gcs`, etc. It must be configured in `[[storage.providers]]`, see [configuration](/user-guide/operations/configuration#storage-engine-provider). |
+| `compaction.type` | Compaction strategy of the table         | String value. Only `twcs` is allowed. |
+| `compaction.twcs.max_active_window_files` | Max num of files that can be kept in active writing time window         | String value, such as '8'. Only available when `compaction.type` is `twcs`. |
+| `compaction.twcs.max_inactive_window_files` | Max num of files that can be kept in inactive time window.         | String value, such as '1'. Only available when `compaction.type` is `twcs`. |
+| `compaction.twcs.time_window` | Compaction time window    | String value, such as '1d' for 1 day. The table usually partitions rows into different time windows by their timestamps. Only available when `compaction.type` is `twcs`.  |
+| `memtable.type` | Type of the memtable.         | String value, supports `time_series`, `partition_tree`. |
+| `append_mode`           | Whether the table is append-only     | String value. Default is 'false', which removes duplicate rows by primary keys and timestamps. Setting it to 'true' to enable append mode and create an append-only table which keeps duplicate rows.     |
 
 For example, to create a table with the storage data TTL(Time-To-Live) is seven days and region number is 10:
 
@@ -104,6 +109,23 @@ CREATE TABLE IF NOT EXISTS temperatures(
   ts TIMESTAMP TIME INDEX,
   temperature DOUBLE DEFAULT 10,
 ) engine=mito with(ttl='7d', regions=10, storage="Gcs");
+```
+
+Create a table whose compaction time window is 1 day:
+
+```sql
+CREATE TABLE IF NOT EXISTS temperatures(
+  ts TIMESTAMP TIME INDEX,
+  temperature DOUBLE DEFAULT 10,
+) engine=mito with('compaction.type'='twcs', 'compaction.twcs.time_window'='1d');
+```
+
+Create an append-only table which disables deduplication.
+```sql
+CREATE TABLE IF NOT EXISTS temperatures(
+  ts TIMESTAMP TIME INDEX,
+  temperature DOUBLE DEFAULT 10,
+) engine=mito with('append_mode'='true');
 ```
 
 ### Column options

--- a/docs/v0.7/en/reference/sql/create.md
+++ b/docs/v0.7/en/reference/sql/create.md
@@ -87,7 +87,7 @@ Users can add table options by using `WITH`. The valid options contain the follo
 | `regions`           | The region number of the table                | Integer value, such as 1, 5, 10 etc.                                                                                                                                         |
 | `storage`           | The name of the table storage engine provider | String value, such as `S3`, `Gcs`, etc. It must be configured in `[[storage.providers]]`, see [configuration](/user-guide/operations/configuration#storage-engine-provider). |
 | `compaction.type` | Compaction strategy of the table         | String value. Only `twcs` is allowed. |
-| `compaction.twcs.max_active_window_files` | Max num of files that can be kept in active writing time window         | String value, such as '8'. Only available when `compaction.type` is `twcs`. |
+| `compaction.twcs.max_active_window_files` | Max num of files that can be kept in active writing time window         | String value, such as '8'. Only available when `compaction.type` is `twcs`. You can refer to this [document](https://cassandra.apache.org/doc/latest/cassandra/managing/operating/compaction/twcs.html) to learn more about the `twcs` compaction strategy. |
 | `compaction.twcs.max_inactive_window_files` | Max num of files that can be kept in inactive time window.         | String value, such as '1'. Only available when `compaction.type` is `twcs`. |
 | `compaction.twcs.time_window` | Compaction time window    | String value, such as '1d' for 1 day. The table usually partitions rows into different time windows by their timestamps. Only available when `compaction.type` is `twcs`.  |
 | `memtable.type` | Type of the memtable.         | String value, supports `time_series`, `partition_tree`. |
@@ -111,14 +111,26 @@ CREATE TABLE IF NOT EXISTS temperatures(
 ) engine=mito with(ttl='7d', regions=10, storage="Gcs");
 ```
 
-Create a table whose compaction time window is 1 day:
+Create a table with custom compaction options. The table will attempt to partition data into 1-day time window based on the timestamps of the data.
+- It merges files within the latest time window if they exceed 8 files
+- It merges files within inactive windows into a single file
 
 ```sql
 CREATE TABLE IF NOT EXISTS temperatures(
   ts TIMESTAMP TIME INDEX,
   temperature DOUBLE DEFAULT 10,
-) engine=mito with('compaction.type'='twcs', 'compaction.twcs.time_window'='1d');
+)
+engine=mito
+with(
+  'compaction.type'='twcs',
+  'compaction.twcs.time_window'='1d',
+  'compaction.twcs.max_active_window_files'='8',
+  'compaction.twcs.max_inactive_window_files'='1',
+);
 ```
+
+
+
 
 Create an append-only table which disables deduplication.
 ```sql

--- a/docs/v0.7/en/user-guide/operations/configuration.md
+++ b/docs/v0.7/en/user-guide/operations/configuration.md
@@ -112,7 +112,7 @@ greptime standalone start --help
 ### Examples
 
 Configurations can be used in one or multiple components according to their features.
-This document only contains examples for frequently used configurations. Please refer to the auto-generated [document]((https://github.com/GreptimeTeam/greptimedb/blob/main/config/config.md)) for all available configurations.
+This document only contains examples for frequently used configurations. Please refer to the auto-generated [document](https://github.com/GreptimeTeam/greptimedb/blob/main/config/config.md) for all available configurations.
 
 You can find all available configurations for each component on GitHub:
 
@@ -391,7 +391,7 @@ type = "time_series"
 ```
 
 
-The `mito` engine provides an experimental memtable which optimizes for write performance and memory efficiency under millions of time-series:
+The `mito` engine provides an experimental memtable which optimizes for write performance and memory efficiency under large amounts of time-series. Its read performance might not as fast as the default `time_series` memtable.
 ```toml
 [region_engine.mito.memtable]
 type = "partition_tree"

--- a/docs/v0.7/en/user-guide/operations/configuration.md
+++ b/docs/v0.7/en/user-guide/operations/configuration.md
@@ -112,12 +112,15 @@ greptime standalone start --help
 ### Examples
 
 Configurations can be used in one or multiple components according to their features.
+This document only contains examples for frequently used configurations. Please refer to the auto-generated [document]((https://github.com/GreptimeTeam/greptimedb/blob/main/config/config.md)) for all available configurations.
+
 You can find all available configurations for each component on GitHub:
 
 - [standalone](https://github.com/GreptimeTeam/greptimedb/blob/main/config/standalone.example.toml)
 - [frontend](https://github.com/GreptimeTeam/greptimedb/blob/main/config/frontend.example.toml)
 - [datanode](https://github.com/GreptimeTeam/greptimedb/blob/main/config/datanode.example.toml)
 - [metasrv](https://github.com/GreptimeTeam/greptimedb/blob/main/config/metasrv.example.toml)
+
 
 ### Specify configuration file
 
@@ -397,32 +400,31 @@ data_freeze_threshold = 32768
 fork_dictionary_bytes = "1GiB"
 ```
 
+Available options:
 
 | Key | Type | Default | Descriptions |
 | --- | -----| ------- | ----------- |
-| `[[region_engine]]` | -- | -- | The region engine options. You can configure multiple region engines. |
-| `region_engine.mito` | -- | -- | The Mito engine options. |
-| `region_engine.mito.num_workers` | Integer | `8` | Number of region workers. |
-| `region_engine.mito.manifest_checkpoint_distance` | Integer | `10` | Number of meta action updated to trigger a new checkpoint for the manifest. |
-| `region_engine.mito.max_background_jobs` | Integer | `4` | Max number of running background jobs |
-| `region_engine.mito.auto_flush_interval` | String | `1h` | Interval to auto flush a region if it has not flushed yet. |
-| `region_engine.mito.global_write_buffer_size` | String | `1GB` | Global write buffer size for all regions. If not set, it's default to 1/8 of OS memory with a max limitation of 1GB. |
-| `region_engine.mito.global_write_buffer_reject_size` | String | `2GB` | Global write buffer size threshold to reject write requests. If not set, it's default to 2 times of `global_write_buffer_size` |
-| `region_engine.mito.sst_meta_cache_size` | String | `128MB` | Cache size for SST metadata. Setting it to 0 to disable the cache.<br/>If not set, it's default to 1/32 of OS memory with a max limitation of 128MB. |
-| `region_engine.mito.vector_cache_size` | String | `512MB` | Cache size for vectors and arrow arrays. Setting it to 0 to disable the cache.<br/>If not set, it's default to 1/16 of OS memory with a max limitation of 512MB. |
-| `region_engine.mito.page_cache_size` | String | `512MB` | Cache size for pages of SST row groups. Setting it to 0 to disable the cache.<br/>If not set, it's default to 1/16 of OS memory with a max limitation of 512MB. |
-| `region_engine.mito.sst_write_buffer_size` | String | `8MB` | Buffer size for SST writing. |
-| `region_engine.mito.scan_parallelism` | Integer | `0` | Parallelism to scan a region (default: 1/4 of cpu cores).<br/>- `0`: using the default value (1/4 of cpu cores).<br/>- `1`: scan in current thread.<br/>- `n`: scan in parallelism n. |
-| `region_engine.mito.inverted_index` | -- | -- | The options for inverted index in Mito engine. |
-| `region_engine.mito.inverted_index.create_on_flush` | String | `auto` | Whether to create the index on flush.<br/>- `auto`: automatically<br/>- `disable`: never |
-| `region_engine.mito.inverted_index.create_on_compaction` | String | `auto` | Whether to create the index on compaction.<br/>- `auto`: automatically<br/>- `disable`: never |
-| `region_engine.mito.inverted_index.apply_on_query` | String | `auto` | Whether to apply the index on query<br/>- `auto`: automatically<br/>- `disable`: never |
-| `region_engine.mito.inverted_index.mem_threshold_on_create` | String | `64M` | Memory threshold for performing an external sort during index creation.<br/>Setting to empty will disable external sorting, forcing all sorting operations to happen in memory. |
-| `region_engine.mito.inverted_index.intermediate_path` | String | `""` | File system path to store intermediate files for external sorting (default `{data_home}/index_intermediate`). |
-| `region_engine.mito.memtable.type` | String | `time_series` | Memtable type.<br/>- `time_series`: time-series memtable<br/>- `partition_tree`: partition tree memtable (experimental) |
-| `region_engine.mito.memtable.index_max_keys_per_shard` | Integer | `8192` | The max number of keys in one shard.<br/>Only available for `partition_tree` memtable. |
-| `region_engine.mito.memtable.data_freeze_threshold` | Integer | `32768` | The max rows of data inside the actively writing buffer in one shard.<br/>Only available for `partition_tree` memtable. |
-| `region_engine.mito.memtable.fork_dictionary_bytes` | String | `1GiB` | Max dictionary bytes.<br/>Only available for `partition_tree` memtable. |
+| `num_workers` | Integer | `8` | Number of region workers. |
+| `manifest_checkpoint_distance` | Integer | `10` | Number of meta action updated to trigger a new checkpoint for the manifest. |
+| `max_background_jobs` | Integer | `4` | Max number of running background jobs |
+| `auto_flush_interval` | String | `1h` | Interval to auto flush a region if it has not flushed yet. |
+| `global_write_buffer_size` | String | `1GB` | Global write buffer size for all regions. If not set, it's default to 1/8 of OS memory with a max limitation of 1GB. |
+| `global_write_buffer_reject_size` | String | `2GB` | Global write buffer size threshold to reject write requests. If not set, it's default to 2 times of `global_write_buffer_size` |
+| `sst_meta_cache_size` | String | `128MB` | Cache size for SST metadata. Setting it to 0 to disable the cache.<br/>If not set, it's default to 1/32 of OS memory with a max limitation of 128MB. |
+| `vector_cache_size` | String | `512MB` | Cache size for vectors and arrow arrays. Setting it to 0 to disable the cache.<br/>If not set, it's default to 1/16 of OS memory with a max limitation of 512MB. |
+| `page_cache_size` | String | `512MB` | Cache size for pages of SST row groups. Setting it to 0 to disable the cache.<br/>If not set, it's default to 1/16 of OS memory with a max limitation of 512MB. |
+| `sst_write_buffer_size` | String | `8MB` | Buffer size for SST writing. |
+| `scan_parallelism` | Integer | `0` | Parallelism to scan a region (default: 1/4 of cpu cores).<br/>- `0`: using the default value (1/4 of cpu cores).<br/>- `1`: scan in current thread.<br/>- `n`: scan in parallelism n. |
+| `inverted_index` | -- | -- | The options for inverted index in Mito engine. |
+| `inverted_index.create_on_flush` | String | `auto` | Whether to create the index on flush.<br/>- `auto`: automatically<br/>- `disable`: never |
+| `inverted_index.create_on_compaction` | String | `auto` | Whether to create the index on compaction.<br/>- `auto`: automatically<br/>- `disable`: never |
+| `inverted_index.apply_on_query` | String | `auto` | Whether to apply the index on query<br/>- `auto`: automatically<br/>- `disable`: never |
+| `inverted_index.mem_threshold_on_create` | String | `64M` | Memory threshold for performing an external sort during index creation.<br/>Setting to empty will disable external sorting, forcing all sorting operations to happen in memory. |
+| `inverted_index.intermediate_path` | String | `""` | File system path to store intermediate files for external sorting (default `{data_home}/index_intermediate`). |
+| `memtable.type` | String | `time_series` | Memtable type.<br/>- `time_series`: time-series memtable<br/>- `partition_tree`: partition tree memtable (experimental) |
+| `memtable.index_max_keys_per_shard` | Integer | `8192` | The max number of keys in one shard.<br/>Only available for `partition_tree` memtable. |
+| `memtable.data_freeze_threshold` | Integer | `32768` | The max rows of data inside the actively writing buffer in one shard.<br/>Only available for `partition_tree` memtable. |
+| `memtable.fork_dictionary_bytes` | String | `1GiB` | Max dictionary bytes.<br/>Only available for `partition_tree` memtable. |
 
 
 ### Specify meta client

--- a/docs/v0.7/zh/reference/sql/create.md
+++ b/docs/v0.7/zh/reference/sql/create.md
@@ -86,8 +86,13 @@ CREATE TABLE [IF NOT EXISTS] [db.]table_name
 | ------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ttl`               | 表数据的存储时间                         | 字符串值，例如 `'60m'`, `'1h'` 代表 1 小时， `'14d'` 代表 14 天等。支持的时间单位有：`s` / `m` / `h` / `d`                                           |
 | `regions`           | 表的 region 值                           | 整数值，例如 1, 5, 10 etc.                                                                                                                           |
-| `write_buffer_size` | 表的 memtable 大小                       | 表示有效大小的字符串值，例如 `32MB`, `128MB` 等。默认值为 `32MB`。支持的单位有：`MB` / `GB`.                                                         |
 | `storage`           | 自定义表的存储引擎，存储引擎提供商的名字 | 字符串，类似 `S3`、`Gcs` 等。 必须在 `[[storage.providers]]` 列表里配置, 参考 [configuration](/user-guide/operations/configuration#存储引擎提供商)。 |
+| `compaction.type` | Compaction 策略         | 字符串值. 只支持 `twcs`. |
+| `compaction.twcs.max_active_window_files` | 当前活跃时间窗口内的最大文件数         | 字符串值，如 '8'。只在 `compaction.type` 为 `twcs` 时可用 |
+| `compaction.twcs.max_inactive_window_files` | 非活跃时间窗口内的最大文件数         | 字符串值，如 '1'。只在 `compaction.type` 为 `twcs` 时可用 |
+| `compaction.twcs.time_window` | Compaction 时间窗口    | 字符串值，如 '1d' 表示 1 天。该表会根据时间戳将数据分区到不同的时间窗口中。只在 `compaction.type` 为 `twcs` 时可用 |
+| `memtable.type` | memtable 的类型         | 字符串值，支持 `time_series`，`partition_tree` |
+| `append_mode`           | 该表是否时 append-only 的     | 字符串值. 默认为 'false'，表示会根据主键和时间戳对数据去重。设置为 'true' 可以开启 append 模式和创建 append-only 表，保留所有重复的行     |
 
 例如，创建一个存储数据 TTL(Time-To-Live) 为七天，region 数为 10 的表：
 
@@ -106,6 +111,24 @@ CREATE TABLE IF NOT EXISTS temperatures(
   temperature DOUBLE DEFAULT 10,
 ) engine=mito with(ttl='7d', regions=10, storage="Gcs");
 ```
+
+创建一个 compaction 时间窗口为 1 天的表
+
+```sql
+CREATE TABLE IF NOT EXISTS temperatures(
+  ts TIMESTAMP TIME INDEX,
+  temperature DOUBLE DEFAULT 10,
+) engine=mito with('compaction.type'='twcs', 'compaction.twcs.time_window'='1d');
+```
+
+创建一个 append-only 表来关闭去重
+```sql
+CREATE TABLE IF NOT EXISTS temperatures(
+  ts TIMESTAMP TIME INDEX,
+  temperature DOUBLE DEFAULT 10,
+) engine=mito with('append_mode'='true');
+```
+
 
 ### 列选项
 


### PR DESCRIPTION
## What's Changed in this PR

This PR updates
- the configuration doc for mito engine, especially its memtables
- the doc for table options
  - adds compaction options
  - adds append mode

fixes https://github.com/GreptimeTeam/docs/issues/863

## Checklist

- [x] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
