### PR TITLE
docs: update some information_schema tables results

### DIFF
--- a/docs/nightly/en/reference/sql/information-schema/build-info.md
+++ b/docs/nightly/en/reference/sql/information-schema/build-info.md
@@ -12,9 +12,9 @@ The output is as follows:
 
 ```sql
 +------------+------------------------------------------+------------------+-----------+-------------+
-| git_branch | git_commit                               | git_commit_short | git_dirty | pkg_version |
+| git_branch | git_commit                               | git_commit_short | git_clean | pkg_version |
 +------------+------------------------------------------+------------------+-----------+-------------+
-| main       | 92a8e863ded618fe1be93f799360015b4f8f28b6 | 92a8e86          | true      | 0.7.1       |
+|            | c595a56ac89bef78b19a76aa60d8c6bcac7354a5 | c595a56a         | true      | 0.9.0       |
 +------------+------------------------------------------+------------------+-----------+-------------+
 ```
 
@@ -23,6 +23,6 @@ The columns in the output:
 * `branch`: the build git branch name.
 * `git_commit`: the build commit revision.
 * `git_commit_short`: the short commit revision.
-* `git_dirty`:  `true` if the build source directory contains uncommitted changes.
+* `git_clean`:  `true` if the build source directory contains all the committed changes.
 * `pkg_version`: the GreptimeDB version.
 

--- a/docs/nightly/en/reference/sql/information-schema/cluster-info.md
+++ b/docs/nightly/en/reference/sql/information-schema/cluster-info.md
@@ -33,6 +33,7 @@ The columns in table:
 * `peer_type`: the node type, `METASRV`,`FRONTEND`, or `DATANODE` for distributed clusters and `STANDALONE` for standalone deployments.
 * `peer_addr`: the GRPC server address of the node. It's always empty for standalone deployments.
 * `version`: The build version of the node, such as `0.7.2` etc.
+* `git_commit`: The build git commit of the node.
 * `start_time`: The node start time.
 * `uptime`: The uptime of the node, in the format of duration string `24h 10m 59s 150ms`.
 * `active_time`: The duration string in the format of `24h 10m 59s 150ms` since the node's last active time(sending the heartbeats), it's always empty for standalone deployments.

--- a/docs/nightly/en/reference/sql/information-schema/tables.md
+++ b/docs/nightly/en/reference/sql/information-schema/tables.md
@@ -10,17 +10,34 @@ DESC TABLES;
 The output is as follows:
 
 ```sql
-+---------------+--------+------+------+---------+---------------+
-| Column        | Type   | Key  | Null | Default | Semantic Type |
-+---------------+--------+------+------+---------+---------------+
-| table_catalog | String |      | NO   |         | FIELD         |
-| table_schema  | String |      | NO   |         | FIELD         |
-| table_name    | String |      | NO   |         | FIELD         |
-| table_type    | String |      | NO   |         | FIELD         |
-| table_id      | UInt32 |      | YES  |         | FIELD         |
-| engine        | String |      | YES  |         | FIELD         |
-+---------------+--------+------+------+---------+---------------+
-6 rows in set (0.00 sec)
++------------------+----------+------+------+---------+---------------+
+| Column           | Type     | Key  | Null | Default | Semantic Type |
++------------------+----------+------+------+---------+---------------+
+| table_catalog    | String   |      | NO   |         | FIELD         |
+| table_schema     | String   |      | NO   |         | FIELD         |
+| table_name       | String   |      | NO   |         | FIELD         |
+| table_type       | String   |      | NO   |         | FIELD         |
+| table_id         | UInt32   |      | YES  |         | FIELD         |
+| data_length      | UInt64   |      | YES  |         | FIELD         |
+| max_data_length  | UInt64   |      | YES  |         | FIELD         |
+| index_length     | UInt64   |      | YES  |         | FIELD         |
+| max_index_length | UInt64   |      | YES  |         | FIELD         |
+| avg_row_length   | UInt64   |      | YES  |         | FIELD         |
+| engine           | String   |      | YES  |         | FIELD         |
+| version          | UInt64   |      | YES  |         | FIELD         |
+| row_format       | String   |      | YES  |         | FIELD         |
+| table_rows       | UInt64   |      | YES  |         | FIELD         |
+| data_free        | UInt64   |      | YES  |         | FIELD         |
+| auto_increment   | UInt64   |      | YES  |         | FIELD         |
+| create_time      | DateTime |      | YES  |         | FIELD         |
+| update_time      | DateTime |      | YES  |         | FIELD         |
+| check_time       | DateTime |      | YES  |         | FIELD         |
+| table_collation  | String   |      | YES  |         | FIELD         |
+| checksum         | UInt64   |      | YES  |         | FIELD         |
+| create_options   | String   |      | YES  |         | FIELD         |
+| table_comment    | String   |      | YES  |         | FIELD         |
+| temporary        | String   |      | YES  |         | FIELD         |
++------------------+----------+------+------+---------+---------------+
 ```
 
 ```sql
@@ -29,12 +46,30 @@ SELECT * FROM tables WHERE table_schema='public' AND table_name='monitor'\G
 
 ```sql
 *************************** 1. row ***************************
