### PR TITLE
docs: remove tumble function usage

### DIFF
--- a/docs/nightly/en/user-guide/continuous-aggregation/define-time-window.md
+++ b/docs/nightly/en/user-guide/continuous-aggregation/define-time-window.md
@@ -5,6 +5,19 @@ These time windows are left-closed and right-open intervals.
 
 A time window corresponds to a range of time. Data from source table will be mapped to the corresponding window based on the time index column. Time window is also the scope of one calculation of an aggregation expression, so each time window will result in one row in the result table.
 
+To define a time window, you can use the `date_bin()` function, which takes two necessary param and one optional param: `interval`, `exoression` and `origin-timestamp`. It returns the start time of the time window that the source timestamp belongs to.
+
+For example, on this timestamp line:
+```
+          x
+...|---|---|---|...
+   7   8   9   10
+```
+
+If `x` is the source timestamp, `date_bin(2, x, 7)` will return `7`, `date_bin(1, x, 8)` will return `8`, and so on.
+
+<!-- 
+TODO(discord9): add back image after also impl equal of hop
 GreptimeDB provides two types of time windows: `hop` and `tumble`, or "sliding window" and "fixed window" in other words. You can specify the time window in the `GROUP BY` clause using `hop()` function or `tumble()` function respectively. These two functions are only supported in continuous aggregate queries's `GROUP BY` position.
 
 Here illustrates how the `hop()` and `tumble()` functions work:
@@ -23,7 +36,7 @@ tumble(col, interval, start_time)
 - `interval` specifies the size of the window. The `tumble` function divides the time column into fixed-size windows and aggregates the data in each window.
 - `start_time` specify the start time of the first window.
 <!-- - `start_time` is an optional parameter to specify the start time of the first window. If not provided, the start time will be aligned to calender. -->
-
+<!--
 ## Hop (not supported yet)
 
 `hop` defines sliding window that moves forward by a fixed interval. This feeaure is not supported yet and is expected to be available in the near future.

--- a/docs/nightly/en/user-guide/continuous-aggregation/define-time-window.md
+++ b/docs/nightly/en/user-guide/continuous-aggregation/define-time-window.md
@@ -15,7 +15,3 @@ For example, on this timestamp line:
 ```
 
 If `x` is the source timestamp, `date_bin(2, x, 7)` will return `7`, `date_bin(1, x, 8)` will return `8`, and so on.
-
-## Hop (not supported yet)
-
-`hop` defines sliding window that moves forward by a fixed interval. This feeaure is not supported yet and is expected to be available in the near future.

--- a/docs/nightly/en/user-guide/continuous-aggregation/define-time-window.md
+++ b/docs/nightly/en/user-guide/continuous-aggregation/define-time-window.md
@@ -5,13 +5,18 @@ These time windows are left-closed and right-open intervals.
 
 A time window corresponds to a range of time. Data from source table will be mapped to the corresponding window based on the time index column. Time window is also the scope of one calculation of an aggregation expression, so each time window will result in one row in the result table.
 
-To define a time window, you can use the `date_bin()` function, which takes two necessary param and one optional param: `interval`, `expression` and `origin-timestamp`. It returns the start time of the time window that the source timestamp belongs to.
+To define a time window, you can use the `date_bin()` function, which calculates time intervals and returns the start of the interval nearest to the specified timestamp. Use `date_bin` to downsample time series data by grouping rows into time-based “bins” or “windows” and applying an aggregate or selector function to each window.
 
-For example, on this timestamp line:
+For example, if you “bin” or “window” data into 15 minute intervals, an input timestamp of `2023-01-01T18:18:18Z` will be updated to the start time of the 15 minute bin it is in: `2023-01-01T18:15:00Z`.
+
 ```
