### PR TITLE
fix: influxdb line protocol curl comand

### DIFF
--- a/docs/nightly/en/user-guide/clients/influxdb-line.md
+++ b/docs/nightly/en/user-guide/clients/influxdb-line.md
@@ -9,7 +9,7 @@ GreptimeDB is compatible with InfluxDB's line protocol authentication format, bo
 InfluxDB's V2 protocol uses a format much like HTTP's standard basic authentication scheme. We can write data easily through InfluxDB's line protocol.
 
 ```shell
-❯ curl 'http://localhost:4000/v1/influxdb/api/v2/write?db=public' \
+curl 'http://localhost:4000/v1/influxdb/api/v2/write?db=public' \
     -H 'authorization: token greptime_user:greptime_pwd' \
     -d 'monitor,host=host1 cpu=1.2 1664370459457010101'
 ```
@@ -21,7 +21,7 @@ Note: replace `greptime_user(username)`, `greptime_pwd(password)` with your conf
 GreptimeDB also supports InfluxDB's V1 authentication format. Add `u` for user and `p` for password to the HTTP query string as shown below:
 
 ```shell
-❯ curl 'http://localhost:4000/v1/influxdb/write?db=public&u=greptime_user&p=greptime_pwd' \
+curl 'http://localhost:4000/v1/influxdb/write?db=public&u=greptime_user&p=greptime_pwd' \
     -d 'monitor,host=host2 cpu=1.2 1678679359062504960'
 ```
 

--- a/docs/nightly/zh/user-guide/clients/influxdb-line.md
+++ b/docs/nightly/zh/user-guide/clients/influxdb-line.md
@@ -9,7 +9,7 @@ Greptime 完全兼容 InfluxDB line protocol 的鉴权格式，包括 v1 和 v2�
 InfluxDB 的 v2 协议使用的格式很像 HTTP 的标准基本鉴权方案，我们可以通过 InfluxDB 的 line protocol 轻松写入数据。在下方的示例代码中，请注意将 `greptime_user(username)`, `greptime_pwd(password)` 替换为用户自己配置的用户名和密码。
 
 ```shell
-❯ curl 'http://localhost:4000/v1/influxdb/api/v2/write?db=public' \
+curl 'http://localhost:4000/v1/influxdb/api/v2/write?db=public' \
     -H 'authorization: token greptime_user:greptime_pwd' \
     -d 'monitor,host=host1 cpu=1.2 1664370459457010101'
 ```
@@ -19,7 +19,7 @@ InfluxDB 的 v2 协议使用的格式很像 HTTP 的标准基本鉴权方案，�
 GreptimeDB 同样支持 InfluxDB 的 v1 鉴权格式。在 HTTP 查询字符串中添加 `u` 代表用户，`p` 代表密码，请注意将 `greptime_user(username)`, `greptime_pwd(password)` 替换为用户自己配置的用户名和密码，如下所示：
 
 ```shell
-❯ curl 'http://localhost:4000/v1/influxdb/write?db=public&u=greptime_user&p=greptime_pwd' \
+curl 'http://localhost:4000/v1/influxdb/write?db=public&u=greptime_user&p=greptime_pwd' \
     -d 'monitor,host=host2 cpu=1.2 1678679359062504960'
 ```
 

--- a/docs/v0.8/en/user-guide/clients/influxdb-line.md
+++ b/docs/v0.8/en/user-guide/clients/influxdb-line.md
@@ -9,7 +9,7 @@ GreptimeDB is compatible with InfluxDB's line protocol authentication format, bo
 InfluxDB's V2 protocol uses a format much like HTTP's standard basic authentication scheme. We can write data easily through InfluxDB's line protocol.
 
 ```shell
-❯ curl 'http://localhost:4000/v1/influxdb/api/v2/write?db=public' \
+curl 'http://localhost:4000/v1/influxdb/api/v2/write?db=public' \
     -H 'authorization: token greptime_user:greptime_pwd' \
     -d 'monitor,host=host1 cpu=1.2 1664370459457010101'
 ```
@@ -21,7 +21,7 @@ Note: replace `greptime_user(username)`, `greptime_pwd(password)` with your conf
 GreptimeDB also supports InfluxDB's V1 authentication format. Add `u` for user and `p` for password to the HTTP query string as shown below:
 
 ```shell
-❯ curl 'http://localhost:4000/v1/influxdb/write?db=public&u=greptime_user&p=greptime_pwd' \
+curl 'http://localhost:4000/v1/influxdb/write?db=public&u=greptime_user&p=greptime_pwd' \
     -d 'monitor,host=host2 cpu=1.2 1678679359062504960'
 ```
 

--- a/docs/v0.8/zh/user-guide/clients/influxdb-line.md
+++ b/docs/v0.8/zh/user-guide/clients/influxdb-line.md
@@ -9,7 +9,7 @@ Greptime 完全兼容 InfluxDB line protocol 的鉴权格式，包括 v1 和 v2�
 InfluxDB 的 v2 协议使用的格式很像 HTTP 的标准基本鉴权方案，我们可以通过 InfluxDB 的 line protocol 轻松写入数据。在下方的示例代码中，请注意将 `greptime_user(username)`, `greptime_pwd(password)` 替换为用户自己配置的用户名和密码。
 
 ```shell
-❯ curl 'http://localhost:4000/v1/influxdb/api/v2/write?db=public' \
+curl 'http://localhost:4000/v1/influxdb/api/v2/write?db=public' \
     -H 'authorization: token greptime_user:greptime_pwd' \
     -d 'monitor,host=host1 cpu=1.2 1664370459457010101'
 ```
@@ -19,7 +19,7 @@ InfluxDB 的 v2 协议使用的格式很像 HTTP 的标准基本鉴权方案，�
 GreptimeDB 同样支持 InfluxDB 的 v1 鉴权格式。在 HTTP 查询字符串中添加 `u` 代表用户，`p` 代表密码，请注意将 `greptime_user(username)`, `greptime_pwd(password)` 替换为用户自己配置的用户名和密码，如下所示：
 
 ```shell
-❯ curl 'http://localhost:4000/v1/influxdb/write?db=public&u=greptime_user&p=greptime_pwd' \
+curl 'http://localhost:4000/v1/influxdb/write?db=public&u=greptime_user&p=greptime_pwd' \
     -d 'monitor,host=host2 cpu=1.2 1678679359062504960'
 ```
 


### PR DESCRIPTION
## What's Changed in this PR

Removed an invalid character before `curl` command in InfluxDB line protocol documents.

## Checklist

- [ ] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