-table_catalog: greptime
- table_schema: public
-   table_name: monitor
-   table_type: BASE TABLE
-     table_id: 1025
-       engine: mito
+   table_catalog: greptime
+    table_schema: public
+      table_name: monitor
+      table_type: BASE TABLE
+        table_id: 1054
+     data_length: 0
+ max_data_length: 0
+    index_length: 0
+max_index_length: 0
+  avg_row_length: 0
+          engine: mito
+         version: 11
+      row_format: Fixed
+      table_rows: 0
+       data_free: 0
+  auto_increment: 0
+     create_time: 2024-07-24 22:06:18.085000
+     update_time: NULL
+      check_time: NULL
+ table_collation: NULL
+        checksum: 0
+  create_options:
+   table_comment: NULL
+       temporary: N
 1 row in set (0.01 sec)
 ```
 
@@ -61,3 +96,7 @@ The description of columns in the `TABLES` table is as follows:
   - `VIEW`  for a view.
 - `table_id`: The ID of the table.
 - `engine`: The storage engine of the table used.
+- `version`:  Version. The value is `11` by default.
+- `create_time`: The table created timestamp.
+- `table_comment`: The table comment.
+- Other columns such as `table_rows`, `row_format` etc. are not supported, just for compatibility with MySQL. GreptimeDB may support some of them in the future.

--- a/docs/nightly/zh/reference/sql/information-schema/build-info.md
+++ b/docs/nightly/zh/reference/sql/information-schema/build-info.md
@@ -12,9 +12,9 @@ SELECT * FROM BUILD_INFO;
 
 ```sql
 +------------+------------------------------------------+------------------+-----------+-------------+
-| git_branch | git_commit                               | git_commit_short | git_dirty | pkg_version |
+| git_branch | git_commit                               | git_commit_short | git_clean | pkg_version |
 +------------+------------------------------------------+------------------+-----------+-------------+
