### PR TITLE
chore: remove http client from mysql and pgsql

### DIFF
--- a/docs/nightly/en/user-guide/clients/mysql.md
+++ b/docs/nightly/en/user-guide/clients/mysql.md
@@ -22,10 +22,9 @@ Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 mysql>
 ```
 
-## HTTP API
+## Table management
 
-GreptimeDB supports sending SQL statements through HTTP API.
-For information on how to set up authentication and how to set up time zone, please refer to [HTTP API](./http-api.md).
+Please refer to [Table Management](../table-management.md).
 
 ## Write data
 

--- a/docs/nightly/en/user-guide/clients/opentsdb.md
+++ b/docs/nightly/en/user-guide/clients/opentsdb.md
@@ -1,9 +1,5 @@
 # OpenTSDB
 
-## HTTP API
-
-GreptimeDB also supports OpenTSDB through HTTP API. For information on how to set up authentication, please refer to [HTTP API](./http-api.md).
-
 ## Write data
 
 Please refer to [write data](../write-data/opentsdb.md).

--- a/docs/nightly/en/user-guide/clients/postgresql.md
+++ b/docs/nightly/en/user-guide/clients/postgresql.md
@@ -17,9 +17,9 @@ public=>
 
 Note: Be sure to replace `greptime_user(username)` and `greptime_pwd(password)` with your own username and password.
 
-## HTTP API
+## Table management
 
-GreptimeDB supports sending SQL statements through HTTP API. For information on how to set up authentication, please refer to [HTTP API](./http-api.md).
+Please refer to [Table Management](../table-management.md).
 
 ## Write data
 

--- a/docs/nightly/zh/user-guide/clients/mysql.md
+++ b/docs/nightly/zh/user-guide/clients/mysql.md
@@ -22,9 +22,9 @@ Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 mysql>
 ```
 
-## HTTP API
+## 管理表
 
-GreptimeDB 支持通过 HTTP API 发送 SQL 语句。关于如何设置鉴权认证信息，请参考 [HTTP API](./http-api.md)。
+请参考 [管理表](../table-management.md)。
 
 ## 写入数据
 

--- a/docs/nightly/zh/user-guide/clients/opentsdb.md
+++ b/docs/nightly/zh/user-guide/clients/opentsdb.md
@@ -1,9 +1,5 @@
 # OpenTSDB
 
-## HTTP API
-
-GreptimeDB 同样支持通过 HTTP API 写入 OpenTSDB 协议数据。请参考 [HTTP API](./http-api.md) 获取鉴权相关的信息。
-
 ## 写入数据
 
 请参考 [写入数据](../write-data/opentsdb.md).

--- a/docs/nightly/zh/user-guide/clients/postgresql.md
+++ b/docs/nightly/zh/user-guide/clients/postgresql.md
@@ -17,9 +17,9 @@ public=>
 
 记得将示例中的 `greptime_user(username)` 和 `greptime_pwd(password)` 替换成自己的用户名和密码。
 
-## HTTP API
+## 管理表
 
-GreptimeDB 支持通过 HTTP API 发送 SQL 语句。要在 HTTP 请求中设置鉴权，请参考 [HTTP API](./http-api.md)。
+请参考 [管理表](../table-management.md)。
 
 ## 写入数据
 

--- a/docs/v0.8/en/user-guide/clients/mysql.md
+++ b/docs/v0.8/en/user-guide/clients/mysql.md
@@ -22,10 +22,9 @@ Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 mysql>
 ```
 
-## HTTP API
+## Table management
 
-GreptimeDB supports sending SQL statements through HTTP API.
-For information on how to set up authentication and how to set up time zone, please refer to [HTTP API](./http-api.md).
+Please refer to [Table Management](../table-management.md).
 
 ## Write data
 

--- a/docs/v0.8/en/user-guide/clients/opentsdb.md
+++ b/docs/v0.8/en/user-guide/clients/opentsdb.md
@@ -1,9 +1,5 @@
 # OpenTSDB
 
-## HTTP API
-
-GreptimeDB also supports OpenTSDB through HTTP API. For information on how to set up authentication, please refer to [HTTP API](./http-api.md).
-
 ## Write data
 
 Please refer to [write data](../write-data/opentsdb.md).

--- a/docs/v0.8/en/user-guide/clients/postgresql.md
+++ b/docs/v0.8/en/user-guide/clients/postgresql.md
@@ -17,9 +17,9 @@ public=>
 
 Note: Be sure to replace `greptime_user(username)` and `greptime_pwd(password)` with your own username and password.
 
-## HTTP API
+## Table management
 
-GreptimeDB supports sending SQL statements through HTTP API. For information on how to set up authentication, please refer to [HTTP API](./http-api.md).
+Please refer to [Table Management](../table-management.md).
 
 ## Write data
 

--- a/docs/v0.8/zh/user-guide/clients/mysql.md
+++ b/docs/v0.8/zh/user-guide/clients/mysql.md
@@ -22,9 +22,9 @@ Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 mysql>
 ```
 
-## HTTP API
+## 管理表
 
-GreptimeDB 支持通过 HTTP API 发送 SQL 语句。关于如何设置鉴权认证信息，请参考 [HTTP API](./http-api.md)。
+请参考 [管理表](../table-management.md)。
 
 ## 写入数据
 

--- a/docs/v0.8/zh/user-guide/clients/opentsdb.md
+++ b/docs/v0.8/zh/user-guide/clients/opentsdb.md
@@ -1,9 +1,5 @@
 # OpenTSDB
 
-## HTTP API
-
-GreptimeDB 同样支持通过 HTTP API 写入 OpenTSDB 协议数据。请参考 [HTTP API](./http-api.md) 获取鉴权相关的信息。
-
 ## 写入数据
 
 请参考 [写入数据](../write-data/opentsdb.md).

--- a/docs/v0.8/zh/user-guide/clients/postgresql.md
+++ b/docs/v0.8/zh/user-guide/clients/postgresql.md
@@ -17,9 +17,9 @@ public=>
 
 记得将示例中的 `greptime_user(username)` 和 `greptime_pwd(password)` 替换成自己的用户名和密码。
 
-## HTTP API
+## 管理表
 
-GreptimeDB 支持通过 HTTP API 发送 SQL 语句。要在 HTTP 请求中设置鉴权，请参考 [HTTP API](./http-api.md)。
+请参考 [管理表](../table-management.md)。
 
 ## 写入数据
 


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

as http client doesn't belong to any one of MySQL or PGSQL, so we removed it from MySQL and PGSQL client documentation.


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated various user guides to shift focus from HTTP API to table management.
  - Removed sections detailing HTTP API support and redirected users to table management sections.
  - Applied changes across English and Chinese documentation for MySQL, OpenTSDB, and PostgreSQL clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->