### PR TITLE
docs: add note about using "detached" mode to start greptimedb docker…

### DIFF
--- a/docs/nightly/en/db-cloud-shared/quick-start/prometheus.md
+++ b/docs/nightly/en/db-cloud-shared/quick-start/prometheus.md
@@ -18,3 +18,8 @@ Spin up a Docker container to write sample data to your database:
 ```shell
 docker run --rm -e GREPTIME_URL='https://<host>/v1/prometheus/write?db=<dbname>' -e GREPTIME_USERNAME='<username>' -e GREPTIME_PASSWORD='<password>' --name greptime-node-exporter greptime/node-exporter
 ```
+
+:::tip NOTE
+To avoid accidently exit the Docker container, you may want to run it in the "detached" mode: add the `-d` flag to
+the `docker run` command.
+:::

--- a/docs/nightly/en/getting-started/installation/greptimedb-standalone.md
+++ b/docs/nightly/en/getting-started/installation/greptimedb-standalone.md
@@ -50,6 +50,11 @@ greptime/greptimedb:<%greptimedb-version%> standalone start \
 --postgres-addr 0.0.0.0:4003
 ```
 
+:::tip NOTE
+To avoid accidently exit the Docker container, you may want to run it in the "detached" mode: add the `-d` flag to
+the `docker run` command.
+:::
+
 The data will be stored in the `greptimedb/` directory in your current directory.
 
 If you want to use another version of GreptimeDB's image, you can download it from our [GreptimeDB Dockerhub](https://hub.docker.com/r/greptime/greptimedb). In particular, we support GreptimeDB based on CentOS, and you can try image `greptime/greptimedb-centos`.

--- a/docs/nightly/en/user-guide/operations/monitoring.md
+++ b/docs/nightly/en/user-guide/operations/monitoring.md
@@ -37,6 +37,11 @@ docker run \
   prom/prometheus
 ```
 
+:::tip NOTE
+To avoid accidently exit the Docker container, you may want to run it in the "detached" mode: add the `-d` flag to
+the `docker run` command.
+:::
+
 ## Save metrics to GreptimeDB itself
 
 You can also save metrics to GreptimeDB itself for convenient querying and analysis using SQL statements.

--- a/docs/nightly/en/user-guide/operations/remote-wal/quick-start.md
+++ b/docs/nightly/en/user-guide/operations/remote-wal/quick-start.md
@@ -41,6 +41,11 @@ docker run \
   bitnami/kafka:3.6.0
 ```
 
+:::tip NOTE
+To avoid accidently exit the Docker container, you may want to run it in the "detached" mode: add the `-d` flag to
+the `docker run` command.
+:::
+
 The data will be stored in `$(pwd)/kafka-data`.
 
 ### Step 3: Start the GreptimeDB with Remote WAL Configurations
@@ -61,6 +66,11 @@ docker run \
   --mysql-addr 0.0.0.0:4002 \
   --postgres-addr 0.0.0.0:4003
 ```
