### PR TITLE
docs: mention default bind address

### DIFF
--- a/docs/nightly/en/getting-started/installation/greptimedb-standalone.md
+++ b/docs/nightly/en/getting-started/installation/greptimedb-standalone.md
@@ -24,12 +24,14 @@ You can run GreptimeDB in the standalone mode:
 ```
 
 :::tip NOTE
-GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections from other addresses, you can start with the following parameters.
+GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections from all addresses, you can start with the following parameters.
 ```shell
 ./greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
 ```
 
 You can also refer to the [Configuration](../../user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
+
+If the computer running GreptimeDB is directly exposed to the internet, binding to `0.0.0.0` is dangerous and will expose the instance to everybody on the internet.
 :::
 
 
@@ -46,12 +48,14 @@ To run GreptimeDB in standalone mode, open a terminal (like Powershell) at the d
 ```
 
 :::tip NOTE
-GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections from other addresses, you can start with the following parameters.
+GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections from all addresses, you can start with the following parameters.
 ```shell
 .\greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
 ```
 
 You can also refer to the [Configuration](../../user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
+
+If the computer running GreptimeDB is directly exposed to the internet, binding to `0.0.0.0` is dangerous and will expose the instance to everybody on the internet.
 :::
 
 

--- a/docs/nightly/en/getting-started/installation/greptimedb-standalone.md
+++ b/docs/nightly/en/getting-started/installation/greptimedb-standalone.md
@@ -48,7 +48,7 @@ To run GreptimeDB in standalone mode, open a terminal (like Powershell) at the d
 :::tip NOTE
 GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections from other addresses, you can start with the following parameters.
 ```shell
-./greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
+.\greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
 ```
 
 You can also refer to the [Configuration](../../user-guide/operations/configuration.md) document to modify the bind address in the configuration file.

--- a/docs/nightly/en/getting-started/installation/greptimedb-standalone.md
+++ b/docs/nightly/en/getting-started/installation/greptimedb-standalone.md
@@ -23,18 +23,6 @@ You can run GreptimeDB in the standalone mode:
 ./greptime standalone start
 ```
 
-:::tip NOTE
-GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections from all addresses, you can start with the following parameters.
-```shell
-./greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
-```
-
-You can also refer to the [Configuration](/user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
-
-If the computer running GreptimeDB is directly exposed to the internet, binding to `0.0.0.0` is dangerous and will expose the instance to everybody on the internet.
-:::
-
-
 ### Windows
 
 If you have WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about)) enabled, you can lunch a latest Ubuntu and run GreptimeDB like above!
@@ -46,18 +34,6 @@ To run GreptimeDB in standalone mode, open a terminal (like Powershell) at the d
 ```shell
 .\greptime standalone start
 ```
-
-:::tip NOTE
-GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections from all addresses, you can start with the following parameters.
-```shell
-.\greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
-```
-
-You can also refer to the [Configuration](/user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
-
-If the computer running GreptimeDB is directly exposed to the internet, binding to `0.0.0.0` is dangerous and will expose the instance to everybody on the internet.
-:::
-
 
 ## Docker
 
@@ -103,6 +79,38 @@ You can:
 
 2. Upgrade the Docker version to v23.0.0 or higher;
    :::
+
+## Binding address
+
+GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections from other addresses, you can start with the following parameters.
+
+:::danger Warning
+
+If the computer running GreptimeDB is directly exposed to the internet, binding to `0.0.0.0` is dangerous and will expose the instance to everybody on the internet.
+
+:::code-group
+
+```shell [Binary]
+./greptime standalone start \
+   --http-addr 0.0.0.0:4000 \
+   --rpc-addr 0.0.0.0:4001 \
+   --mysql-addr 0.0.0.0:4002 \
+   --postgres-addr 0.0.0.0:4003
+```
+
+```shell [Docker]
+docker run -p 0.0.0.0:4000-4003:4000-4003 \
+-v "$(pwd)/greptimedb:/tmp/greptimedb" \
+--name greptime --rm \
+greptime/greptimedb:<%greptimedb-version%> standalone start \
+--http-addr 0.0.0.0:4000 \
+--rpc-addr 0.0.0.0:4001 \
+--mysql-addr 0.0.0.0:4002 \
+--postgres-addr 0.0.0.0:4003
+```
+:::
+
+You can also refer to the [Configuration](/user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
 
 ## Next Steps
 

--- a/docs/nightly/en/getting-started/installation/greptimedb-standalone.md
+++ b/docs/nightly/en/getting-started/installation/greptimedb-standalone.md
@@ -29,7 +29,7 @@ GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections fr
 ./greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
 ```
 
-You can also refer to the [Configuration](../../user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
+You can also refer to the [Configuration](/user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
 
 If the computer running GreptimeDB is directly exposed to the internet, binding to `0.0.0.0` is dangerous and will expose the instance to everybody on the internet.
 :::
@@ -53,7 +53,7 @@ GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections fr
 .\greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
 ```
 
-You can also refer to the [Configuration](../../user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
+You can also refer to the [Configuration](/user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
 
 If the computer running GreptimeDB is directly exposed to the internet, binding to `0.0.0.0` is dangerous and will expose the instance to everybody on the internet.
 :::

--- a/docs/nightly/en/getting-started/installation/greptimedb-standalone.md
+++ b/docs/nightly/en/getting-started/installation/greptimedb-standalone.md
@@ -23,6 +23,16 @@ You can run GreptimeDB in the standalone mode:
 ./greptime standalone start
 ```
 
+:::tip NOTE
+GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections from other addresses, you can start with the following parameters.
+```shell
+./greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
+```
+
+You can also refer to the [Configuration](../../user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
+:::
+
+
 ### Windows
 
 If you have WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about)) enabled, you can lunch a latest Ubuntu and run GreptimeDB like above!
@@ -34,6 +44,16 @@ To run GreptimeDB in standalone mode, open a terminal (like Powershell) at the d
 ```shell
 .\greptime standalone start
 ```
+
+:::tip NOTE
+GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections from other addresses, you can start with the following parameters.
+```shell
+./greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
+```
+
+You can also refer to the [Configuration](../../user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
+:::
+
 
 ## Docker
 

--- a/docs/nightly/en/getting-started/installation/greptimedb-standalone.md
+++ b/docs/nightly/en/getting-started/installation/greptimedb-standalone.md
@@ -64,7 +64,7 @@ If the computer running GreptimeDB is directly exposed to the internet, binding 
 Make sure the [Docker](https://www.docker.com/) is already installed. If not, you can follow the official [documents](https://www.docker.com/get-started/) to install Docker.
 
 ```shell
-docker run -p 4000-4003:4000-4003 \
+docker run -p 127.0.0.1:4000-4003:4000-4003 \
 -v "$(pwd)/greptimedb:/tmp/greptimedb" \
 --name greptime --rm \
 greptime/greptimedb:<%greptimedb-version%> standalone start \

--- a/docs/nightly/zh/getting-started/installation/greptimedb-standalone.md
+++ b/docs/nightly/zh/getting-started/installation/greptimedb-standalone.md
@@ -25,18 +25,6 @@ curl -fsSL \
 ./greptime standalone start
 ```
 
-:::tip 注意事项
-GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自所有地址的连接，可以通过以下参数启动。
-```shell
-./greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
-```
-
-你也可以参考[配置 GreptimeDB](/user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
-
-如果运行 GreptimeDB 的计算机直接向互联网暴露服务，那么绑定 `0.0.0.0` 会十分危险，因为这将数据库实例暴露给互联网上的所有人。
-:::
-
-
 ### Windows
 
 若您的 Windows 系统已开启 WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about))，您可以直接打开一个最新的 Ubuntu 接着如上所示运行 GreptimeDB ！
@@ -48,19 +36,6 @@ GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自
 ```shell
 .\greptime standalone start
 ```
-
-
-:::tip 注意事项
-GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自所有地址的连接，可以通过以下参数启动。
-```shell
-.\greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
-```
-
-你也可以参考[配置 GreptimeDB](/user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
-
-如果运行 GreptimeDB 的计算机直接向互联网暴露服务，那么绑定 `0.0.0.0` 会十分危险，因为这将数据库实例暴露给互联网上的所有人。
-:::
-
 
 ### Docker
 
@@ -106,6 +81,39 @@ greptime/greptimedb:<%greptimedb-version%> standalone start \
 
 2. 将 Docker 版本升级到 v23.0.0 或更高;
    :::
+
+## 绑定地址
+
+GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自所有地址的连接，可以通过以下参数启动。
+
+:::danger 危险操作
+
+如果运行 GreptimeDB 的计算机直接向互联网暴露服务，那么绑定 `0.0.0.0` 会十分危险，因为这将数据库实例暴露给互联网上的所有人。
+
+:::code-group
+
+```shell [二进制]
+./greptime standalone start \
+   --http-addr 0.0.0.0:4000 \
+   --rpc-addr 0.0.0.0:4001 \
+   --mysql-addr 0.0.0.0:4002 \
+   --postgres-addr 0.0.0.0:4003
+```
+
+```shell [Docker]
+docker run -p 0.0.0.0:4000-4003:4000-4003 \
+-v "$(pwd)/greptimedb:/tmp/greptimedb" \
+--name greptime --rm \
+greptime/greptimedb:<%greptimedb-version%> standalone start \
+--http-addr 0.0.0.0:4000 \
+--rpc-addr 0.0.0.0:4001 \
+--mysql-addr 0.0.0.0:4002 \
+--postgres-addr 0.0.0.0:4003
+```
+
+:::
+
+你也可以参考[配置 GreptimeDB](/user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
 
 ## 下一步
 

--- a/docs/nightly/zh/getting-started/installation/greptimedb-standalone.md
+++ b/docs/nightly/zh/getting-started/installation/greptimedb-standalone.md
@@ -67,7 +67,7 @@ GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自
 请确保已经安装了 [Docker](https://www.docker.com/)。如果还没有安装，可以参考 Docker 官方的[文档](https://www.docker.com/get-started/)进行安装。
 
 ```shell
-docker run -p 4000-4003:4000-4003 \
+docker run -p 127.0.0.1:4000-4003:4000-4003 \
 -v "$(pwd)/greptimedb:/tmp/greptimedb" \
 --name greptime --rm \
 greptime/greptimedb:<%greptimedb-version%> standalone start \

--- a/docs/nightly/zh/getting-started/installation/greptimedb-standalone.md
+++ b/docs/nightly/zh/getting-started/installation/greptimedb-standalone.md
@@ -25,6 +25,16 @@ curl -fsSL \
 ./greptime standalone start
 ```
 
+:::tip 注意事项
+GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自其他地址的连接，可以通过以下参数启动。
+```shell
+./greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
+```
+
+你也可以参考[配置 GreptimeDB](../../user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
+:::
+
+
 ### Windows
 
 若您的 Windows 系统已开启 WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about))，您可以直接打开一个最新的 Ubuntu 接着如上所示运行 GreptimeDB ！
@@ -36,6 +46,17 @@ curl -fsSL \
 ```shell
 .\greptime standalone start
 ```
+
+
+:::tip 注意事项
+GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自其他地址的连接，可以通过以下参数启动。
+```shell
+./greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
+```
+
+你也可以参考[配置 GreptimeDB](../../user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
+:::
+
 
 ### Docker
 
@@ -52,7 +73,7 @@ greptime/greptimedb:<%greptimedb-version%> standalone start \
 --postgres-addr 0.0.0.0:4003
 ```
 
-:::tip NOTE
+:::tip 注意事项
 为了防止不小心退出 Docker 容器，你可能想以 “detached” 模式运行它：在 `docker run` 命令中添加 `-d` 参数即可。
 :::
 

--- a/docs/nightly/zh/getting-started/installation/greptimedb-standalone.md
+++ b/docs/nightly/zh/getting-started/installation/greptimedb-standalone.md
@@ -31,7 +31,7 @@ GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自
 ./greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
 ```
 
-你也可以参考[配置 GreptimeDB](../../user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
+你也可以参考[配置 GreptimeDB](/user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
 
 如果运行 GreptimeDB 的计算机直接向互联网暴露服务，那么绑定 `0.0.0.0` 会十分危险，因为这将数据库实例暴露给互联网上的所有人。
 :::
@@ -56,7 +56,7 @@ GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自
 .\greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
 ```
 
-你也可以参考[配置 GreptimeDB](../../user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
+你也可以参考[配置 GreptimeDB](/user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
 
 如果运行 GreptimeDB 的计算机直接向互联网暴露服务，那么绑定 `0.0.0.0` 会十分危险，因为这将数据库实例暴露给互联网上的所有人。
 :::

--- a/docs/nightly/zh/getting-started/installation/greptimedb-standalone.md
+++ b/docs/nightly/zh/getting-started/installation/greptimedb-standalone.md
@@ -26,12 +26,14 @@ curl -fsSL \
 ```
 
 :::tip 注意事项
-GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自其他地址的连接，可以通过以下参数启动。
+GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自所有地址的连接，可以通过以下参数启动。
 ```shell
 ./greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
 ```
 
 你也可以参考[配置 GreptimeDB](../../user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
+
+如果运行 GreptimeDB 的计算机直接向互联网暴露服务，那么绑定 `0.0.0.0` 会十分危险，因为这将数据库实例暴露给互联网上的所有人。
 :::
 
 
@@ -49,12 +51,14 @@ GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自
 
 
 :::tip 注意事项
-GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自其他地址的连接，可以通过以下参数启动。
+GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自所有地址的连接，可以通过以下参数启动。
 ```shell
 .\greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
 ```
 
 你也可以参考[配置 GreptimeDB](../../user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
+
+如果运行 GreptimeDB 的计算机直接向互联网暴露服务，那么绑定 `0.0.0.0` 会十分危险，因为这将数据库实例暴露给互联网上的所有人。
 :::
 
 

--- a/docs/nightly/zh/getting-started/installation/greptimedb-standalone.md
+++ b/docs/nightly/zh/getting-started/installation/greptimedb-standalone.md
@@ -51,7 +51,7 @@ GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自
 :::tip 注意事项
 GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自其他地址的连接，可以通过以下参数启动。
 ```shell
-./greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
+.\greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
 ```
 
 你也可以参考[配置 GreptimeDB](../../user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。

--- a/docs/v0.5/en/getting-started/installation/greptimedb-standalone.md
+++ b/docs/v0.5/en/getting-started/installation/greptimedb-standalone.md
@@ -40,7 +40,7 @@ To run GreptimeDB in standalone mode, open a terminal (like Powershell) at the d
 Make sure the [Docker](https://www.docker.com/) is already installed. If not, you can follow the official [documents](https://www.docker.com/get-started/) to install Docker.
 
 ```shell
-docker run -p 4000-4003:4000-4003 \
+docker run -p 127.0.0.1:4000-4003:4000-4003 \
 -p 4242:4242 -v "$(pwd)/greptimedb:/tmp/greptimedb" \
 --name greptime --rm \
 greptime/greptimedb standalone start \

--- a/docs/v0.5/zh/getting-started/installation/greptimedb-standalone.md
+++ b/docs/v0.5/zh/getting-started/installation/greptimedb-standalone.md
@@ -42,7 +42,7 @@ curl -fsSL \
 请确保已经安装了 [Docker](https://www.docker.com/)。如果还没有安装，可以参考 Docker 官方的[文档](https://www.docker.com/get-started/)进行安装。
 
 ```shell
-docker run -p 4000-4003:4000-4003 \
+docker run -p 127.0.0.1:4000-4003:4000-4003 \
 -p 4242:4242 -v "$(pwd)/greptimedb:/tmp/greptimedb" \
 --name greptime --rm \
 greptime/greptimedb standalone start \

--- a/docs/v0.6/en/getting-started/installation/greptimedb-standalone.md
+++ b/docs/v0.6/en/getting-started/installation/greptimedb-standalone.md
@@ -40,7 +40,7 @@ To run GreptimeDB in standalone mode, open a terminal (like Powershell) at the d
 Make sure the [Docker](https://www.docker.com/) is already installed. If not, you can follow the official [documents](https://www.docker.com/get-started/) to install Docker.
 
 ```shell
-docker run -p 4000-4003:4000-4003 \
+docker run -p 127.0.0.1:4000-4003:4000-4003 \
 -p 4242:4242 -v "$(pwd)/greptimedb:/tmp/greptimedb" \
 --name greptime --rm \
 greptime/greptimedb standalone start \

--- a/docs/v0.6/zh/getting-started/installation/greptimedb-standalone.md
+++ b/docs/v0.6/zh/getting-started/installation/greptimedb-standalone.md
@@ -42,7 +42,7 @@ curl -fsSL \
 请确保已经安装了 [Docker](https://www.docker.com/)。如果还没有安装，可以参考 Docker 官方的[文档](https://www.docker.com/get-started/)进行安装。
 
 ```shell
-docker run -p 4000-4003:4000-4003 \
+docker run -p 127.0.0.1:4000-4003:4000-4003 \
 -p 4242:4242 -v "$(pwd)/greptimedb:/tmp/greptimedb" \
 --name greptime --rm \
 greptime/greptimedb standalone start \

--- a/docs/v0.7/en/getting-started/installation/greptimedb-standalone.md
+++ b/docs/v0.7/en/getting-started/installation/greptimedb-standalone.md
@@ -40,7 +40,7 @@ To run GreptimeDB in standalone mode, open a terminal (like Powershell) at the d
 Make sure the [Docker](https://www.docker.com/) is already installed. If not, you can follow the official [documents](https://www.docker.com/get-started/) to install Docker.
 
 ```shell
-docker run -p 4000-4003:4000-4003 \
+docker run -p 127.0.0.1:4000-4003:4000-4003 \
 -p 4242:4242 -v "$(pwd)/greptimedb:/tmp/greptimedb" \
 --name greptime --rm \
 greptime/greptimedb:<%greptimedb-version%> standalone start \

--- a/docs/v0.7/zh/getting-started/installation/greptimedb-standalone.md
+++ b/docs/v0.7/zh/getting-started/installation/greptimedb-standalone.md
@@ -42,7 +42,7 @@ curl -fsSL \
 请确保已经安装了 [Docker](https://www.docker.com/)。如果还没有安装，可以参考 Docker 官方的[文档](https://www.docker.com/get-started/)进行安装。
 
 ```shell
-docker run -p 4000-4003:4000-4003 \
+docker run -p 127.0.0.1:4000-4003:4000-4003 \
 -p 4242:4242 -v "$(pwd)/greptimedb:/tmp/greptimedb" \
 --name greptime --rm \
 greptime/greptimedb:<%greptimedb-version%> standalone start \

--- a/docs/v0.8/en/getting-started/installation/greptimedb-standalone.md
+++ b/docs/v0.8/en/getting-started/installation/greptimedb-standalone.md
@@ -23,6 +23,16 @@ You can run GreptimeDB in the standalone mode:
 ./greptime standalone start
 ```
 
+:::tip NOTE
+GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections from other addresses, you can start with the following parameters.
+```shell
+./greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
+```
+
+You can also refer to the [Configuration](../../user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
+:::
+
+
 ### Windows
 
 If you have WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about)) enabled, you can lunch a latest Ubuntu and run GreptimeDB like above!
@@ -34,6 +44,16 @@ To run GreptimeDB in standalone mode, open a terminal (like Powershell) at the d
 ```shell
 .\greptime standalone start
 ```
+
+:::tip NOTE
+GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections from other addresses, you can start with the following parameters.
+```shell
+.\greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
+```
+
+You can also refer to the [Configuration](../../user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
+:::
+
 
 ## Docker
 

--- a/docs/v0.8/en/getting-started/installation/greptimedb-standalone.md
+++ b/docs/v0.8/en/getting-started/installation/greptimedb-standalone.md
@@ -23,18 +23,6 @@ You can run GreptimeDB in the standalone mode:
 ./greptime standalone start
 ```
 
-:::tip NOTE
-GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections from other addresses, you can start with the following parameters.
-```shell
-./greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
-```
-
-You can also refer to the [Configuration](/user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
-
-If the computer running GreptimeDB is directly exposed to the internet, binding to `0.0.0.0` is dangerous and will expose the instance to everybody on the internet.
-:::
-
-
 ### Windows
 
 If you have WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about)) enabled, you can lunch a latest Ubuntu and run GreptimeDB like above!
@@ -46,18 +34,6 @@ To run GreptimeDB in standalone mode, open a terminal (like Powershell) at the d
 ```shell
 .\greptime standalone start
 ```
-
-:::tip NOTE
-GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections from other addresses, you can start with the following parameters.
-```shell
-.\greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
-```
-
-You can also refer to the [Configuration](/user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
-
-If the computer running GreptimeDB is directly exposed to the internet, binding to `0.0.0.0` is dangerous and will expose the instance to everybody on the internet.
-:::
-
 
 ## Docker
 
@@ -103,6 +79,39 @@ You can:
 
 2. Upgrade the Docker version to v23.0.0 or higher;
    :::
+
+## Binding address
+
+GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections from other addresses, you can start with the following parameters.
+
+:::danger Warning
+
+If the computer running GreptimeDB is directly exposed to the internet, binding to `0.0.0.0` is dangerous and will expose the instance to everybody on the internet.
+
+
+:::code-group
+
+```shell [Binary]
+./greptime standalone start \
+   --http-addr 0.0.0.0:4000 \
+   --rpc-addr 0.0.0.0:4001 \
+   --mysql-addr 0.0.0.0:4002 \
+   --postgres-addr 0.0.0.0:4003
+```
+
+```shell [Docker]
+docker run -p 0.0.0.0:4000-4003:4000-4003 \
+-v "$(pwd)/greptimedb:/tmp/greptimedb" \
+--name greptime --rm \
+greptime/greptimedb:<%greptimedb-version%> standalone start \
+--http-addr 0.0.0.0:4000 \
+--rpc-addr 0.0.0.0:4001 \
+--mysql-addr 0.0.0.0:4002 \
+--postgres-addr 0.0.0.0:4003
+```
+:::
+
+You can also refer to the [Configuration](/user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
 
 ## Next Steps
 

--- a/docs/v0.8/en/getting-started/installation/greptimedb-standalone.md
+++ b/docs/v0.8/en/getting-started/installation/greptimedb-standalone.md
@@ -30,6 +30,8 @@ GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections fr
 ```
 
 You can also refer to the [Configuration](../../user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
+
+If the computer running GreptimeDB is directly exposed to the internet, binding to `0.0.0.0` is dangerous and will expose the instance to everybody on the internet.
 :::
 
 
@@ -52,6 +54,8 @@ GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections fr
 ```
 
 You can also refer to the [Configuration](../../user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
+
+If the computer running GreptimeDB is directly exposed to the internet, binding to `0.0.0.0` is dangerous and will expose the instance to everybody on the internet.
 :::
 
 

--- a/docs/v0.8/en/getting-started/installation/greptimedb-standalone.md
+++ b/docs/v0.8/en/getting-started/installation/greptimedb-standalone.md
@@ -29,7 +29,7 @@ GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections fr
 ./greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
 ```
 
-You can also refer to the [Configuration](../../user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
+You can also refer to the [Configuration](/user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
 
 If the computer running GreptimeDB is directly exposed to the internet, binding to `0.0.0.0` is dangerous and will expose the instance to everybody on the internet.
 :::
@@ -53,7 +53,7 @@ GreptimeDB binds to `127.0.0.1` by default. If you need to accept connections fr
 .\greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
 ```
 
-You can also refer to the [Configuration](../../user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
+You can also refer to the [Configuration](/user-guide/operations/configuration.md) document to modify the bind address in the configuration file.
 
 If the computer running GreptimeDB is directly exposed to the internet, binding to `0.0.0.0` is dangerous and will expose the instance to everybody on the internet.
 :::

--- a/docs/v0.8/en/getting-started/installation/greptimedb-standalone.md
+++ b/docs/v0.8/en/getting-started/installation/greptimedb-standalone.md
@@ -64,7 +64,7 @@ If the computer running GreptimeDB is directly exposed to the internet, binding 
 Make sure the [Docker](https://www.docker.com/) is already installed. If not, you can follow the official [documents](https://www.docker.com/get-started/) to install Docker.
 
 ```shell
-docker run -p 4000-4003:4000-4003 \
+docker run -p 127.0.0.1:4000-4003:4000-4003 \
 -v "$(pwd)/greptimedb:/tmp/greptimedb" \
 --name greptime --rm \
 greptime/greptimedb:<%greptimedb-version%> standalone start \

--- a/docs/v0.8/zh/getting-started/installation/greptimedb-standalone.md
+++ b/docs/v0.8/zh/getting-started/installation/greptimedb-standalone.md
@@ -25,18 +25,6 @@ curl -fsSL \
 ./greptime standalone start
 ```
 
-:::tip 注意事项
-GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自所有地址的连接，可以通过以下参数启动。
-```shell
-./greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
-```
-
-你也可以参考[配置 GreptimeDB](/user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
-
-如果运行 GreptimeDB 的计算机直接向互联网暴露服务，那么绑定 `0.0.0.0` 会十分危险，因为这将数据库实例暴露给互联网上的所有人。
-:::
-
-
 ### Windows
 
 若您的 Windows 系统已开启 WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about))，您可以直接打开一个最新的 Ubuntu 接着如上所示运行 GreptimeDB ！
@@ -48,18 +36,6 @@ GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自
 ```shell
 .\greptime standalone start
 ```
-
-:::tip 注意事项
-GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自所有地址的连接，可以通过以下参数启动。
-```shell
-.\greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
-```
-
-你也可以参考[配置 GreptimeDB](/user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
-
-如果运行 GreptimeDB 的计算机直接向互联网暴露服务，那么绑定 `0.0.0.0` 会十分危险，因为这将数据库实例暴露给互联网上的所有人。
-:::
-
 
 ### Docker
 
@@ -105,6 +81,39 @@ greptime/greptimedb:<%greptimedb-version%> standalone start \
 
 2. 将 Docker 版本升级到 v23.0.0 或更高;
    :::
+
+## 绑定地址
+
+GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自所有地址的连接，可以通过以下参数启动。
+
+:::danger 危险操作
+
+如果运行 GreptimeDB 的计算机直接向互联网暴露服务，那么绑定 `0.0.0.0` 会十分危险，因为这将数据库实例暴露给互联网上的所有人。
+
+:::code-group
+
+```shell [二进制]
+./greptime standalone start \
+   --http-addr 0.0.0.0:4000 \
+   --rpc-addr 0.0.0.0:4001 \
+   --mysql-addr 0.0.0.0:4002 \
+   --postgres-addr 0.0.0.0:4003
+```
+
+```shell [Docker]
+docker run -p 0.0.0.0:4000-4003:4000-4003 \
+-v "$(pwd)/greptimedb:/tmp/greptimedb" \
+--name greptime --rm \
+greptime/greptimedb:<%greptimedb-version%> standalone start \
+--http-addr 0.0.0.0:4000 \
+--rpc-addr 0.0.0.0:4001 \
+--mysql-addr 0.0.0.0:4002 \
+--postgres-addr 0.0.0.0:4003
+```
+
+:::
+
+你也可以参考[配置 GreptimeDB](/user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
 
 ## 下一步
 

--- a/docs/v0.8/zh/getting-started/installation/greptimedb-standalone.md
+++ b/docs/v0.8/zh/getting-started/installation/greptimedb-standalone.md
@@ -26,12 +26,14 @@ curl -fsSL \
 ```
 
 :::tip 注意事项
-GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自其他地址的连接，可以通过以下参数启动。
+GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自所有地址的连接，可以通过以下参数启动。
 ```shell
 ./greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
 ```
 
 你也可以参考[配置 GreptimeDB](../../user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
+
+如果运行 GreptimeDB 的计算机直接向互联网暴露服务，那么绑定 `0.0.0.0` 会十分危险，因为这将数据库实例暴露给互联网上的所有人。
 :::
 
 
@@ -48,12 +50,14 @@ GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自
 ```
 
 :::tip 注意事项
-GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自其他地址的连接，可以通过以下参数启动。
+GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自所有地址的连接，可以通过以下参数启动。
 ```shell
 .\greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
 ```
 
 你也可以参考[配置 GreptimeDB](../../user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
+
+如果运行 GreptimeDB 的计算机直接向互联网暴露服务，那么绑定 `0.0.0.0` 会十分危险，因为这将数据库实例暴露给互联网上的所有人。
 :::
 
 

--- a/docs/v0.8/zh/getting-started/installation/greptimedb-standalone.md
+++ b/docs/v0.8/zh/getting-started/installation/greptimedb-standalone.md
@@ -31,7 +31,7 @@ GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自
 ./greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
 ```
 
-你也可以参考[配置 GreptimeDB](../../user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
+你也可以参考[配置 GreptimeDB](/user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
 
 如果运行 GreptimeDB 的计算机直接向互联网暴露服务，那么绑定 `0.0.0.0` 会十分危险，因为这将数据库实例暴露给互联网上的所有人。
 :::
@@ -55,7 +55,7 @@ GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自
 .\greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
 ```
 
-你也可以参考[配置 GreptimeDB](../../user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
+你也可以参考[配置 GreptimeDB](/user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
 
 如果运行 GreptimeDB 的计算机直接向互联网暴露服务，那么绑定 `0.0.0.0` 会十分危险，因为这将数据库实例暴露给互联网上的所有人。
 :::

--- a/docs/v0.8/zh/getting-started/installation/greptimedb-standalone.md
+++ b/docs/v0.8/zh/getting-started/installation/greptimedb-standalone.md
@@ -66,7 +66,7 @@ GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自
 请确保已经安装了 [Docker](https://www.docker.com/)。如果还没有安装，可以参考 Docker 官方的[文档](https://www.docker.com/get-started/)进行安装。
 
 ```shell
-docker run -p 4000-4003:4000-4003 \
+docker run -p 127.0.0.1:4000-4003:4000-4003 \
 -v "$(pwd)/greptimedb:/tmp/greptimedb" \
 --name greptime --rm \
 greptime/greptimedb:<%greptimedb-version%> standalone start \

--- a/docs/v0.8/zh/getting-started/installation/greptimedb-standalone.md
+++ b/docs/v0.8/zh/getting-started/installation/greptimedb-standalone.md
@@ -25,6 +25,16 @@ curl -fsSL \
 ./greptime standalone start
 ```
 
+:::tip 注意事项
+GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自其他地址的连接，可以通过以下参数启动。
+```shell
+./greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
+```
+
+你也可以参考[配置 GreptimeDB](../../user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
+:::
+
+
 ### Windows
 
 若您的 Windows 系统已开启 WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about))，您可以直接打开一个最新的 Ubuntu 接着如上所示运行 GreptimeDB ！
@@ -36,6 +46,16 @@ curl -fsSL \
 ```shell
 .\greptime standalone start
 ```
+
+:::tip 注意事项
+GreptimeDB 默认绑定地址为 `127.0.0.1`。如果你需要能够接收来自其他地址的连接，可以通过以下参数启动。
+```shell
+.\greptime standalone start --http-addr 0.0.0.0:4000 --rpc-addr 0.0.0.0:4001 --mysql-addr 0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
+```
+
+你也可以参考[配置 GreptimeDB](../../user-guide/operations/configuration.md)文档在配置文件中修改绑定的地址。
+:::
+
 
 ### Docker
 


### PR DESCRIPTION
## What's Changed in this PR

This PR mentions the default start command binds the address to `127.0.0.1` and gives an example to change the address to bind.

This fixes https://github.com/GreptimeTeam/docs/issues/975

## Checklist

- [x] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
