### PR TITLE
docs: flownode start

### DIFF
--- a/docs/nightly/en/reference/command-lines.md
+++ b/docs/nightly/en/reference/command-lines.md
@@ -68,6 +68,19 @@ Starts a frontend instance with command line arguments specifying the address of
 greptime frontend start --metasrv-addrs=0.0.0.0:3002
 ```
 
+Starts a flownode instance with customized configurations:
+
+```sh
+greptime flownode start -c config/flownode.example.toml
+```
+
+Starts a flownode instance with command line arguments specifying the address of the metasrv:
+
+```sh
+greptime flownode start --node-id=0 --rpc-addr=127.0.0.1:6800 --metasrv-addrs=127.0.0.1:3002;
+```
+
 ## Upgrade GreptimeDB version
 
 Please refer to [the upgrade steps](/user-guide/upgrade.md)
+

--- a/docs/nightly/en/user-guide/operations/configuration.md
+++ b/docs/nightly/en/user-guide/operations/configuration.md
@@ -132,6 +132,7 @@ You can find all available configurations for each component on GitHub:
 - [standalone](https://github.com/GreptimeTeam/greptimedb/blob/main/config/standalone.example.toml)
 - [frontend](https://github.com/GreptimeTeam/greptimedb/blob/main/config/frontend.example.toml)
 - [datanode](https://github.com/GreptimeTeam/greptimedb/blob/main/config/datanode.example.toml)
+- [flownode](https://github.com/GreptimeTeam/greptimedb/blob/main/config/flownode.example.toml)
 - [metasrv](https://github.com/GreptimeTeam/greptimedb/blob/main/config/metasrv.example.toml)
 
 

--- a/docs/nightly/en/user-guide/operations/configuration.md
+++ b/docs/nightly/en/user-guide/operations/configuration.md
@@ -87,6 +87,21 @@ greptime frontend start --help
 - `--tls-mode <TLS_MODE>`: TLS Mode;
 - `--user-provider <USER_PROVIDER>`: You can refer [authentication](/user-guide/clients/authentication);
 
+### Flownode subcommand options
+
+You can list all the options from the following command:
+
+```
+greptime flownode start --help
+```
+
+- `--node-id <NODE_ID>`: Flownode's id
+- `--rpc-addr <RPC_ADDR>`: Bind address for the gRPC server
+- `--rpc-hostname <RPC_HOSTNAME>`: Hostname for the gRPC server
+- `--metasrv-addrs <METASRV_ADDRS>...`: Metasrv address list
+- `-c, --config-file <CONFIG_FILE>`: The configuration file for the flownode
+- `--env-prefix <ENV_PREFIX>`: The prefix of environment variables, default is `GREPTIMEDB_FLOWNODE`
+
 ### Standalone subcommand options
 
 You can list all the options from the following command:

--- a/docs/nightly/zh/reference/command-lines.md
+++ b/docs/nightly/zh/reference/command-lines.md
@@ -69,6 +69,18 @@ greptime frontend start -c config/frontend.example.toml
 greptime frontend start --metasrv-addrs=0.0.0.0:3002
 ```
 
+使用自定义配置启动 flownode
+
+```sh
+greptime flownode start -c config/flownode.example.toml
+```
+
+使用命令行参数启动 flownode，指定 metasrv 和 frontend 的地址：
+
+```sh
+greptime flownode start --node-id=0 --rpc-addr=127.0.0.1:6800 --metasrv-addrs=127.0.0.1:3002;
+```
+
 ## 升级 GreptimeDB 版本
 
 请参考具体的[升级步骤](/user-guide/upgrade.md)

--- a/docs/nightly/zh/user-guide/operations/configuration.md
+++ b/docs/nightly/zh/user-guide/operations/configuration.md
@@ -87,6 +87,22 @@ greptime frontend start --help
 - `--tls-mode <TLS_MODE>`: TLS 模式
 - `--user-provider <USER_PROVIDER>`: 参考 [鉴权](/user-guide/clients/authentication);
 
+
+### Flownode 子命令选项
+
+通过执行下列命令来获取 `flownode` 子命令的帮助菜单：
+
+```
+greptime flownode start --help
+```
+
+- `--node-id <NODE_ID>`: Flownode的ID
+- `--rpc-addr <RPC_ADDR>`: gRPC服务器的绑定地址
+- `--rpc-hostname <RPC_HOSTNAME>`: gRPC服务器的主机名
+- `--metasrv-addrs <METASRV_ADDRS>...`: Metasrv地址列表
+- `-c, --config-file <CONFIG_FILE>`: Flownode的配置文件
+- `--env-prefix <ENV_PREFIX>`: 环境变量的前缀，默认为 `GREPTIMEDB_FLOWNODE`
+
 ### standalone 子命令选项
 
 通过执行下列命令来获取 `standalone` 子命令的帮助菜单：

--- a/docs/nightly/zh/user-guide/operations/configuration.md
+++ b/docs/nightly/zh/user-guide/operations/configuration.md
@@ -132,6 +132,7 @@ greptime standalone start --help
 - [standalone](https://github.com/GreptimeTeam/greptimedb/blob/main/config/standalone.example.toml)
 - [frontend](https://github.com/GreptimeTeam/greptimedb/blob/main/config/frontend.example.toml)
 - [datanode](https://github.com/GreptimeTeam/greptimedb/blob/main/config/datanode.example.toml)
+- [flownode](https://github.com/GreptimeTeam/greptimedb/blob/main/config/flownode.example.toml)
 - [metasrv](https://github.com/GreptimeTeam/greptimedb/blob/main/config/metasrv.example.toml)
 
 ### 指定配置文件


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

*Describe the change in this PR*


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added new command line examples for starting a flownode instance with customized configurations in the reference guide.
  - Introduced a new section detailing options for the `greptime flownode start` command in the user guide.
  - Included parameters like `--node-id`, `--rpc-addr`, `--rpc-hostname`, `--metasrv-addrs`, `-c, --config-file`, and `--env-prefix` in the configuration options.
  - Added translated command line examples and command details in the Chinese reference guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->