-| main       | 92a8e863ded618fe1be93f799360015b4f8f28b6 | 92a8e86          | true      | 0.7.1       |
+|            | c595a56ac89bef78b19a76aa60d8c6bcac7354a5 | c595a56a         | true      | 0.9.0       |
 +------------+------------------------------------------+------------------+-----------+-------------+
 ```
 
@@ -23,5 +23,5 @@ SELECT * FROM BUILD_INFO;
 * `branch`：构建的 git 分支名称。
 * `git_commit`：提交构建的 `commit`。
 * `git_commit_short`：提交构建的 `commit` 缩写。
-* `git_dirty`：如果构建源目录包含未提交的更改，则为 `true`。
+* `git_clean`：如果构建源目录包含了所有提交的更改，则为 `true`。
 * `pkg_version`：GreptimeDB 版本。

--- a/docs/nightly/zh/reference/sql/information-schema/cluster-info.md
+++ b/docs/nightly/zh/reference/sql/information-schema/cluster-info.md
@@ -33,6 +33,7 @@ DESC TABLE CLUSTER_INFO;
 * `peer_type`: 节点类型, 分布式集群里可能是 `METASRV`、`FRONTEND` 或者 `DATANODE`。单机模式显示为 `STANDALONE`。
 * `peer_addr`: 节点的 gRPC 服务地址。对于单机部署，该字段总为空。
 * `version`: 节点的版本号，形如 `0.7.2` 的字符串。
+* `git_commit`: 节点编译的 git 版本号。
 * `start_time`: 节点的启动时间。
 * `uptime`: 节点的持续运行时间，形如 `24h 10m 59s 150ms` 的字符串。
 * `active_time`: 距离节点上一次活跃（也就是发送心跳请求）过去的时间，形如 `24h 10m 59s 150ms` 的字符串。单机模式下该字段总为空。

--- a/docs/nightly/zh/reference/sql/information-schema/tables.md
+++ b/docs/nightly/zh/reference/sql/information-schema/tables.md
@@ -10,17 +10,34 @@ DESC TABLES;
 结果如下：
 
 ```sql
-+---------------+--------+------+------+---------+---------------+
-| Column        | Type   | Key  | Null | Default | Semantic Type |
-+---------------+--------+------+------+---------+---------------+
-| table_catalog | String |      | NO   |         | FIELD         |
-| table_schema  | String |      | NO   |         | FIELD         |
-| table_name    | String |      | NO   |         | FIELD         |
-| table_type    | String |      | NO   |         | FIELD         |
-| table_id      | UInt32 |      | YES  |         | FIELD         |
-| engine        | String |      | YES  |         | FIELD         |
-+---------------+--------+------+------+---------+---------------+
-6 rows in set (0.00 sec)
++------------------+----------+------+------+---------+---------------+
+| Column           | Type     | Key  | Null | Default | Semantic Type |
++------------------+----------+------+------+---------+---------------+
+| table_catalog    | String   |      | NO   |         | FIELD         |
+| table_schema     | String   |      | NO   |         | FIELD         |
+| table_name       | String   |      | NO   |         | FIELD         |
+| table_type       | String   |      | NO   |         | FIELD         |
+| table_id         | UInt32   |      | YES  |         | FIELD         |
+| data_length      | UInt64   |      | YES  |         | FIELD         |
+| max_data_length  | UInt64   |      | YES  |         | FIELD         |
+| index_length     | UInt64   |      | YES  |         | FIELD         |
+| max_index_length | UInt64   |      | YES  |         | FIELD         |
+| avg_row_length   | UInt64   |      | YES  |         | FIELD         |
+| engine           | String   |      | YES  |         | FIELD         |
+| version          | UInt64   |      | YES  |         | FIELD         |
+| row_format       | String   |      | YES  |         | FIELD         |
+| table_rows       | UInt64   |      | YES  |         | FIELD         |
+| data_free        | UInt64   |      | YES  |         | FIELD         |
+| auto_increment   | UInt64   |      | YES  |         | FIELD         |
+| create_time      | DateTime |      | YES  |         | FIELD         |
+| update_time      | DateTime |      | YES  |         | FIELD         |
+| check_time       | DateTime |      | YES  |         | FIELD         |
+| table_collation  | String   |      | YES  |         | FIELD         |
+| checksum         | UInt64   |      | YES  |         | FIELD         |
+| create_options   | String   |      | YES  |         | FIELD         |
+| table_comment    | String   |      | YES  |         | FIELD         |
+| temporary        | String   |      | YES  |         | FIELD         |
++------------------+----------+------+------+---------+---------------+
 ```
 
 ```sql
