### PR TITLE
refactor: accept additional args for running `pnpm run docs:dev`

### DIFF
--- a/script/build.js
+++ b/script/build.js
@@ -4,7 +4,13 @@ import { execSync } from 'node:child_process'
   const files = fs.readdirSync('./docs')
   const versionMap = files.filter(file => file.match(/v\d\.\d/))
   for (let i = versionMap.length; i >= 0; i--) {
-    await execSync(`pnpm run docs:build`, {
+    // Retrieve command-line arguments, excluding the first two default arguments (Node.js path and script path).
+    const additionalArgs = process.argv.slice(2)
+    // Concatenate the command with additional arguments.
+    const command = `pnpm run docs:build ${additionalArgs.join(' ')}`;
+    console.log(`Running command: ${command}`)
+
+    await execSync(command, {
       env: {
         ...process.env,
         VERSION: versionMap[i],

--- a/script/dev.js
+++ b/script/dev.js
@@ -4,7 +4,13 @@ import { execSync } from 'node:child_process'
   const files = fs.readdirSync('./docs')
   const versionMap = files.filter(file => file.match(/v\d\.\d/))
   try {
-    await execSync(`pnpm run docs:dev`, {
+    // Retrieve command-line arguments, excluding the first two default arguments (Node.js path and script path).
+    const additionalArgs = process.argv.slice(2)
+    // Concatenate the command with additional arguments.
+    const command = `pnpm run docs:dev ${additionalArgs.join(' ')}`;
+    console.log(`Running command: ${command}`)
+
+    await execSync(command, {
       stdio: 'inherit',
       env: {
         ...process.env,


### PR DESCRIPTION
## What's Changed in this PR

Resolve #923.

We can run the following commands to add additional args:

```console
pnpm run dev --host 0.0.0.0 --port 5177
```

## Checklist

- [ ] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
