### PR TITLE
fix: backtick

### DIFF
--- a/docs/nightly/en/reference/sql/compatibility.md
+++ b/docs/nightly/en/reference/sql/compatibility.md
@@ -16,4 +16,4 @@ GreptimeDB supports a subset of ANSI SQL and has some unique extensions. Some ma
 5. Delete data: Deletion syntax is basically consistent with ANSI SQL.
 6. Others:
    * Identifiers such as table names and column names have constraints similar to ANSI SQL, are case sensitive, and require double quotes when encountering special characters or uppercase letters.
-   * GreptimeDB has optimized identifier rules for different dialects. For example, when you connect with a MySQL or PostgreSQL client, you can use identifier rules specific to that SQL dialect, such as using backticks ``` for MySQL and standard double quotes `"` for PostgreSQL.
+   * GreptimeDB has optimized identifier rules for different dialects. For example, when you connect with a MySQL or PostgreSQL client, you can use identifier rules specific to that SQL dialect, such as using backticks `` ` `` for MySQL and standard double quotes `"` for PostgreSQL.

--- a/docs/nightly/zh/reference/sql/compatibility.md
+++ b/docs/nightly/zh/reference/sql/compatibility.md
@@ -16,4 +16,4 @@ GreptimeDB 支持的 SQL 是 ANSI SQL 的子集，并且拥有一些特有的扩
 5. 删除数据：语法与 ANSI SQL 基本一致。
 6. 他项：
     * 标识符，如表名，列名等，约束与 ANSI SQL 类似，大小写敏感，遇到特殊字符或者大写需要用双引号括起来。
-    * GreptimeDB 针对不同方言做了优化，比如用 MySQL 客户端或者 PostgreSQL 客户端连接到数据库时， 允许使用特定 SQL 方言的标识符规则，比如在 MySQL 中可以用反引号 ```，而在 PostgreSQL 中还是标准的双引号 `"`。
+    * GreptimeDB 针对不同方言做了优化，比如用 MySQL 客户端或者 PostgreSQL 客户端连接到数据库时， 允许使用特定 SQL 方言的标识符规则，比如在 MySQL 中可以用反引号 `` ` ``，而在 PostgreSQL 中还是标准的双引号 `"`。

--- a/docs/v0.8/en/reference/sql/compatibility.md
+++ b/docs/v0.8/en/reference/sql/compatibility.md
@@ -16,4 +16,4 @@ GreptimeDB supports a subset of ANSI SQL and has some unique extensions. Some ma
 5. Delete data: Deletion syntax is basically consistent with ANSI SQL.
 6. Others:
    * Identifiers such as table names and column names have constraints similar to ANSI SQL, are case sensitive, and require double quotes when encountering special characters or uppercase letters.
-   * GreptimeDB has optimized identifier rules for different dialects. For example, when you connect with a MySQL or PostgreSQL client, you can use identifier rules specific to that SQL dialect, such as using backticks ``` for MySQL and standard double quotes `"` for PostgreSQL.
+   * GreptimeDB has optimized identifier rules for different dialects. For example, when you connect with a MySQL or PostgreSQL client, you can use identifier rules specific to that SQL dialect, such as using backticks `` ` `` for MySQL and standard double quotes `"` for PostgreSQL.

--- a/docs/v0.8/zh/reference/sql/compatibility.md
+++ b/docs/v0.8/zh/reference/sql/compatibility.md
@@ -16,4 +16,4 @@ GreptimeDB 支持的 SQL 是 ANSI SQL 的子集，并且拥有一些特有的扩
 5. 删除数据：语法与 ANSI SQL 基本一致。
 6. 他项：
     * 标识符，如表名，列名等，约束与 ANSI SQL 类似，大小写敏感，遇到特殊字符或者大写需要用双引号括起来。
-    * GreptimeDB 针对不同方言做了优化，比如用 MySQL 客户端或者 PostgreSQL 客户端连接到数据库时， 允许使用特定 SQL 方言的标识符规则，比如在 MySQL 中可以用反引号 ```，而在 PostgreSQL 中还是标准的双引号 `"`。
+    * GreptimeDB 针对不同方言做了优化，比如用 MySQL 客户端或者 PostgreSQL 客户端连接到数据库时， 允许使用特定 SQL 方言的标识符规则，比如在 MySQL 中可以用反引号 `` ` ``，而在 PostgreSQL 中还是标准的双引号 `"`。


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

*Describe the change in this PR*

Fixed the backtick.

Before:
<img width="890" alt="Screenshot 2024-07-07 at 18 14 41" src="https://github.com/GreptimeTeam/docs/assets/14142/c32e4612-05c4-48ad-8dd7-c307ca9d1746">


After:
<img width="700" alt="Screenshot 2024-07-07 at 18 14 05" src="https://github.com/GreptimeTeam/docs/assets/14142/50c4ef8a-7ac7-45a1-9826-ff5ade97ec59">



## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated SQL compatibility guidelines to clarify the use of backticks for MySQL and double quotes for PostgreSQL in identifier rules.
  - Enhanced Chinese documentation with the same SQL compatibility updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->