@@ -29,14 +46,33 @@ SELECT * FROM tables WHERE table_schema='public' AND table_name='monitor'\G
 
 ```sql
 *************************** 1. row ***************************
-table_catalog: greptime
- table_schema: public
-   table_name: monitor
-   table_type: BASE TABLE
-     table_id: 1025
-       engine: mito
+   table_catalog: greptime
+    table_schema: public
+      table_name: monitor
+      table_type: BASE TABLE
+        table_id: 1054
+     data_length: 0
+ max_data_length: 0
+    index_length: 0
+max_index_length: 0
+  avg_row_length: 0
+          engine: mito
+         version: 11
+      row_format: Fixed
+      table_rows: 0
+       data_free: 0
+  auto_increment: 0
+     create_time: 2024-07-24 22:06:18.085000
+     update_time: NULL
+      check_time: NULL
+ table_collation: NULL
+        checksum: 0
+  create_options:
+   table_comment: NULL
+       temporary: N
 1 row in set (0.01 sec)
 ```
+
 
 下方的语句是等价的：
 
@@ -61,3 +97,9 @@ SHOW TABLES
   - `VIEW`：视图表
 - `table_id`：表 ID。
 - `engine`：该表使用的存储引擎。
+- `version`: 版本。固定值为 `11`。
+- `create_time`: 表创建的时间戳。
+- `table_comment`: 表的注释。
+- 其他列如 `table_rows`， `row_format` 等不支持，仅用于兼容 MySQL。GreptimeDB 未来可能会支持其中的一些列。
+
+

--- a/docs/v0.9/en/reference/sql/information-schema/build-info.md
+++ b/docs/v0.9/en/reference/sql/information-schema/build-info.md
@@ -12,9 +12,9 @@ The output is as follows:
 
 ```sql
 +------------+------------------------------------------+------------------+-----------+-------------+
-| git_branch | git_commit                               | git_commit_short | git_dirty | pkg_version |
+| git_branch | git_commit                               | git_commit_short | git_clean | pkg_version |
 +------------+------------------------------------------+------------------+-----------+-------------+
-| main       | 92a8e863ded618fe1be93f799360015b4f8f28b6 | 92a8e86          | true      | 0.7.1       |
+|            | c595a56ac89bef78b19a76aa60d8c6bcac7354a5 | c595a56a         | true      | 0.9.0       |
 +------------+------------------------------------------+------------------+-----------+-------------+
 ```
 
@@ -23,6 +23,6 @@ The columns in the output:
 * `branch`: the build git branch name.
 * `git_commit`: the build commit revision.
 * `git_commit_short`: the short commit revision.
-* `git_dirty`:  `true` if the build source directory contains uncommitted changes.
+* `git_clean`:  `true` if the build source directory doesn't contain uncommitted changes.
 * `pkg_version`: the GreptimeDB version.
 

--- a/docs/v0.9/en/reference/sql/information-schema/build-info.md
+++ b/docs/v0.9/en/reference/sql/information-schema/build-info.md
@@ -23,6 +23,6 @@ The columns in the output:
 * `branch`: the build git branch name.
 * `git_commit`: the build commit revision.
 * `git_commit_short`: the short commit revision.
-* `git_clean`:  `true` if the build source directory doesn't contain uncommitted changes.
+* `git_clean`:  `true` if the build source directory contains all the committed changes.
 * `pkg_version`: the GreptimeDB version.
 

--- a/docs/v0.9/en/reference/sql/information-schema/cluster-info.md
+++ b/docs/v0.9/en/reference/sql/information-schema/cluster-info.md
@@ -33,6 +33,7 @@ The columns in table:
 * `peer_type`: the node type, `METASRV`,`FRONTEND`, or `DATANODE` for distributed clusters and `STANDALONE` for standalone deployments.
 * `peer_addr`: the GRPC server address of the node. It's always empty for standalone deployments.
 * `version`: The build version of the node, such as `0.7.2` etc.
+* `git_commit`: The build git commit of the node.
 * `start_time`: The node start time.
 * `uptime`: The uptime of the node, in the format of duration string `24h 10m 59s 150ms`.
 * `active_time`: The duration string in the format of `24h 10m 59s 150ms` since the node's last active time(sending the heartbeats), it's always empty for standalone deployments.

