### PR TITLE
fix: incorrect format of migrate_region options

### DIFF
--- a/docs/nightly/en/user-guide/operations/region-migration.md
+++ b/docs/nightly/en/user-guide/operations/region-migration.md
@@ -51,10 +51,9 @@ The parameters of `migrate_region`：
 select migrate_region(region_id, from_peer_id, to_peer_id, replay_timeout);
 ```
 
-| Option           | Description                                                    | Required     |   |
-|------------------|----------------------------------------------------------------|--------------|---|
-| `region_id`      | The region id.                                                 | **Required** |   |
-| `from_peer_id`   | The peer id of the migration source(Datanode).                 | **Required** |   |
-| `to_peer_id`     | The peer id of the migration destination(Datanode).            | **Required** |   |
-| `replay_timeout` | The timeout(secs) of replay data. If the new Region fails to replay the data within the specified timeout, 
-the migration will fail, however the data in the old Region will not be lost.                             |   Optional   |   |
+| Option           | Description                                                                                                                                                                               | Required     |     |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | --- |
+| `region_id`      | The region id.                                                                                                                                                                            | **Required** |     |
+| `from_peer_id`   | The peer id of the migration source(Datanode).                                                                                                                                            | **Required** |     |
+| `to_peer_id`     | The peer id of the migration destination(Datanode).                                                                                                                                       | **Required** |     |
+| `replay_timeout` | The timeout(secs) of replay data. If the new Region fails to replay the data within the specified timeout,  the migration will fail, however the data in the old Region will not be lost. | Optional     |     |

--- a/docs/nightly/zh/user-guide/operations/region-migration.md
+++ b/docs/nightly/zh/user-guide/operations/region-migration.md
@@ -50,9 +50,9 @@ select migrate_region(4398046511104, 1, 2, 60);
 select migrate_region(region_id, from_peer_id, to_peer_id, replay_timeout);
 ```
 
-| Option           | Description                                                    | Required     |   |
-|------------------|----------------------------------------------------------------|--------------|---|
-| `region_id`      | Region Id                                                      | **Required** |   |
-| `from_peer_id`   | 迁移起始节点(Datanode) 的 peer id。                               | **Required** |   |
-| `to_peer_id`     | 迁移目标节点(Datanode) 的 peer id。                               | **Required** |   |
-| `replay_timeout` | 迁移时回放数据的超时时间（单位：秒）。如果新 Region 未能在指定时间内回放数据，迁移将失败，旧 Region 中的数据不会丢失。                               |   Optional   |   |
+| Option           | Description                                                                                                            | Required     |     |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------- | ------------ | --- |
+| `region_id`      | Region Id                                                                                                              | **Required** |     |
+| `from_peer_id`   | 迁移起始节点(Datanode) 的 peer id。                                                                                    | **Required** |     |
+| `to_peer_id`     | 迁移目标节点(Datanode) 的 peer id。                                                                                    | **Required** |     |
+| `replay_timeout` | 迁移时回放数据的超时时间（单位：秒）。如果新 Region 未能在指定时间内回放数据，迁移将失败，旧 Region 中的数据不会丢失。 | Optional     |     |

--- a/docs/v0.7/en/user-guide/operations/region-migration.md
+++ b/docs/v0.7/en/user-guide/operations/region-migration.md
@@ -51,10 +51,9 @@ The parameters of `migrate_region`：
 select migrate_region(region_id, from_peer_id, to_peer_id, replay_timeout);
 ```
 
-| Option           | Description                                                    | Required     |   |
-|------------------|----------------------------------------------------------------|--------------|---|
-| `region_id`      | The region id.                                                 | **Required** |   |
-| `from_peer_id`   | The peer id of the migration source(Datanode).                 | **Required** |   |
-| `to_peer_id`     | The peer id of the migration destination(Datanode).            | **Required** |   |
-| `replay_timeout` | The timeout(secs) of replay data. If the new Region fails to replay the data within the specified timeout, 
-the migration will fail, however the data in the old Region will not be lost.                             |   Optional   |   |
+| Option           | Description                                                                                                                                                                               | Required     |     |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | --- |
+| `region_id`      | The region id.                                                                                                                                                                            | **Required** |     |
+| `from_peer_id`   | The peer id of the migration source(Datanode).                                                                                                                                            | **Required** |     |
+| `to_peer_id`     | The peer id of the migration destination(Datanode).                                                                                                                                       | **Required** |     |
+| `replay_timeout` | The timeout(secs) of replay data. If the new Region fails to replay the data within the specified timeout,  the migration will fail, however the data in the old Region will not be lost. | Optional     |     |

--- a/docs/v0.7/zh/user-guide/operations/region-migration.md
+++ b/docs/v0.7/zh/user-guide/operations/region-migration.md
@@ -50,9 +50,9 @@ select migrate_region(4398046511104, 1, 2, 60);
 select migrate_region(region_id, from_peer_id, to_peer_id, replay_timeout);
 ```
 
-| Option           | Description                                                    | Required     |   |
-|------------------|----------------------------------------------------------------|--------------|---|
-| `region_id`      | Region Id                                                      | **Required** |   |
-| `from_peer_id`   | 迁移起始节点(Datanode) 的 peer id。                               | **Required** |   |
-| `to_peer_id`     | 迁移目标节点(Datanode) 的 peer id。                               | **Required** |   |
-| `replay_timeout` | 迁移时回放数据的超时时间（单位：秒）。如果新 Region 未能在指定时间内回放数据，迁移将失败，旧 Region 中的数据不会丢失。                               |   Optional   |   |
+| Option           | Description                                                                                                            | Required     |     |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------- | ------------ | --- |
+| `region_id`      | Region Id                                                                                                              | **Required** |     |
+| `from_peer_id`   | 迁移起始节点(Datanode) 的 peer id。                                                                                    | **Required** |     |
+| `to_peer_id`     | 迁移目标节点(Datanode) 的 peer id。                                                                                    | **Required** |     |
+| `replay_timeout` | 迁移时回放数据的超时时间（单位：秒）。如果新 Region 未能在指定时间内回放数据，迁移将失败，旧 Region 中的数据不会丢失。 | Optional     |     |


### PR DESCRIPTION
## What's Changed in this PR

Wrong version:
<img width="909" alt="image" src="https://github.com/GreptimeTeam/docs/assets/15380403/7324e7db-6a9d-4594-a09b-a2b94dae4707">


## Checklist

- [ ] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