-          x
-...|---|---|---|...
-   7   8   9   10
+date_bin(interval, expression, origin-timestamp)
 ```
 
-If `x` is the source timestamp, `date_bin(2, x, 7)` will return `7`, `date_bin(1, x, 8)` will return `8`, and so on.
+Arguments being:
+
+- interval: Bin interval.
+
+- expression: Time expression to operate on. Can be a constant, column, or function.
+
+- origin-timestamp: Optional. Starting point used to determine bin boundaries. If not specified defaults 1970-01-01T00:00:00Z (the UNIX epoch in UTC).

--- a/docs/nightly/en/user-guide/continuous-aggregation/define-time-window.md
+++ b/docs/nightly/en/user-guide/continuous-aggregation/define-time-window.md
@@ -1,22 +1,20 @@
 # Define Time Window
 
-Time window is an important attribute of your continuous aggregation query. It defines how the data is aggregated in the flow.
-These time windows are left-closed and right-open intervals.
+The time window is a crucial attribute of your continuous aggregation query. It determines how the data is aggregated in the flow.
+These time windows are intervals that are left-closed and right-open.
 
-A time window corresponds to a range of time. Data from source table will be mapped to the corresponding window based on the time index column. Time window is also the scope of one calculation of an aggregation expression, so each time window will result in one row in the result table.
+A time window represents a specific range of time. Data from the source table is mapped to the corresponding window based on the time index column. Each time window corresponds to one calculation of an aggregation expression, resulting in one row in the result table.
 
-To define a time window, you can use the `date_bin()` function, which calculates time intervals and returns the start of the interval nearest to the specified timestamp. Use `date_bin` to downsample time series data by grouping rows into time-based “bins” or “windows” and applying an aggregate or selector function to each window.
+To define a time window, you can utilize the `date_bin()` function. This function calculates time intervals and returns the start of the interval closest to the specified timestamp. By using `date_bin`, you can downsample time series data by grouping rows into time-based bins or windows and applying an aggregate or selector function to each window.
 
-For example, if you “bin” or “window” data into 15 minute intervals, an input timestamp of `2023-01-01T18:18:18Z` will be updated to the start time of the 15 minute bin it is in: `2023-01-01T18:15:00Z`.
+For instance, if you bin or window the data into 15-minute intervals, an input timestamp of `2023-01-01T18:18:18Z` will be adjusted to the start time of the 15-minute bin it belongs to: `2023-01-01T18:15:00Z`.
 
-```
+```sql
 date_bin(interval, expression, origin-timestamp)
 ```
 
-Arguments being:
+The arguments are as follows:
 
-- interval: Bin interval.
-
-- expression: Time expression to operate on. Can be a constant, column, or function.
-
-- origin-timestamp: Optional. Starting point used to determine bin boundaries. If not specified defaults 1970-01-01T00:00:00Z (the UNIX epoch in UTC).
+- interval: The interval for the bin.
+- expression: The time expression to operate on. It can be a constant, column, or function.
+- origin-timestamp: Optional. The starting point used to determine the bin boundaries. If not specified, it defaults to 1970-01-01T00:00:00Z (the UNIX epoch in UTC).

--- a/docs/nightly/en/user-guide/continuous-aggregation/define-time-window.md
+++ b/docs/nightly/en/user-guide/continuous-aggregation/define-time-window.md
@@ -5,7 +5,7 @@ These time windows are left-closed and right-open intervals.
 
 A time window corresponds to a range of time. Data from source table will be mapped to the corresponding window based on the time index column. Time window is also the scope of one calculation of an aggregation expression, so each time window will result in one row in the result table.
 