--- a/docs/v0.9/en/reference/sql/information-schema/tables.md
+++ b/docs/v0.9/en/reference/sql/information-schema/tables.md
@@ -10,17 +10,34 @@ DESC TABLES;
 The output is as follows:
 
 ```sql
-+---------------+--------+------+------+---------+---------------+
-| Column        | Type   | Key  | Null | Default | Semantic Type |
-+---------------+--------+------+------+---------+---------------+
-| table_catalog | String |      | NO   |         | FIELD         |
-| table_schema  | String |      | NO   |         | FIELD         |
-| table_name    | String |      | NO   |         | FIELD         |
-| table_type    | String |      | NO   |         | FIELD         |
-| table_id      | UInt32 |      | YES  |         | FIELD         |
-| engine        | String |      | YES  |         | FIELD         |
-+---------------+--------+------+------+---------+---------------+
-6 rows in set (0.00 sec)
++------------------+----------+------+------+---------+---------------+
+| Column           | Type     | Key  | Null | Default | Semantic Type |
++------------------+----------+------+------+---------+---------------+
+| table_catalog    | String   |      | NO   |         | FIELD         |
+| table_schema     | String   |      | NO   |         | FIELD         |
+| table_name       | String   |      | NO   |         | FIELD         |
+| table_type       | String   |      | NO   |         | FIELD         |
+| table_id         | UInt32   |      | YES  |         | FIELD         |
+| data_length      | UInt64   |      | YES  |         | FIELD         |
+| max_data_length  | UInt64   |      | YES  |         | FIELD         |
+| index_length     | UInt64   |      | YES  |         | FIELD         |
+| max_index_length | UInt64   |      | YES  |         | FIELD         |
+| avg_row_length   | UInt64   |      | YES  |         | FIELD         |
+| engine           | String   |      | YES  |         | FIELD         |
+| version          | UInt64   |      | YES  |         | FIELD         |
+| row_format       | String   |      | YES  |         | FIELD         |
+| table_rows       | UInt64   |      | YES  |         | FIELD         |
+| data_free        | UInt64   |      | YES  |         | FIELD         |
+| auto_increment   | UInt64   |      | YES  |         | FIELD         |
+| create_time      | DateTime |      | YES  |         | FIELD         |
+| update_time      | DateTime |      | YES  |         | FIELD         |
+| check_time       | DateTime |      | YES  |         | FIELD         |
+| table_collation  | String   |      | YES  |         | FIELD         |
+| checksum         | UInt64   |      | YES  |         | FIELD         |
+| create_options   | String   |      | YES  |         | FIELD         |
+| table_comment    | String   |      | YES  |         | FIELD         |
+| temporary        | String   |      | YES  |         | FIELD         |
++------------------+----------+------+------+---------+---------------+
 ```
 
 ```sql
@@ -29,12 +46,30 @@ SELECT * FROM tables WHERE table_schema='public' AND table_name='monitor'\G
 
 ```sql
 *************************** 1. row ***************************
