### PR TITLE
docs: remove cargo test workspace command

### DIFF
--- a/docs/nightly/en/contributor-guide/getting-started.md
+++ b/docs/nightly/en/contributor-guide/getting-started.md
@@ -43,10 +43,20 @@ The artifacts can be found under `$REPO/target/debug` or `$REPO/target/release`,
 
 ## Unit test
 
-GreptimeDB is well-tested, the entire unit test suite is shipped with source code. To test them, run
+GreptimeDB is well-tested, the entire unit test suite is shipped with source code. To test them, run with [nextest](https://nexte.st/index.html).
+
+To install nextest using cargo, run:
 
 ```shell
-cargo test --workspace
+cargo install cargo-nextest --locked
+```
+
+Or you can check their [docs](https://nexte.st/docs/installation/pre-built-binaries/) for other ways to install.
+
+After nextest is ready, you can run the test suite with:
+
+```shell
+cargo nextest run
 ```
 
 ## Docker

--- a/docs/nightly/en/contributor-guide/tests/unit-test.md
+++ b/docs/nightly/en/contributor-guide/tests/unit-test.md
@@ -5,7 +5,7 @@
 Unit tests are embedded into the codebase, usually placed next to the logic being tested.
 They are written using Rust's `#[test]` attribute and can run with `cargo nextest run`.
 
-The default test runner ships with `cargo` is not supported in our codebase. It's recommended
+The default test runner ships with `cargo` is not supported in GreptimeDB codebase. It's recommended
 to use [`nextest`](https://nexte.st/) instead. You can install it with
 
 ```shell

--- a/docs/nightly/en/contributor-guide/tests/unit-test.md
+++ b/docs/nightly/en/contributor-guide/tests/unit-test.md
@@ -3,12 +3,12 @@
 ## Introduction
 
 Unit tests are embedded into the codebase, usually placed next to the logic being tested.
-They are written using Rust's `#[test]` attribute and can run with `cargo test --workspace`.
+They are written using Rust's `#[test]` attribute and can run with `cargo nextest run`.
 Since `GreptimeDB` orchestrates its components in the "workspace" manner, the tailing
 `--workspace` is necessary to run all the unit cases.
 
-The default test runner ships with `cargo` is a bit slow. It's recommended to use
-[`nextest`](https://nexte.st/) to speed up the test procedure. You can install it with
+The default test runner ships with `cargo` is not supported in our codebase. It's recommended
+to use [`nextest`](https://nexte.st/) instead. You can install it with
 
 ```shell
 cargo install cargo-nextest --locked

--- a/docs/nightly/en/contributor-guide/tests/unit-test.md
+++ b/docs/nightly/en/contributor-guide/tests/unit-test.md
@@ -4,8 +4,6 @@
 
 Unit tests are embedded into the codebase, usually placed next to the logic being tested.
 They are written using Rust's `#[test]` attribute and can run with `cargo nextest run`.
-Since `GreptimeDB` orchestrates its components in the "workspace" manner, the tailing
-`--workspace` is necessary to run all the unit cases.
 
 The default test runner ships with `cargo` is not supported in our codebase. It's recommended
 to use [`nextest`](https://nexte.st/) instead. You can install it with

--- a/docs/nightly/zh/contributor-guide/getting-started.md
+++ b/docs/nightly/zh/contributor-guide/getting-started.md
@@ -43,10 +43,20 @@ cargo build # --release
 
 ## 单元测试
 
-GreptimeDB 经过了充分的测试，整个单元测试套件都随源代码一起提供。通过以下命令来运行测试：
+GreptimeDB 经过了充分的测试，整个单元测试套件都随源代码一起提供。要测试它们，请使用 [nextest](https://nexte.st/index.html)。
+
+要使用 cargo 安装 nextest，请运行：
 
 ```shell
-cargo test --workspace
+cargo install cargo-nextest --locked
+```
+
+或者，你可以查看他们的[文档](https://nexte.st/docs/installation/pre-built-binaries/)以了解其他安装方式。
+
+安装好 nextest 后，你可以使用以下命令运行测试套件：
+
+```shell
+cargo nextest run
 ```
 
 ## Docker

--- a/docs/nightly/zh/contributor-guide/tests/unit-test.md
+++ b/docs/nightly/zh/contributor-guide/tests/unit-test.md
@@ -4,8 +4,6 @@
 
 Unit tests are embedded into the codebase, usually placed next to the logic being tested.
 They are written using Rust's `#[test]` attribute and can run with `cargo nextest run`.
-Since `GreptimeDB` orchestrates its components in the "workspace" manner, the tailing
-`--workspace` is necessary to run all the unit cases.
 
 The default test runner ships with `cargo` is a bit slow. It's recommended to use
 [`nextest`](https://nexte.st/) to speed up the test procedure. You can install it with

--- a/docs/nightly/zh/contributor-guide/tests/unit-test.md
+++ b/docs/nightly/zh/contributor-guide/tests/unit-test.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 Unit tests are embedded into the codebase, usually placed next to the logic being tested.
-They are written using Rust's `#[test]` attribute and can run with `cargo test --workspace`.
+They are written using Rust's `#[test]` attribute and can run with `cargo nextest run`.
 Since `GreptimeDB` orchestrates its components in the "workspace" manner, the tailing
 `--workspace` is necessary to run all the unit cases.
 

--- a/docs/nightly/zh/contributor-guide/tests/unit-test.md
+++ b/docs/nightly/zh/contributor-guide/tests/unit-test.md
@@ -5,8 +5,8 @@
 Unit tests are embedded into the codebase, usually placed next to the logic being tested.
 They are written using Rust's `#[test]` attribute and can run with `cargo nextest run`.
 
-The default test runner ships with `cargo` is a bit slow. It's recommended to use
-[`nextest`](https://nexte.st/) to speed up the test procedure. You can install it with
+The default test runner ships with `cargo` is not supported in GreptimeDB codebase. It's recommended
+to use [`nextest`](https://nexte.st/) instead. You can install it with
 
 ```shell
 cargo install cargo-nextest --locked

--- a/docs/v0.8/en/contributor-guide/getting-started.md
+++ b/docs/v0.8/en/contributor-guide/getting-started.md
@@ -43,10 +43,20 @@ The artifacts can be found under `$REPO/target/debug` or `$REPO/target/release`,
 
 ## Unit test
 
-GreptimeDB is well-tested, the entire unit test suite is shipped with source code. To test them, run
+GreptimeDB is well-tested, the entire unit test suite is shipped with source code. To test them, run with [nextest](https://nexte.st/index.html).
+
+To install nextest using cargo, run:
 
 ```shell
-cargo test --workspace
+cargo install cargo-nextest --locked
+```
+
+Or you can check their [docs](https://nexte.st/docs/installation/pre-built-binaries/) for other ways to install.
+
+After nextest is ready, you can run the test suite with:
+
+```shell
+cargo nextest run
 ```
 
 ## Docker

--- a/docs/v0.8/en/contributor-guide/tests/unit-test.md
+++ b/docs/v0.8/en/contributor-guide/tests/unit-test.md
@@ -4,8 +4,6 @@
 
 Unit tests are embedded into the codebase, usually placed next to the logic being tested.
 They are written using Rust's `#[test]` attribute and can run with `cargo nextest run`.
-Since `GreptimeDB` orchestrates its components in the "workspace" manner, the tailing
-`--workspace` is necessary to run all the unit cases.
 
 The default test runner ships with `cargo` is a bit slow. It's recommended to use
 [`nextest`](https://nexte.st/) to speed up the test procedure. You can install it with

--- a/docs/v0.8/en/contributor-guide/tests/unit-test.md
+++ b/docs/v0.8/en/contributor-guide/tests/unit-test.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 Unit tests are embedded into the codebase, usually placed next to the logic being tested.
-They are written using Rust's `#[test]` attribute and can run with `cargo test --workspace`.
+They are written using Rust's `#[test]` attribute and can run with `cargo nextest run`.
 Since `GreptimeDB` orchestrates its components in the "workspace" manner, the tailing
 `--workspace` is necessary to run all the unit cases.
 

--- a/docs/v0.8/en/contributor-guide/tests/unit-test.md
+++ b/docs/v0.8/en/contributor-guide/tests/unit-test.md
@@ -5,8 +5,8 @@
 Unit tests are embedded into the codebase, usually placed next to the logic being tested.
 They are written using Rust's `#[test]` attribute and can run with `cargo nextest run`.
 
-The default test runner ships with `cargo` is a bit slow. It's recommended to use
-[`nextest`](https://nexte.st/) to speed up the test procedure. You can install it with
+The default test runner ships with `cargo` is not supported in GreptimeDB codebase. It's recommended
+to use [`nextest`](https://nexte.st/) instead. You can install it with
 
 ```shell
 cargo install cargo-nextest --locked

--- a/docs/v0.8/zh/contributor-guide/getting-started.md
+++ b/docs/v0.8/zh/contributor-guide/getting-started.md
@@ -43,10 +43,20 @@ cargo build # --release
 
 ## 单元测试
 
-GreptimeDB 经过了充分的测试，整个单元测试套件都随源代码一起提供。通过以下命令来运行测试：
+GreptimeDB 经过了充分的测试，整个单元测试套件都随源代码一起提供。要测试它们，请使用 [nextest](https://nexte.st/index.html)。
+
+要使用 cargo 安装 nextest，请运行：
 
 ```shell
-cargo test --workspace
+cargo install cargo-nextest --locked
+```
+
+或者，你可以查看他们的[文档](https://nexte.st/docs/installation/pre-built-binaries/)以了解其他安装方式。
+
+安装好 nextest 后，你可以使用以下命令运行测试套件：
+
+```shell
+cargo nextest run
 ```
 
 ## Docker

--- a/docs/v0.8/zh/contributor-guide/tests/unit-test.md
+++ b/docs/v0.8/zh/contributor-guide/tests/unit-test.md
@@ -5,7 +5,7 @@
 Unit tests are embedded into the codebase, usually placed next to the logic being tested.
 They are written using Rust's `#[test]` attribute and can run with `cargo nextest run`.
 
-The default test runner ships with `cargo` is not supported in our codebase. It's recommended
+The default test runner ships with `cargo` is not supported in GreptimeDB codebase. It's recommended
 to use [`nextest`](https://nexte.st/) instead. You can install it with
 
 ```shell

--- a/docs/v0.8/zh/contributor-guide/tests/unit-test.md
+++ b/docs/v0.8/zh/contributor-guide/tests/unit-test.md
@@ -3,12 +3,12 @@
 ## Introduction
 
 Unit tests are embedded into the codebase, usually placed next to the logic being tested.
-They are written using Rust's `#[test]` attribute and can run with `cargo test --workspace`.
+They are written using Rust's `#[test]` attribute and can run with `cargo nextest run`.
 Since `GreptimeDB` orchestrates its components in the "workspace" manner, the tailing
 `--workspace` is necessary to run all the unit cases.
 
-The default test runner ships with `cargo` is a bit slow. It's recommended to use
-[`nextest`](https://nexte.st/) to speed up the test procedure. You can install it with
+The default test runner ships with `cargo` is not supported in our codebase. It's recommended
+to use [`nextest`](https://nexte.st/) instead. You can install it with
 
 ```shell
 cargo install cargo-nextest --locked

--- a/docs/v0.8/zh/contributor-guide/tests/unit-test.md
+++ b/docs/v0.8/zh/contributor-guide/tests/unit-test.md
@@ -4,8 +4,6 @@
 
 Unit tests are embedded into the codebase, usually placed next to the logic being tested.
 They are written using Rust's `#[test]` attribute and can run with `cargo nextest run`.
-Since `GreptimeDB` orchestrates its components in the "workspace" manner, the tailing
-`--workspace` is necessary to run all the unit cases.
 
 The default test runner ships with `cargo` is not supported in our codebase. It's recommended
 to use [`nextest`](https://nexte.st/) instead. You can install it with


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

*Describe the change in this PR*

Related to https://github.com/GreptimeTeam/greptimedb/issues/4324


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated test documentation to recommend using `cargo nextest run` for running Rust unit tests, improving test execution speed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->