-To define a time window, you can use the `date_bin()` function, which takes two necessary param and one optional param: `interval`, `exoression` and `origin-timestamp`. It returns the start time of the time window that the source timestamp belongs to.
+To define a time window, you can use the `date_bin()` function, which takes two necessary param and one optional param: `interval`, `expression` and `origin-timestamp`. It returns the start time of the time window that the source timestamp belongs to.
 
 For example, on this timestamp line:
 ```

--- a/docs/nightly/en/user-guide/continuous-aggregation/define-time-window.md
+++ b/docs/nightly/en/user-guide/continuous-aggregation/define-time-window.md
@@ -5,7 +5,7 @@ These time windows are intervals that are left-closed and right-open.
 
 A time window represents a specific range of time. Data from the source table is mapped to the corresponding window based on the time index column. Each time window corresponds to one calculation of an aggregation expression, resulting in one row in the result table.
 
-To define a time window, you can utilize the `date_bin()` function. This function calculates time intervals and returns the start of the interval closest to the specified timestamp. By using `date_bin`, you can downsample time series data by grouping rows into time-based bins or windows and applying an aggregate or selector function to each window.
+To define a time window, you can utilize the `date_bin(interval, expression, origin-timestamp)` function. This function calculates time intervals and returns the start of the interval closest to the specified timestamp. By using `date_bin`, you can downsample time series data by grouping rows into time-based bins or windows and applying an aggregate or selector function to each window.
 
 For instance, if you bin or window the data into 15-minute intervals, an input timestamp of `2023-01-01T18:18:18Z` will be adjusted to the start time of the 15-minute bin it belongs to: `2023-01-01T18:15:00Z`.
 
@@ -15,6 +15,6 @@ date_bin(interval, expression, origin-timestamp)
 
 The arguments are as follows:
 
-- interval: The interval for the bin.
-- expression: The time expression to operate on. It can be a constant, column, or function.
-- origin-timestamp: Optional. The starting point used to determine the bin boundaries. If not specified, it defaults to 1970-01-01T00:00:00Z (the UNIX epoch in UTC).
+- `interval`: The interval for the bin.
+- `expression`: The time expression to operate on. It can be a constant, column, or function.
+- `origin-timestamp`: Optional. The starting point used to determine the bin boundaries. If not specified, it defaults to 1970-01-01T00:00:00Z (the UNIX epoch in UTC).

--- a/docs/nightly/en/user-guide/continuous-aggregation/define-time-window.md
+++ b/docs/nightly/en/user-guide/continuous-aggregation/define-time-window.md
@@ -16,39 +16,6 @@ For example, on this timestamp line:
 
 If `x` is the source timestamp, `date_bin(2, x, 7)` will return `7`, `date_bin(1, x, 8)` will return `8`, and so on.
 
-<!-- 
-TODO(discord9): add back image after also impl equal of hop
-GreptimeDB provides two types of time windows: `hop` and `tumble`, or "sliding window" and "fixed window" in other words. You can specify the time window in the `GROUP BY` clause using `hop()` function or `tumble()` function respectively. These two functions are only supported in continuous aggregate queries's `GROUP BY` position.
-
-Here illustrates how the `hop()` and `tumble()` functions work:
-
-![Time Window](/time-window.svg)
-
-## Tumble
-
-`tumble()` defines fixed windows that do not overlap.
-
-```
-tumble(col, interval, start_time)
-```
-
-- `col` specifies use which column to compute the time window. The provided column must have a timestamp type.
-- `interval` specifies the size of the window. The `tumble` function divides the time column into fixed-size windows and aggregates the data in each window.
-- `start_time` specify the start time of the first window.
-<!-- - `start_time` is an optional parameter to specify the start time of the first window. If not provided, the start time will be aligned to calender. -->
-<!--
 ## Hop (not supported yet)
 
 `hop` defines sliding window that moves forward by a fixed interval. This feeaure is not supported yet and is expected to be available in the near future.
-
-<!-- `hop` defines sliding window that moves forward by a fixed interval. It signature is like the following:
-
-```
-hop(col, size_interval, hop_interval, <start_time>)
-```
-
-Where `col` specifies use which column to compute the time window. The provided column must have a timestamp type.
-
-`size_interval` specifies the size of each window, while `hop_interval` specifies the delta between two windows' start timestamp. You can think the `tumble()` function as a special case of `hop()` function where the `size_interval` and `hop_interval` are the same.
-
-`start_time` is an optional parameter to specify the start time of the first window. If not provided, the start time will be aligned to calender. -->

--- a/docs/nightly/en/user-guide/continuous-aggregation/manage-flow.md
+++ b/docs/nightly/en/user-guide/continuous-aggregation/manage-flow.md
@@ -48,10 +48,10 @@ SINK TO my_sink_table
 EXPIRE AFTER INTERVAL '1 hour'
 COMMENT = "My first flow in GreptimeDB"
 AS
-SELECT count(item) from my_source_table GROUP BY tumble(time_index, INTERVAL '5 minutes', '2024-05-20 00:00:00');
+SELECT date_bin(INTERVAL '5 minutes', time_index, '2024-05-20 00:00:00'), count(item) from my_source_table GROUP BY date_bin(INTERVAL '5 minutes', time_index, '2024-05-20 00:00:00');
 ```
 
