### PR TITLE
chore: add 'paths-ignore' in addDocsToS3BucketAWS workflow

### DIFF
--- a/.github/workflows/addDocsToS3BucketAWS.yml
+++ b/.github/workflows/addDocsToS3BucketAWS.yml
@@ -6,8 +6,8 @@ on:
   pull_request_target:
     branches: ['main']
     types: [closed]
-    paths:
-      - "./docs/**/zh/**/*.md"
+    paths-ignore:
+      - "./docs/**/en/**"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel


### PR DESCRIPTION
## What's Changed in this PR
Push china docs to s3 when main branch change.
Ignore english docs push s3 when merge main branch.

Workflows example: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions

*Describe the change in this PR*

## Checklist

- [ ] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
