### PR TITLE
chore: remove opentsdb telnet in nightly doc

### DIFF
--- a/docs/nightly/en/getting-started/installation/greptimedb-standalone.md
+++ b/docs/nightly/en/getting-started/installation/greptimedb-standalone.md
@@ -47,8 +47,7 @@ greptime/greptimedb standalone start \
 --http-addr 0.0.0.0:4000 \
 --rpc-addr 0.0.0.0:4001 \
 --mysql-addr 0.0.0.0:4002 \
---postgres-addr 0.0.0.0:4003 \
---opentsdb-addr 0.0.0.0:4242
+--postgres-addr 0.0.0.0:4003
 ```
 
 The data will be stored in the `greptimedb/` directory in your current directory.
@@ -70,8 +69,7 @@ You can:
    --http-addr 0.0.0.0:4000 \
    --rpc-addr 0.0.0.0:4001 \
    --mysql-addr 0.0.0.0:4002 \
-   --postgres-addr 0.0.0.0:4003 \
-   --opentsdb-addr 0.0.0.0:4242
+   --postgres-addr 0.0.0.0:4003
    ```
 
 2. Upgrade the Docker version to v23.0.0 or higher;

--- a/docs/nightly/en/getting-started/quick-start/prerequisites.md
+++ b/docs/nightly/en/getting-started/quick-start/prerequisites.md
@@ -22,8 +22,7 @@ services:
       - 4001:4001
       - 4002:4002
       - 4003:4003
-      - 4242:4242
-    command: "standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003 --opentsdb-addr 0.0.0.0:4242"
+    command: "standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003"
     volumes:
       - ./greptimedb:/tmp/greptimedb
 

--- a/docs/nightly/en/getting-started/quick-start/prometheus.md
+++ b/docs/nightly/en/getting-started/quick-start/prometheus.md
@@ -47,8 +47,7 @@ services:
       - 4001:4001
       - 4002:4002
       - 4003:4003
-      - 4242:4242
-    command: "standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003 --opentsdb-addr 0.0.0.0:4242"
+    command: "standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003"
     volumes:
       - ./greptimedb:/tmp/greptimedb
 

--- a/docs/nightly/en/getting-started/quick-start/vector.md
+++ b/docs/nightly/en/getting-started/quick-start/vector.md
@@ -43,8 +43,7 @@ services:
       - 4001:4001
       - 4002:4002
       - 4003:4003
-      - 4242:4242
-    command: "standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003 --opentsdb-addr 0.0.0.0:4242"
+    command: "standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003"
     volumes:
       - ./greptimedb:/tmp/greptimedb
 

--- a/docs/nightly/en/user-guide/clients/opentsdb.md
+++ b/docs/nightly/en/user-guide/clients/opentsdb.md
@@ -1,25 +1,5 @@
 # OpenTSDB
 