-table_catalog: greptime
- table_schema: public
-   table_name: monitor
-   table_type: BASE TABLE
-     table_id: 1025
-       engine: mito
+   table_catalog: greptime
+    table_schema: public
+      table_name: monitor
+      table_type: BASE TABLE
+        table_id: 1054
+     data_length: 0
+ max_data_length: 0
+    index_length: 0
+max_index_length: 0
+  avg_row_length: 0
+          engine: mito
+         version: 11
+      row_format: Fixed
+      table_rows: 0
+       data_free: 0
+  auto_increment: 0
+     create_time: 2024-07-24 22:06:18.085000
+     update_time: NULL
+      check_time: NULL
+ table_collation: NULL
+        checksum: 0
+  create_options:
+   table_comment: NULL
+       temporary: N
 1 row in set (0.01 sec)
 ```
 
@@ -61,3 +96,7 @@ The description of columns in the `TABLES` table is as follows:
   - `VIEW`  for a view.
 - `table_id`: The ID of the table.
 - `engine`: The storage engine of the table used.
+- `version`:  Version. The value is `11` by default.
+- `create_time`: The table created timestamp.
+- `table_comment`: The table comment.
+- Other columns such as `table_rows`, `row_format` etc. are not supported, just for compatibility with MySQL. GreptimeDB may support some of them in the future.

--- a/docs/v0.9/zh/reference/sql/information-schema/build-info.md
+++ b/docs/v0.9/zh/reference/sql/information-schema/build-info.md
@@ -23,5 +23,5 @@ SELECT * FROM BUILD_INFO;
 * `branch`：构建的 git 分支名称。
 * `git_commit`：提交构建的 `commit`。
 * `git_commit_short`：提交构建的 `commit` 缩写。
-* `git_clean`：如果构建源目录不包含未提交的更改，则为 `true`。
+* `git_clean`：如果构建源目录包含了所有提交的更改，则为 `true`。
 * `pkg_version`：GreptimeDB 版本。

--- a/docs/v0.9/zh/reference/sql/information-schema/build-info.md
+++ b/docs/v0.9/zh/reference/sql/information-schema/build-info.md
@@ -12,9 +12,9 @@ SELECT * FROM BUILD_INFO;
 
 ```sql
 +------------+------------------------------------------+------------------+-----------+-------------+
-| git_branch | git_commit                               | git_commit_short | git_dirty | pkg_version |
+| git_branch | git_commit                               | git_commit_short | git_clean | pkg_version |
 +------------+------------------------------------------+------------------+-----------+-------------+
-| main       | 92a8e863ded618fe1be93f799360015b4f8f28b6 | 92a8e86          | true      | 0.7.1       |
+|            | c595a56ac89bef78b19a76aa60d8c6bcac7354a5 | c595a56a         | true      | 0.9.0       |
 +------------+------------------------------------------+------------------+-----------+-------------+
 ```
 
@@ -23,5 +23,5 @@ SELECT * FROM BUILD_INFO;
 * `branch`：构建的 git 分支名称。
 * `git_commit`：提交构建的 `commit`。
 * `git_commit_short`：提交构建的 `commit` 缩写。
-* `git_dirty`：如果构建源目录包含未提交的更改，则为 `true`。
+* `git_clean`：如果构建源目录不包含未提交的更改，则为 `true`。
 * `pkg_version`：GreptimeDB 版本。

--- a/docs/v0.9/zh/reference/sql/information-schema/cluster-info.md
+++ b/docs/v0.9/zh/reference/sql/information-schema/cluster-info.md
@@ -33,6 +33,7 @@ DESC TABLE CLUSTER_INFO;
 * `peer_type`: 节点类型, 分布式集群里可能是 `METASRV`、`FRONTEND` 或者 `DATANODE`。单机模式显示为 `STANDALONE`。
 * `peer_addr`: 节点的 gRPC 服务地址。对于单机部署，该字段总为空。
 * `version`: 节点的版本号，形如 `0.7.2` 的字符串。
+* `git_commit`: 节点编译的 git 版本号。
 * `start_time`: 节点的启动时间。
 * `uptime`: 节点的持续运行时间，形如 `24h 10m 59s 150ms` 的字符串。
 * `active_time`: 距离节点上一次活跃（也就是发送心跳请求）过去的时间，形如 `24h 10m 59s 150ms` 的字符串。单机模式下该字段总为空。

--- a/docs/v0.9/zh/reference/sql/information-schema/tables.md
+++ b/docs/v0.9/zh/reference/sql/information-schema/tables.md
@@ -10,17 +10,34 @@ DESC TABLES;
 结果如下：
 
 ```sql