-The created flow will compute `count(item)` for every 5 minutes and store the result in `my_sink_table`. All data comes within 1 hour will be used in the flow. For the `tumble()` function, refer to [define time window](./define-time-window.md) part. 
+The created flow will compute `count(item)` for every 5 minutes and store the result in `my_sink_table`. All data comes within 1 hour will be used in the flow. For the `date_bin()` function, refer to [define time window](./define-time-window.md) part. 
 
 ### `EXPIRE AFTER` clause
 

--- a/docs/nightly/en/user-guide/continuous-aggregation/manage-flow.md
+++ b/docs/nightly/en/user-guide/continuous-aggregation/manage-flow.md
@@ -51,7 +51,7 @@ AS
 SELECT date_bin(INTERVAL '5 minutes', time_index, '2024-05-20 00:00:00'), count(item) from my_source_table GROUP BY date_bin(INTERVAL '5 minutes', time_index, '2024-05-20 00:00:00');
 ```
 
-The created flow will compute `count(item)` for every 5 minutes and store the result in `my_sink_table`. All data comes within 1 hour will be used in the flow. For the `date_bin()` function, refer to [define time window](./define-time-window.md) part. 
+The created flow will compute `count(item)` for every 5 minutes and store the result in `my_sink_table`. All data comes within 1 hour will be used in the flow. For the `date_bin(interval, expression, origin-timestamp)` function, refer to [define time window](./define-time-window.md) part. 
 
 ### `EXPIRE AFTER` clause
 

--- a/docs/nightly/en/user-guide/continuous-aggregation/overview.md
+++ b/docs/nightly/en/user-guide/continuous-aggregation/overview.md
@@ -38,7 +38,7 @@ Then create the flow `test_numbers` to aggregate the sum of `number` column in `
 CREATE FLOW test_numbers 
 SINK TO out_num_cnt
 AS 