-## Telnet
-
-:::tip NOTE
-At the moment, authentication of OpenTSDB protocol over TCP is not yet supported. If there is a authentication with GreptimeDB, please use [HTTP endpoints](#http-api).
-:::
-
-The GreptimeDB is listening on port `4242` by default to receive metrics via `telnet`. You can open
-your favorite terminal and type `telnet 127.0.0.1 4242` to connect to GreptimeDB.
-
-```shell
-~ % telnet 127.0.0.1 4242
-Trying 127.0.0.1...
-Connected to localhost.
-Escape character is '^]'.
-put sys.cpu.system 1667892080 3 host=web01 dc=hz
-quit
-Connection closed by foreign host.
-~ %
-```
-
 ## HTTP API
 
 GreptimeDB also supports OpenTSDB through HTTP API. For information on how to set up authentication, please refer to [HTTP API](./http-api.md).

--- a/docs/nightly/en/user-guide/operations/configuration.md
+++ b/docs/nightly/en/user-guide/operations/configuration.md
@@ -81,7 +81,6 @@ greptime frontend start --help
 - `--influxdb-enable`: Whether to enable InfluxDB protocol in HTTP API;
 - `--metasrv-addr <METASRV_ADDR>`: Metasrv address list;
 - `--mysql-addr <MYSQL_ADDR>`: MySQL server address;
-- `--opentsdb-addr <OPENTSDB_ADDR>`: OpenTSDB server address;
 - `--postgres-addr <POSTGRES_ADDR>`: Postgres server address;
 - `--tls-cert-path <TLS_CERT_PATH>`: The TLS public key file path;
 - `--tls-key-path <TLS_KEY_PATH>`: The TLS private key file path;
@@ -102,7 +101,6 @@ greptime standalone start --help
 - `--http-addr <HTTP_ADDR>`: HTTP server address;
 - `--influxdb-enable`: Whether to enable InfluxDB protocol in HTTP API;
 - `--mysql-addr <MYSQL_ADDR>`: MySQL server address;
-- `--opentsdb-addr <OPENTSDB_ADDR>`: OpenTSDB server address;
 - `--postgres-addr <POSTGRES_ADDR>`: Postgres server address;
 - `--rpc-addr <RPC_ADDR>`:  gRPC server address;
 
@@ -177,8 +175,6 @@ key_path = ""
 
 [opentsdb]
 enable = true
-addr = "127.0.0.1:4242"
-runtime_size = 2
 
 [influxdb]
 enable = true
@@ -206,9 +202,7 @@ The following table describes the options in detail:
 | influxdb   |                    |         | InfluxDB Protocol options                                                       |
 |            | enable             | Boolean | Whether to enable InfluxDB protocol in HTTP API, true by default                |
 | opentsdb   |                    |         | OpenTSDB Protocol options                                                       |
-|            | enable             | Boolean | Whether to enable OpenTSDB protocol, true by default                            |
-|            | addr               | String  | OpenTSDB telnet API server address, "127.0.0.1:4242" by default                 |
-|            | runtime_size       | Integer | The number of server worker threads, 2 by default                               |
+|            | enable             | Boolean | Whether to enable OpenTSDB protocol in HTTP API, true by default                |
 | prom_store |                    |         | Prometheus remote storage options                                               |
 |            | enable             | Boolean | Whether to enable Prometheus Remote Write and read in HTTP API, true by default |
 |            | with_metric_engine | Boolean | Whether to use the metric engine on Prometheus Remote Write, true by default    |

--- a/docs/nightly/en/user-guide/operations/remote-wal/quick-start.md
+++ b/docs/nightly/en/user-guide/operations/remote-wal/quick-start.md
@@ -59,8 +59,7 @@ docker run \
   --http-addr 0.0.0.0:4000 \
   --rpc-addr 0.0.0.0:4001 \
   --mysql-addr 0.0.0.0:4002 \
-  --postgres-addr 0.0.0.0:4003 \
-  --opentsdb-addr 0.0.0.0:4242
+  --postgres-addr 0.0.0.0:4003
 ```
 
 We use the [environment variables](/user-guide/operations/configuration#environment-variable) to specify the provider:

--- a/docs/nightly/en/user-guide/write-data/opentsdb.md
+++ b/docs/nightly/en/user-guide/write-data/opentsdb.md
@@ -1,42 +1,8 @@
 # OpenTSDB
 
-GreptimeDB supports ingesting OpenTSDB via Telnet or HTTP API.
+GreptimeDB supports ingesting OpenTSDB via HTTP API.
 
 ## Insert
-
-### Telnet
-
-GreptimeDB fully supports OpenTSDB's "put" command format:
-
-`put <metric> <timestamp> <value> <tagk1=tagv1[tagk2=tagv2...tagkN=tagvN]>`
-
-You can use `put`  to insert metrics:
-
-```shell
-~ % telnet 127.0.0.1 4242
-Trying 127.0.0.1...
-Connected to localhost.
-Escape character is '^]'.
-put sys.cpu.system 1667892080 3 host=web01 dc=hz
-put sys.cpu.system 1667892080 2 host=web02 dc=hz
-put sys.cpu.system 1667892080 2 host=web03 dc=hz
-put sys.cpu.system 1667892081 1 host=web01
-put sys.cpu.system 1667892081 4 host=web04 dc=sh
-put sys.cpu.system 1667892082 10 host=web10 dc=sh
-quit
-Connection closed by foreign host.
-~ %
-```
-
-GreptimeDB treats each metric as an individual table, and makes tags its columns.
-`greptime_timestamp` and `greptime_value` are two reserved columns, corresponding to timestamp and
-value in put command.
-
-GreptimeDB will automatically creates the metrics table after you put the metrics so you don't need
-to create the metrics table manually.
-
-> Note that only "put" command is supported, other commands such as "histogram" or "stats"
-> are not supported.
 
 ### HTTP API
 

--- a/docs/nightly/zh/getting-started/installation/greptimedb-standalone.md
+++ b/docs/nightly/zh/getting-started/installation/greptimedb-standalone.md
@@ -49,8 +49,7 @@ greptime/greptimedb standalone start \
 --http-addr 0.0.0.0:4000 \
 --rpc-addr 0.0.0.0:4001 \
 --mysql-addr 0.0.0.0:4002 \
---postgres-addr 0.0.0.0:4003 \
---opentsdb-addr 0.0.0.0:4242
+--postgres-addr 0.0.0.0:4003
 ```
 
 数据将会存储在当前目录下的 `greptimedb/` 目录中。
@@ -73,8 +72,7 @@ greptime/greptimedb standalone start \
    --http-addr 0.0.0.0:4000 \
    --rpc-addr 0.0.0.0:4001 \
    --mysql-addr 0.0.0.0:4002 \
-   --postgres-addr 0.0.0.0:4003 \
-   --opentsdb-addr 0.0.0.0:4242
+   --postgres-addr 0.0.0.0:4003
    ```
 
 2. 将 Docker 版本升级到 v23.0.0 或更高;

--- a/docs/nightly/zh/getting-started/quick-start/prerequisites.md
+++ b/docs/nightly/zh/getting-started/quick-start/prerequisites.md
@@ -22,8 +22,7 @@ services:
       - 4001:4001
       - 4002:4002
       - 4003:4003
-      - 4242:4242
-    command: "standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003 --opentsdb-addr 0.0.0.0:4242"
+    command: "standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003"
     volumes:
       - ./greptimedb:/tmp/greptimedb
 

--- a/docs/nightly/zh/getting-started/quick-start/prometheus.md
+++ b/docs/nightly/zh/getting-started/quick-start/prometheus.md
@@ -47,8 +47,7 @@ services:
       - 4001:4001
       - 4002:4002
       - 4003:4003
-      - 4242:4242
-    command: "standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003 --opentsdb-addr 0.0.0.0:4242"
+    command: "standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003"
     volumes:
       - ./greptimedb:/tmp/greptimedb
 

--- a/docs/nightly/zh/getting-started/quick-start/vector.md
+++ b/docs/nightly/zh/getting-started/quick-start/vector.md
@@ -42,8 +42,7 @@ services:
       - 4001:4001
       - 4002:4002
       - 4003:4003
-      - 4242:4242
-    command: "standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003 --opentsdb-addr 0.0.0.0:4242"
+    command: "standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003"
     volumes:
       - ./greptimedb:/tmp/greptimedb
 

--- a/docs/nightly/zh/user-guide/clients/opentsdb.md
+++ b/docs/nightly/zh/user-guide/clients/opentsdb.md
@@ -1,24 +1,5 @@
 # OpenTSDB
 
-## Telnet
-
-:::tip 注意
-当前，GreptimeDB 还不支持 TCP 协议的 OpenTSDB 鉴权。如果你的 GreptimeDB 配置了鉴权，请使用 [HTTP API](#http-api)。
-:::
-
-GreptimeDB 默认监听 `4242` 端口来接收 `telnet` 协议发来的数据。打开终端，输入 `telnet 127.0.0.1 4242` 连接到本地的 GreptimeDB。
-
-```shell
-~ % telnet 127.0.0.1 4242
-Trying 127.0.0.1...
-Connected to localhost.
-Escape character is '^]'.
-put sys.cpu.system 1667892080 3 host=web01 dc=hz
-quit
-Connection closed by foreign host.
-~ %
-```
-
 ## HTTP API
 
 GreptimeDB 同样支持通过 HTTP API 写入 OpenTSDB 协议数据。请参考 [HTTP API](./http-api.md) 获取鉴权相关的信息。

--- a/docs/nightly/zh/user-guide/operations/configuration.md
+++ b/docs/nightly/zh/user-guide/operations/configuration.md
@@ -81,7 +81,6 @@ greptime frontend start --help
 - `--influxdb-enable`:  是否启用 `influxdb` HTTP 接口，默认为 true。
 - `--metasrv-addr <METASRV_ADDR>`:   Metasrv 地址列表，用逗号隔开
 - `--mysql-addr <MYSQL_ADDR>`:  MySQL 服务地址
-- `--opentsdb-addr <OPENTSDB_ADDR>`:  OpenTSDB 服务地址
 - `--postgres-addr <POSTGRES_ADDR>`: Postgres 服务地址
 - `--tls-cert-path <TLS_CERT_PATH>`: TLS 公钥文件地址
 - `--tls-key-path <TLS_KEY_PATH>`: TLS 私钥文件地址
@@ -101,7 +100,6 @@ greptime standalone start --help
 - `--http-addr <HTTP_ADDR>`: HTTP 服务器地址
 - `--influxdb-enable`:  是否启用 `influxdb` HTTP 接口，默认为 true。
 - `--mysql-addr <MYSQL_ADDR>`:  MySQL 服务地址
-- `--opentsdb-addr <OPENTSDB_ADDR>`:  OpenTSDB 服务地址
 - `--postgres-addr <POSTGRES_ADDR>`: Postgres 服务地址
 - `--rpc-addr <RPC_ADDR>`:  gRPC 服务地址
 
@@ -174,8 +172,6 @@ key_path = ""
 
 [opentsdb]
 enable = true
-addr = "127.0.0.1:4242"
-runtime_size = 2
 
 [influxdb]
 enable = true
@@ -203,8 +199,6 @@ enable = true
 |            | enable             | 布尔值 | 是否在 HTTP API 中启用 InfluxDB 协议，默认为 true           |
 | opentsdb   |                    |        | OpenTSDB 协议选项                                           |
 |            | enable             | 布尔值 | 是否启用 OpenTSDB 协议，默认为 true                         |
-|            | addr               | 字符串 | OpenTSDB telnet API 服务器地址，默认为 "127.0.0.1:4242"     |
-|            | runtime_size       | 整数   | 服务器工作线程数量，默认为 2                                |
 | prom_store |                    |        | Prometheus 远程存储选项                                     |
 |            | enable             | 布尔值 | 是否在 HTTP API 中启用 Prometheus 远程读写，默认为 true     |
 |            | with_metric_engine | 布尔值 | 是否在 Prometheus 远程写入中使用 Metric Engine，默认为 true |

--- a/docs/nightly/zh/user-guide/operations/remote-wal/quick-start.md
+++ b/docs/nightly/zh/user-guide/operations/remote-wal/quick-start.md
@@ -60,8 +60,7 @@ docker run \
   --http-addr 0.0.0.0:4000 \
   --rpc-addr 0.0.0.0:4001 \
   --mysql-addr 0.0.0.0:4002 \
-  --postgres-addr 0.0.0.0:4003 \
-  --opentsdb-addr 0.0.0.0:4242
+  --postgres-addr 0.0.0.0:4003
 ```
 
 

--- a/docs/nightly/zh/user-guide/write-data/opentsdb.md
+++ b/docs/nightly/zh/user-guide/write-data/opentsdb.md
@@ -1,40 +1,8 @@
 # OpenTSDB
 
-GreptimeDB支持通过 Telnet 或 HTTP API 使用 OpenTSDB 协议。
+GreptimeDB支持通过 HTTP API 使用 OpenTSDB 协议。
 
 ## 写入新数据
-
-### Telnet
-
-`GreptimeDB` 完全支持 `OpenTSDB` 的 `put` 命令格式：
-
-`put <metric> <timestamp> <value> <tagk1=tagv1[tagk2=tagv2...tagkN=tagvN]>`
-
-你可以使用 `put` 来写入新数据：
-
-```shell
-~ % telnet 127.0.0.1 4242
-Trying 127.0.0.1...
-Connected to localhost.
-Escape character is '^]'.
-put sys.cpu.system 1667892080 3 host=web01 dc=hz
-put sys.cpu.system 1667892080 2 host=web02 dc=hz
-put sys.cpu.system 1667892080 2 host=web03 dc=hz
-put sys.cpu.system 1667892081 1 host=web01
-put sys.cpu.system 1667892081 4 host=web04 dc=sh
-put sys.cpu.system 1667892082 10 host=web10 dc=sh
-quit
-Connection closed by foreign host.
-~ %
-```
-
-GreptimeDB将每个指标视为单独的表，并将标签作为其列。`greptime_timestamp` 和 `greptime_value` 是两个保留列，对应于 `put` 命令中的时间戳和值。
-
-GreptimeDB 将在您放置指标后自动创建指标表，因此您无需手动创建指标表。
-
-:::tip 注意
-只支持 `put` 命令，其他命令如 `histogram` 或 `stats` 不被支持。
-:::
 
 ### HTTP API
 


### PR DESCRIPTION
## What's Changed in this PR

This pr mainly removes the OpenTSDB TCP/Telnet related docs.

wait for https://github.com/GreptimeTeam/greptimedb/pull/3828 to be merged first

closes #926 

## Checklist

- [ ] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
