### PR TITLE
fix: Chinese summary doesn't include flownode

### DIFF
--- a/docs/nightly/zh/summary-i18n.yml
+++ b/docs/nightly/zh/summary-i18n.yml
@@ -24,6 +24,7 @@ Integrations: 集成
 Usage-&-Billing: 用量及费用
 Frontend: Frontend
 Datanode: Datanode
+Flownode: Flownode
 Metasrv: Metasrv
 Reference: Reference
 Admin: 管理

--- a/docs/v0.8/zh/summary-i18n.yml
+++ b/docs/v0.8/zh/summary-i18n.yml
@@ -24,6 +24,7 @@ Integrations: 集成
 Usage-&-Billing: 用量及费用
 Frontend: Frontend
 Datanode: Datanode
+Flownode: Flownode
 Metasrv: Metasrv
 Reference: Reference
 Admin: 管理


### PR DESCRIPTION
## What's Changed in this PR


<img width="724" alt="image" src="https://github.com/GreptimeTeam/docs/assets/15380403/1a20d0e8-bd14-4e35-af83-0c09e53fcadd">

Flownode's content is present but the summary seems incorrect.

## Checklist

- [ ] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