-SELECT sum(number) FROM numbers_input GROUP BY tumble(ts, '1 second', '2021-07-01 00:00:00');
+SELECT date_bin(ts, '1 second', '2021-07-01 00:00:00'), sum(number) FROM numbers_input GROUP BY date_bin(ts, '1 second', '2021-07-01 00:00:00');
 ```
 
 To observe the outcome of the continuous aggregation in the `out_num_cnt` table, insert some data into the source table `numbers_input`.

--- a/docs/nightly/en/user-guide/continuous-aggregation/query.md
+++ b/docs/nightly/en/user-guide/continuous-aggregation/query.md
@@ -15,6 +15,6 @@ Only two kinds of expression are allowed after `SELECT` keyword:
 
 The query should have a `FROM` clause to identify the source table. As the join clause is currently not supported, the query can only aggregate columns from a single table.
 
-`GROUP BY` clause works as in a normal query. It groups the data by the specified columns. One special thing is the time window functions `hop()` and `tumble()` described in [Define Time Window](./define-time-window.md) part. They are used in the `GROUP BY` clause to define the time window for the aggregation. Other expressions in `GROUP BY` can be either literal, column or scalar expressions.
+`GROUP BY` clause works as in a normal query. It groups the data by the specified columns. One special thing is the time window functions `date_bin()` described in [Define Time Window](./define-time-window.md) part. They are used in the `GROUP BY` clause to define the time window for the aggregation. Other expressions in `GROUP BY` can be either literal, column or scalar expressions.
 
 Others things like `ORDER BY`, `LIMIT`, `OFFSET` are not supported in the continuous aggregation query.

--- a/docs/nightly/en/user-guide/continuous-aggregation/query.md
+++ b/docs/nightly/en/user-guide/continuous-aggregation/query.md
@@ -15,6 +15,6 @@ Only two kinds of expression are allowed after `SELECT` keyword:
 
 The query should have a `FROM` clause to identify the source table. As the join clause is currently not supported, the query can only aggregate columns from a single table.
 
-`GROUP BY` clause works as in a normal query. It groups the data by the specified columns. One special thing is the time window functions `date_bin()` described in [Define Time Window](./define-time-window.md) part. They are used in the `GROUP BY` clause to define the time window for the aggregation. Other expressions in `GROUP BY` can be either literal, column or scalar expressions.
+`GROUP BY` clause works as in a normal query. It groups the data by the specified columns. One special thing is the time window functions `date_bin(interval, expression, origin-timestamp)` described in [Define Time Window](./define-time-window.md) part. They are used in the `GROUP BY` clause to define the time window for the aggregation. Other expressions in `GROUP BY` can be either literal, column or scalar expressions.
 
 Others things like `ORDER BY`, `LIMIT`, `OFFSET` are not supported in the continuous aggregation query.

--- a/docs/nightly/zh/user-guide/continuous-aggregation/define-time-window.md
+++ b/docs/nightly/zh/user-guide/continuous-aggregation/define-time-window.md
@@ -1,47 +1,24 @@
 # 定义时间窗口
 
-时间窗口是连续聚合查询的重要属性。
-它定义了数据在流中的聚合方式。
-这些窗口是左闭右开的区间。
+时间窗口是连续聚合查询中的一个关键属性，它决定了数据在流中的聚合方式。
+这些时间窗口是左闭右开的间隔。
 
-时间窗口对应于时间范围。
-source 表中的数据将根据时间索引列映射到相应的窗口。
-时间窗口也是聚合表达式计算的范围，因此每个时间窗口将在结果表中生成一行。
+时间窗口表示特定的时间范围，
+源表中的数据根据时间索引列映射到相应的窗口。
+每个时间窗口对应一个聚合表达式的计算，结果是存储到表中的一行数据。
 
-GreptimeDB 提供两种时间窗口类型：`hop` 和 `tumble`，或者换句话说是滑动窗口和固定窗口。
-你可以在 `GROUP BY` 子句中使用 `hop()` 函数或 `tumble()` 函数指定时间窗口。
-这两个函数仅支持在连续聚合查询的 `GROUP BY` 位置使用。
+要定义一个时间窗口，可以使用 `date_bin(interval, expression, origin-timestamp)` 函数。
+该函数计算时间间隔，并返回最接近指定时间戳的间隔的起始时间。
+通过使用 `date_bin` ，可以将时间序列数据进行降采样，将行分组到基于时间的容器或窗口中，并对每个窗口应用聚合或选择器函数。
 
-下图展示了 `hop()` 和 `tumble()` 函数的工作方式：
+例如，如果将数据分组或窗口化为 15 分钟间隔，输入时间戳 `2023-01-01T18:18:18Z` 将被调整为所属的 15 分钟容器的起始时间：`2023-01-01T18:15:00Z`。
 
-![Time Window](/time-window.svg)
-
-## Tumble
-
-`tumble()` 定义固定窗口，窗口之间不重叠。
-
-```
-tumble(col, interval, start_time)
+```sql
+date_bin(interval, expression, origin-timestamp)
 ```
 
-- `col` 指定使用哪一列计算时间窗口。提供的列必须是时间戳类型。
-- `interval` 指定窗口的大小。`tumble` 函数将时间列划分为固定大小的窗口，并在每个窗口中聚合数据。
-- `start_time` 用于指定第一个窗口的开始时间。
-<!-- `start_time` 是一个可选参数，用于指定第一个窗口的开始时间。如果未提供，开始时间将与日历对齐。 -->
+参数说明如下：
 
-## Hop（尚未支持）
-
-`hop` 定义滑动窗口，窗口按固定间隔向前移动。
-此功能尚未支持，预计将在不久的将来提供。
-
-<!-- `hop` defines sliding window that moves forward by a fixed interval. It signature is like the following:
-
-```
-hop(col, size_interval, hop_interval, <start_time>)
-```
-
-Where `col` specifies use which column to compute the time window. The provided column must have a timestamp type.
-
-`size_interval` specifies the size of each window, while `hop_interval` specifies the delta between two windows' start timestamp. You can think the `tumble()` function as a special case of `hop()` function where the `size_interval` and `hop_interval` are the same.
-
-`start_time` is an optional parameter to specify the start time of the first window. If not provided, the start time will be aligned to calender. -->
+- `interval`：容器的时间间隔。
+- `expression`：要操作的时间表达式。可以是常量、列或函数。
+- `origin-timestamp`：可选。用于确定时间窗口边界的起始点。如果未指定，默认为 1970-01-01T00:00:00Z（UNIX 纪元时间，以 UTC 为准）。