-+---------------+--------+------+------+---------+---------------+
-| Column        | Type   | Key  | Null | Default | Semantic Type |
-+---------------+--------+------+------+---------+---------------+
-| table_catalog | String |      | NO   |         | FIELD         |
-| table_schema  | String |      | NO   |         | FIELD         |
-| table_name    | String |      | NO   |         | FIELD         |
-| table_type    | String |      | NO   |         | FIELD         |
-| table_id      | UInt32 |      | YES  |         | FIELD         |
-| engine        | String |      | YES  |         | FIELD         |
-+---------------+--------+------+------+---------+---------------+
-6 rows in set (0.00 sec)
++------------------+----------+------+------+---------+---------------+
+| Column           | Type     | Key  | Null | Default | Semantic Type |
++------------------+----------+------+------+---------+---------------+
+| table_catalog    | String   |      | NO   |         | FIELD         |
+| table_schema     | String   |      | NO   |         | FIELD         |
+| table_name       | String   |      | NO   |         | FIELD         |
+| table_type       | String   |      | NO   |         | FIELD         |
+| table_id         | UInt32   |      | YES  |         | FIELD         |
+| data_length      | UInt64   |      | YES  |         | FIELD         |
+| max_data_length  | UInt64   |      | YES  |         | FIELD         |
+| index_length     | UInt64   |      | YES  |         | FIELD         |
+| max_index_length | UInt64   |      | YES  |         | FIELD         |
+| avg_row_length   | UInt64   |      | YES  |         | FIELD         |
+| engine           | String   |      | YES  |         | FIELD         |
+| version          | UInt64   |      | YES  |         | FIELD         |
+| row_format       | String   |      | YES  |         | FIELD         |
+| table_rows       | UInt64   |      | YES  |         | FIELD         |
+| data_free        | UInt64   |      | YES  |         | FIELD         |
+| auto_increment   | UInt64   |      | YES  |         | FIELD         |
+| create_time      | DateTime |      | YES  |         | FIELD         |
+| update_time      | DateTime |      | YES  |         | FIELD         |
+| check_time       | DateTime |      | YES  |         | FIELD         |
+| table_collation  | String   |      | YES  |         | FIELD         |
+| checksum         | UInt64   |      | YES  |         | FIELD         |
+| create_options   | String   |      | YES  |         | FIELD         |
+| table_comment    | String   |      | YES  |         | FIELD         |
+| temporary        | String   |      | YES  |         | FIELD         |
++------------------+----------+------+------+---------+---------------+
 ```
 
 ```sql
@@ -29,14 +46,33 @@ SELECT * FROM tables WHERE table_schema='public' AND table_name='monitor'\G
 
 ```sql
 *************************** 1. row ***************************
-table_catalog: greptime
- table_schema: public
-   table_name: monitor
-   table_type: BASE TABLE
-     table_id: 1025
-       engine: mito
+   table_catalog: greptime
+    table_schema: public
+      table_name: monitor
+      table_type: BASE TABLE
+        table_id: 1054
+     data_length: 0
+ max_data_length: 0
+    index_length: 0
+max_index_length: 0
+  avg_row_length: 0
+          engine: mito
+         version: 11
+      row_format: Fixed
+      table_rows: 0
+       data_free: 0
+  auto_increment: 0
+     create_time: 2024-07-24 22:06:18.085000
+     update_time: NULL
+      check_time: NULL
+ table_collation: NULL
+        checksum: 0
+  create_options:
+   table_comment: NULL
+       temporary: N
 1 row in set (0.01 sec)
 ```
+
 
 下方的语句是等价的：
 
@@ -61,3 +97,9 @@ SHOW TABLES
   - `VIEW`：视图表
 - `table_id`：表 ID。
 - `engine`：该表使用的存储引擎。
+- `version`: 版本。固定值为 `11`。
+- `create_time`: 表创建的时间戳。
+- `table_comment`: 表的注释。
+- 其他列如 `table_rows`， `row_format` 等不支持，仅用于兼容 MySQL。GreptimeDB 未来可能会支持其中的一些列。
+
+


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

Some tables schema in `information_schema` have been changed since v0.9.0, updated the documents to reflect them.


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
