### PR TITLE
fix: broken links to storage options

### DIFF
--- a/docs/v0.7/en/user-guide/concepts/storage-location.md
+++ b/docs/v0.7/en/user-guide/concepts/storage-location.md
@@ -23,14 +23,14 @@ The storage file structure of GreptimeDB includes of the following:
 ```
 
 - `metadata`:  The internal metadata directory that keeps catalog/table info, procedure states, etc. In cluster mode, this directory does not exist in Datanodes or Frontends, because all those states including region route info are saved in Metasrv.
-- `data`: The files in data directory store time series data of GreptimeDB. To customize this path, please refer to [Storage option](../operations/configuration.md#storage-option).
+- `data`: The files in data directory store time series data of GreptimeDB. To customize this path, please refer to [Storage option](../operations/configuration.md#storage-options).
 - `logs`: The log files contains all the logs of operations in GreptimeDB.
 - `wal`: The wal directory contains the write-ahead log files.
 - `index_intermediate`: the temporary intermediate data while indexing.
 
 ## Cloud storage
 
-The `data` directory in the file structure can be stored in cloud storage. Please refer to [Storage option](../operations/configuration.md#storage-option) for more details.
+The `data` directory in the file structure can be stored in cloud storage. Please refer to [Storage option](../operations/configuration.md#storage-options) for more details.
 
 ## Multiple storage engines
 

--- a/docs/v0.7/zh/user-guide/concepts/storage-location.md
+++ b/docs/v0.7/zh/user-guide/concepts/storage-location.md
@@ -21,7 +21,7 @@ GreptimeDB 的存储文件结构包括以下内容：
 ```
 
 - `cluster`：集群目录包含了内部数据，并按数据节点的 ID 组织数据。
-- `data`：data 目录下的文件存储 GreptimeDB 的时序数据。要定制这个路径，请参考 [Storage option](../operations/configuration.md#storage-options)。
+- `data`：data 目录下的文件存储 GreptimeDB 的时序数据。要定制这个路径，请参考[存储选项](../operations/configuration.md#storage-options)。
 - `logs`：日志文件包含 GreptimeDB 中所有的操作日志。
 - `wal`：wal 目录包含了预写日志文件。
 - `index_intermediate`: 索引相关的临时文件目录。

--- a/docs/v0.7/zh/user-guide/concepts/storage-location.md
+++ b/docs/v0.7/zh/user-guide/concepts/storage-location.md
@@ -21,14 +21,14 @@ GreptimeDB 的存储文件结构包括以下内容：
 ```
 
 - `cluster`：集群目录包含了内部数据，并按数据节点的 ID 组织数据。
-- `data`：data 目录下的文件存储 GreptimeDB 的时序数据。要定制这个路径，请参考[存储选项](../operations/configuration.md#storage-options)。
+- `data`：data 目录下的文件存储 GreptimeDB 的时序数据。要定制这个路径，请参考[存储选项](../operations/configuration.md#存储选项)。
 - `logs`：日志文件包含 GreptimeDB 中所有的操作日志。
 - `wal`：wal 目录包含了预写日志文件。
 - `index_intermediate`: 索引相关的临时文件目录。
 
 ## 云存储
 
-文件结构中的 `cluster` 和 `data` 目录可以存储在云存储中。请参考[存储选项](../operations/configuration.md#storage-options)了解更多细节。
+文件结构中的 `cluster` 和 `data` 目录可以存储在云存储中。请参考[存储选项](../operations/configuration.md#存储选项)了解更多细节。
 
 ## 多存储引擎支持
 

--- a/docs/v0.7/zh/user-guide/concepts/storage-location.md
+++ b/docs/v0.7/zh/user-guide/concepts/storage-location.md
@@ -21,14 +21,14 @@ GreptimeDB 的存储文件结构包括以下内容：
 ```
 
 - `cluster`：集群目录包含了内部数据，并按数据节点的 ID 组织数据。
-- `data`：data 目录下的文件存储 GreptimeDB 的时序数据。要定制这个路径，请参考 [Storage option](../operations/configuration.md#storage-option)。
+- `data`：data 目录下的文件存储 GreptimeDB 的时序数据。要定制这个路径，请参考 [Storage option](../operations/configuration.md#storage-options)。
 - `logs`：日志文件包含 GreptimeDB 中所有的操作日志。
 - `wal`：wal 目录包含了预写日志文件。
 - `index_intermediate`: 索引相关的临时文件目录。
 
 ## 云存储
 
-文件结构中的 `cluster` 和 `data` 目录可以存储在云存储中。请参考[存储选项](../operations/configuration.md#storage-option)了解更多细节。
+文件结构中的 `cluster` 和 `data` 目录可以存储在云存储中。请参考[存储选项](../operations/configuration.md#storage-options)了解更多细节。
 
 ## 多存储引擎支持
 


### PR DESCRIPTION
## What's Changed in this PR

Fixed the broken links in storage location doc.

## Checklist

- [x] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