--- a/docs/nightly/zh/user-guide/continuous-aggregation/manage-flow.md
+++ b/docs/nightly/zh/user-guide/continuous-aggregation/manage-flow.md
@@ -56,10 +56,10 @@ CREATE FLOW IF NOT EXISTS my_flow
 SINK TO my_sink_table
 COMMENT = "My first flow in GreptimeDB"
 AS
-SELECT count(item) from my_source_table GROUP BY tumble(time_index, INTERVAL '5 minutes', '2024-05-20 00:00:00');
+SELECT date_bin(INTERVAL '5 minutes', time_index, '2024-05-20 00:00:00'), count(item) from my_source_table GROUP BY date_bin(INTERVAL '5 minutes', time_index, '2024-05-20 00:00:00');
 ```
 
-创建的 flow 将每 5 分钟计算 `count(item)` 并将结果存储在 `my_sink_table` 中。所有在 1 小时内的数据将在 flow 中使用。有关 `tumble()` 函数，请参考[定义时间窗口](./define-time-window.md) 部分。
+创建的 flow 将每 5 分钟计算 `count(item)` 并将结果存储在 `my_sink_table` 中。所有在 1 小时内的数据将在 flow 中使用。有关 `date_bin(interval, expression, origin-timestamp)` 函数，请参考[定义时间窗口](./define-time-window.md) 部分。
 
 ### `EXPIRE AFTER` 语句
 

--- a/docs/nightly/zh/user-guide/continuous-aggregation/overview.md
+++ b/docs/nightly/zh/user-guide/continuous-aggregation/overview.md
@@ -41,7 +41,7 @@ CREATE TABLE out_num_cnt (
 CREATE FLOW test_numbers 
 SINK TO out_num_cnt
 AS 
-SELECT sum(number) FROM numbers_input GROUP BY tumble(ts, '1 second', '2021-07-01 00:00:00');
+SELECT date_bin(ts, '1 second', '2021-07-01 00:00:00'), sum(number) FROM numbers_input GROUP BY date_bin(ts, '1 second', '2021-07-01 00:00:00');
 ```
 
 要观察 `out_num_cnt` 表中连续聚合的结果，向 source 表 `numbers_input` 插入一些数据。

--- a/docs/nightly/zh/user-guide/continuous-aggregation/query.md
+++ b/docs/nightly/zh/user-guide/continuous-aggregation/query.md
@@ -18,7 +18,7 @@ SELECT AGGR_FUNCTION(column1, column2,..) FROM <source_table> GROUP BY TIME_WIND
 
 `GROUP BY` 子句与普通查询中的工作方式相同。
 它根据指定的列对数据进行分组。
-`GROUP BY` 子句中使用的时间窗口函数 `hop()` 和 `tumble()` 在 [定义时间窗口](./define-time-window.md) 部分中有描述。
+`GROUP BY` 子句中使用的时间窗口函数 `date_bin(interval, expression, origin-timestamp)` 在 [定义时间窗口](./define-time-window.md) 部分中有描述。
 它们用于在聚合中定义时间窗口。
 `GROUP BY` 中的其他表达式可以是 literal、列名或 scalar 表达式。
 


### PR DESCRIPTION
## What's Changed in this PR

remove `tumble` function usage in flow, and replace it with `date_bin` function, this pr require changes in localized docs

NOTE: this PR require https://github.com/GreptimeTeam/greptimedb/pull/4367 and https://github.com/GreptimeTeam/greptimedb/pull/4347 to work

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

*Describe the change in this PR*


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [x] This change requires follow-up update in localized docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the User Guide to use the `date_bin()` function for defining time windows, replacing `hop()` and `tumble()`.
  - Enhanced explanations and examples for time window concepts and SQL queries involving continuous aggregation.
  - Applied these changes to both English and Chinese versions of the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->