+
+:::tip NOTE
+To avoid accidently exit the Docker container, you may want to run it in the "detached" mode: add the `-d` flag to
+the `docker run` command.
+:::
 
 We use the [environment variables](/user-guide/operations/configuration#environment-variable) to specify the provider:
 

--- a/docs/nightly/zh/db-cloud-shared/quick-start/prometheus.md
+++ b/docs/nightly/zh/db-cloud-shared/quick-start/prometheus.md
@@ -18,3 +18,7 @@ remote_write:
 ```shell
 docker run --rm -e GREPTIME_URL='https://<host>/v1/prometheus/write?db=<dbname>' -e GREPTIME_USERNAME='<username>' -e GREPTIME_PASSWORD='<password>' --name greptime-node-exporter greptime/node-exporter
 ```
+
+:::tip NOTE
+为了防止不小心退出 Docker 容器，你可能想以 “detached” 模式运行它：在 `docker run` 命令中添加 `-d` 参数即可。
+:::

--- a/docs/nightly/zh/getting-started/installation/greptimedb-standalone.md
+++ b/docs/nightly/zh/getting-started/installation/greptimedb-standalone.md
@@ -52,6 +52,10 @@ greptime/greptimedb:<%greptimedb-version%> standalone start \
 --postgres-addr 0.0.0.0:4003
 ```
 
+:::tip NOTE
+为了防止不小心退出 Docker 容器，你可能想以 “detached” 模式运行它：在 `docker run` 命令中添加 `-d` 参数即可。
+:::
+
 数据将会存储在当前目录下的 `greptimedb/` 目录中。
 
 如果你想要使用另一个版本的 GreptimeDB 镜像，可以从我们的 [GreptimeDB Dockerhub](https://hub.docker.com/r/greptime/greptimedb) 下载。

--- a/docs/nightly/zh/user-guide/operations/monitoring.md
+++ b/docs/nightly/zh/user-guide/operations/monitoring.md
@@ -36,6 +36,10 @@ docker run \
   prom/prometheus
 ```
 
+:::tip NOTE
+为了防止不小心退出 Docker 容器，你可能想以 “detached” 模式运行它：在 `docker run` 命令中添加 `-d` 参数即可。
+:::
+
 ## 将指标保存到 GreptimeDB 自身
 
 你还可以将指标保存到 GreptimeDB 本身，以便于使用 SQL 语句进行查询和分析。

--- a/docs/nightly/zh/user-guide/operations/remote-wal/quick-start.md
+++ b/docs/nightly/zh/user-guide/operations/remote-wal/quick-start.md
@@ -42,6 +42,10 @@ docker run \
   bitnami/kafka:3.6.0
 ```
 
+:::tip NOTE
+为了防止不小心退出 Docker 容器，你可能想以 “detached” 模式运行它：在 `docker run` 命令中添加 `-d` 参数即可。
+:::
+
 数据将保存在 `$(pwd)/kafka-data`.
 
 ### Step 3: 用 Remote WAL 模式启动 standalone 模式 GreptimeDB
@@ -63,6 +67,9 @@ docker run \
   --postgres-addr 0.0.0.0:4003
 ```
 
+:::tip NOTE
+为了防止不小心退出 Docker 容器，你可能想以 “detached” 模式运行它：在 `docker run` 命令中添加 `-d` 参数即可。
+:::
 
 我们使用环境变量来指定 provider：
 

--- a/docs/v0.8/en/db-cloud-shared/quick-start/prometheus.md
+++ b/docs/v0.8/en/db-cloud-shared/quick-start/prometheus.md
@@ -18,3 +18,8 @@ Spin up a Docker container to write sample data to your database:
 ```shell
 docker run --rm -e GREPTIME_URL='https://<host>/v1/prometheus/write?db=<dbname>' -e GREPTIME_USERNAME='<username>' -e GREPTIME_PASSWORD='<password>' --name greptime-node-exporter greptime/node-exporter
 ```
+
+:::tip NOTE
+To avoid accidently exit the Docker container, you may want to run it in the "detached" mode: add the `-d` flag to
+the `docker run` command.
+:::

--- a/docs/v0.8/en/getting-started/installation/greptimedb-standalone.md
+++ b/docs/v0.8/en/getting-started/installation/greptimedb-standalone.md
@@ -50,6 +50,11 @@ greptime/greptimedb:<%greptimedb-version%> standalone start \
 --postgres-addr 0.0.0.0:4003
 ```
 
+:::tip NOTE
+To avoid accidently exit the Docker container, you may want to run it in the "detached" mode: add the `-d` flag to
+the `docker run` command.
+:::
+
 The data will be stored in the `greptimedb/` directory in your current directory.
 
 If you want to use another version of GreptimeDB's image, you can download it from our [GreptimeDB Dockerhub](https://hub.docker.com/r/greptime/greptimedb). In particular, we support GreptimeDB based on CentOS, and you can try image `greptime/greptimedb-centos`.

--- a/docs/v0.8/en/user-guide/operations/monitoring.md
+++ b/docs/v0.8/en/user-guide/operations/monitoring.md
@@ -37,6 +37,11 @@ docker run \
   prom/prometheus
 ```
 
+:::tip NOTE
+To avoid accidently exit the Docker container, you may want to run it in the "detached" mode: add the `-d` flag to
+the `docker run` command.
+:::
+
 ## Save metrics to GreptimeDB itself
 
 You can also save metrics to GreptimeDB itself for convenient querying and analysis using SQL statements.

--- a/docs/v0.8/en/user-guide/operations/remote-wal/quick-start.md
+++ b/docs/v0.8/en/user-guide/operations/remote-wal/quick-start.md
@@ -41,6 +41,11 @@ docker run \
   bitnami/kafka:3.6.0
 ```
 
+:::tip NOTE
+To avoid accidently exit the Docker container, you may want to run it in the "detached" mode: add the `-d` flag to
+the `docker run` command.
+:::
+
 The data will be stored in `$(pwd)/kafka-data`.
 
 ### Step 3: Start the GreptimeDB with Remote WAL Configurations
@@ -61,6 +66,11 @@ docker run \
   --mysql-addr 0.0.0.0:4002 \
   --postgres-addr 0.0.0.0:4003
 ```
+
+:::tip NOTE
+To avoid accidently exit the Docker container, you may want to run it in the "detached" mode: add the `-d` flag to
+the `docker run` command.
+:::
 
 We use the [environment variables](/user-guide/operations/configuration#environment-variable) to specify the provider:
 

--- a/docs/v0.8/zh/db-cloud-shared/quick-start/prometheus.md
+++ b/docs/v0.8/zh/db-cloud-shared/quick-start/prometheus.md
@@ -18,3 +18,7 @@ remote_write:
 ```shell
 docker run --rm -e GREPTIME_URL='https://<host>/v1/prometheus/write?db=<dbname>' -e GREPTIME_USERNAME='<username>' -e GREPTIME_PASSWORD='<password>' --name greptime-node-exporter greptime/node-exporter
 ```
+
+:::tip NOTE
+为了防止不小心退出 Docker 容器，你可能想以 “detached” 模式运行它：在 `docker run` 命令中添加 `-d` 参数即可。
+:::

--- a/docs/v0.8/zh/getting-started/installation/greptimedb-standalone.md
+++ b/docs/v0.8/zh/getting-started/installation/greptimedb-standalone.md
@@ -52,6 +52,10 @@ greptime/greptimedb:<%greptimedb-version%> standalone start \
 --postgres-addr 0.0.0.0:4003
 ```
 
+:::tip NOTE
+为了防止不小心退出 Docker 容器，你可能想以 “detached” 模式运行它：在 `docker run` 命令中添加 `-d` 参数即可。
+:::
+
 数据将会存储在当前目录下的 `greptimedb/` 目录中。
 
 如果你想要使用另一个版本的 GreptimeDB 镜像，可以从我们的 [GreptimeDB Dockerhub](https://hub.docker.com/r/greptime/greptimedb) 下载。

--- a/docs/v0.8/zh/user-guide/operations/monitoring.md
+++ b/docs/v0.8/zh/user-guide/operations/monitoring.md
@@ -36,6 +36,10 @@ docker run \
   prom/prometheus
 ```
 
+:::tip NOTE
+为了防止不小心退出 Docker 容器，你可能想以 “detached” 模式运行它：在 `docker run` 命令中添加 `-d` 参数即可。
+:::
+
 ## 将指标保存到 GreptimeDB 自身
 
 你还可以将指标保存到 GreptimeDB 本身，以便于使用 SQL 语句进行查询和分析。

--- a/docs/v0.8/zh/user-guide/operations/remote-wal/quick-start.md
+++ b/docs/v0.8/zh/user-guide/operations/remote-wal/quick-start.md
@@ -42,6 +42,10 @@ docker run \
   bitnami/kafka:3.6.0
 ```
 
+:::tip NOTE
+为了防止不小心退出 Docker 容器，你可能想以 “detached” 模式运行它：在 `docker run` 命令中添加 `-d` 参数即可。
+:::
+
 数据将保存在 `$(pwd)/kafka-data`.
 
 ### Step 3: 用 Remote WAL 模式启动 standalone 模式 GreptimeDB
@@ -63,6 +67,9 @@ docker run \
   --postgres-addr 0.0.0.0:4003
 ```
 
+:::tip NOTE
+为了防止不小心退出 Docker 容器，你可能想以 “detached” 模式运行它：在 `docker run` 命令中添加 `-d` 参数即可。
+:::
 
 我们使用环境变量来指定 provider：
 


### PR DESCRIPTION
…, otherwise user could be too easy to copy our "docker run" command and run it in the ssh session, only to find their greptimedb is exited for "no reason" after their ssh session got expired

## What's Changed in this PR

as the long title

## Checklist

- [ ] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
