### PR TITLE
refactor:  re-write the cluster installation of quick-start

### DIFF
--- a/docs/nightly/en/getting-started/installation/greptimedb-cluster.md
+++ b/docs/nightly/en/getting-started/installation/greptimedb-cluster.md
@@ -1,73 +1,42 @@
 # GreptimeDB Cluster
 
-The GreptimeDB cluster can run in the [cluster](/contributor-guide/overview.md) mode to scale horizontally.
+The GreptimeDB cluster can run in cluster mode to scale horizontally.
 
-## Install gtctl and run playground
+## Use Docker Compose
 
-[gtctl](https://github.com/GreptimeTeam/gtctl) is the cli tool for managing the GreptimeDB cluster. You can use the following one-line installation(only for Linux and macOS):
+###  Prerequisites
 
-```
-curl -fsSL \
-  https://raw.githubusercontent.com/greptimeteam/gtctl/develop/hack/install.sh |\
-  sh
-```
+Using Docker Compose is the easiest way to run the GreptimeDB cluster. Before starting, make sure you have already installed the Docker.
 
-:::tip Note
-
-For Windows users, due to the complexity and compatibility of running multiple components together, we strongly recommend enabling WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about)) on your operating system, and lunch a latest Ubuntu to proceed.
-
-:::
-
-Once the download is completed, the binary file `gtctl` will be stored in your current directory.
-
-The **fastest** way to experience the GreptimeDB cluster is to use the playground:
+### Step1: Download the YAML file for Docker Compose
 
 ```
-./gtctl playground
+wget https://raw.githubusercontent.com/GreptimeTeam/greptimedb/<%greptimedb-version%>/docker/docker-compose/cluster-with-etcd.yaml
 ```
 
-When the command is executed, the playground will be started in the foreground. You can use `Ctrl+C` to stop the playground. The playground will deploy the minimal GreptimeDB cluster in bare-metal mode on your host.
+### Step2: Start the cluster
 
-If everything is ok, you can visit the Dashboard via `http://localhost:4000/dashboard/`.
+```
+GREPTIMEDB_VERSION=<%greptimedb-version%> \
+  docker compose -f ./cluster-with-etcd.yaml up 
+```
 
-For more details, please refer to [gtctl operations](/reference/gtctl.md).
+If the cluster starts successfully, it will listen on 4000-4003. , you can access the cluster by referencing the [Quick Start](../quick-start.md).
+
+### Clean up
+
+You can use the following command to stop the cluster:
+
+```
+docker compose -f ./cluster-with-etcd.yaml down
+```
+
+By default, the data will be stored in `/tmp/greptimedb-cluster-docker-compose`. You also can remove the data directory if you want to clean up the data.
 
 ## Deploy the GreptimeDB cluster in Kubernetes
 
-If your Kubernetes cluster is ready(a 1.18 or higher version is required), you can use the following command to deploy the GreptimeDB cluster:
-
-```
-./gtctl cluster create mycluster
-```
-
-After the creation is completed, you can use the following command to connect the cluster with MySQL protocol:
-
-```
-./gtctl cluster connect mycluster
-```
-
-You also can use [Helm Charts](/user-guide/operations/deploy-on-kubernetes/overview.md) to deploy the cluster.
-
-:::tip Note
-
-You can use the [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) to create the Kubernetes:
-
-```
-kind create cluster
-```
-
-:::
-
-When the cluster is ready on your Kubernetes, you can use the following commands to expose all the service ports(make sure you already install [kubectl](https://kubernetes.io/docs/tasks/tools/)):
-
-```
-kubectl port-forward svc/mycluster-frontend \
-  4000:4000 \
-  4001:4001 \
-  4002:4002 \
-  4003:4003
-```
+Please refer to [Deploy on Kubernetes](/user-guide/operations/deploy-on-kubernetes/overview.md).
 
 ## Next Steps
 
-Learn how to write data to GreptimeDB in the [Quick Start](../quick-start.md).
+Learn how to write data to GreptimeDB in [Quick Start](../quick-start.md).

--- a/docs/nightly/zh/getting-started/installation/greptimedb-cluster.md
+++ b/docs/nightly/zh/getting-started/installation/greptimedb-cluster.md
@@ -2,69 +2,46 @@
 
 GreptimeDB 可以运行于 [cluster](/contributor-guide/overview.md) 模式以支持水平扩展。
 
-## 安装 gtctl 并运行 playground
+## 使用 Docker Compose
 
-[gtctl](https://github.com/GreptimeTeam/gtctl) 是用于管理 GreptimeDB 的命令行工具。 你可以用如下命令进行安装（只适用于 Linux 和 macOS）:
+### 前置条件
 
-```
-curl -fsSL https://downloads.greptime.cn/releases/scripts/gtctl/install.sh | sh -s -- -s aws
-```
+使用 Docker Compose 是运行 GreptimeDB 集群的最简单方法。开始之前，请确保已经安装了 Docker。
 
-:::tip Note
-
-若您使用 Windows 操作系统，考虑到各组件运行的复杂性和兼容性，我们强烈建议您开启 WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about))，启动一个最新的 Ubuntu 来继续执行 GreptimeDB 集群版的安装。
-
-:::
-
-一旦下载已经完成，`gtctl` 的二进制文件将保存在你的当前目录下。
-
-最快体验 GreptimeDB 分布式集群的方式便是运行 `playground` 命令：
+### 步骤 1: 下载 Docker Compose 的 YAML 文件
 
 ```
-./gtctl playground
+wget https://raw.githubusercontent.com/GreptimeTeam/greptimedb/<%greptimedb-version%>/docker/docker-compose/cluster-with-etcd.yaml
 ```
 
-当命令执行完毕之后，playground 将会在前台启动。你可以使用 `Ctrl+C` 来停止 playground。playground 将会在你的主机上以 bare-metal 模式部署最小的 GreptimeDB 集群。
+### 步骤 2: 启动集群
 
-如果一切正常，你可以使用浏览器访问内置的 Dashboard `http://localhost:4000/dashboard/`。
+```
+GREPTIMEDB_VERSION=<%greptimedb-version%> \
+GREPTIMEDB_REGISTRY=greptime-registry.cn-hangzhou.cr.aliyuncs.com \
+ETCD_REGISTRY=greptime-registry.cn-hangzhou.cr.aliyuncs.com \
+  docker compose -f ./cluster-with-etcd.yaml up 
+```
 
-更多的细节，请参考 [gtctl operations](/reference/gtctl.md)。
+如果集群成功启动，它将监听 4000-4003 端口。你可以通过参考 [快速开始](../quick-start.md#连接到-greptimedb) 访问集群。
+
+### 清理
+
+你可以使用以下命令停止集群：
+
+```
+docker compose -f ./cluster-with-etcd.yaml down
+```
+
+默认情况下，数据将被存储在 `/tmp/greptimedb-cluster-docker-compose`。如果你想清理数据，也可以删除数据目录：
+
+```
+rm -rf /tmp/greptimedb-cluster-docker-compose
+```
 
 ## 在 Kubernetes 中部署 GreptimeDB 集群
 
-如果您的 Kubernetes 集群已经准备就绪（需要 1.18 或更高版本），您可以使用以下命令部署 GreptimeDB 集群：
-
-```
-./gtctl cluster create mycluster --use-greptime-cn-artifacts
-```
-
-创建完成后，你可以使用以下命令连接集群：
-
-```
-./gtctl cluster connect mycluster
-```
-
-您还可以使用 [Helm Charts](/user-guide/operations/deploy-on-kubernetes/overview.md) 来部署集群。
-
-:::tip 提示
-
-您可以使用 [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) 来创建 Kubernetes：
-
-```
-kind create cluster
-```
-
-:::
-
-当集群在您的 Kubernetes 上就绪时，您可以使用以下命令来暴露所有的服务端口（确保您已经安装了 [kubectl](https://kubernetes.io/docs/tasks/tools/)）：
-
-```
-kubectl port-forward svc/mycluster-frontend \
-4000:4000 \
-4001:4001 \
-4002:4002 \
-4003:4003
-```
+请参考 [在 Kubernetes 上部署](/user-guide/operations/deploy-on-kubernetes/overview.md)。
 
 ## 下一步
 

--- a/docs/v0.9/en/getting-started/installation/greptimedb-cluster.md
+++ b/docs/v0.9/en/getting-started/installation/greptimedb-cluster.md
@@ -1,73 +1,42 @@
 # GreptimeDB Cluster
 
-The GreptimeDB cluster can run in the [cluster](/contributor-guide/overview.md) mode to scale horizontally.
+The GreptimeDB cluster can run in cluster mode to scale horizontally.
 
-## Install gtctl and run playground
+## Use Docker Compose
 
-[gtctl](https://github.com/GreptimeTeam/gtctl) is the cli tool for managing the GreptimeDB cluster. You can use the following one-line installation(only for Linux and macOS):
+###  Prerequisites
 
-```
-curl -fsSL \
-  https://raw.githubusercontent.com/greptimeteam/gtctl/develop/hack/install.sh |\
-  sh
-```
+Using Docker Compose is the easiest way to run the GreptimeDB cluster. Before starting, make sure you have already installed the Docker.
 
-:::tip Note
-
-For Windows users, due to the complexity and compatibility of running multiple components together, we strongly recommend enabling WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about)) on your operating system, and lunch a latest Ubuntu to proceed.
-
-:::
-
-Once the download is completed, the binary file `gtctl` will be stored in your current directory.
-
-The **fastest** way to experience the GreptimeDB cluster is to use the playground:
+### Step1: Download the YAML file for Docker Compose
 
 ```
-./gtctl playground
+wget https://raw.githubusercontent.com/GreptimeTeam/greptimedb/<%greptimedb-version%>/docker/docker-compose/cluster-with-etcd.yaml
 ```
 
-When the command is executed, the playground will be started in the foreground. You can use `Ctrl+C` to stop the playground. The playground will deploy the minimal GreptimeDB cluster in bare-metal mode on your host.
+### Step2: Start the cluster
 
-If everything is ok, you can visit the Dashboard via `http://localhost:4000/dashboard/`.
+```
+GREPTIMEDB_VERSION=<%greptimedb-version%> \
+  docker compose -f ./cluster-with-etcd.yaml up 
+```
 
-For more details, please refer to [gtctl operations](/reference/gtctl.md).
+If the cluster starts successfully, it will listen on 4000-4003. , you can access the cluster by referencing the [Quick Start](../quick-start.md).
+
+### Clean up
+
+You can use the following command to stop the cluster:
+
+```
+docker compose -f ./cluster-with-etcd.yaml down
+```
+
+By default, the data will be stored in `/tmp/greptimedb-cluster-docker-compose`. You also can remove the data directory if you want to clean up the data.
 
 ## Deploy the GreptimeDB cluster in Kubernetes
 
-If your Kubernetes cluster is ready(a 1.18 or higher version is required), you can use the following command to deploy the GreptimeDB cluster:
-
-```
-./gtctl cluster create mycluster
-```
-
-After the creation is completed, you can use the following command to connect the cluster with MySQL protocol:
-
-```
-./gtctl cluster connect mycluster
-```
-
-You also can use [Helm Charts](/user-guide/operations/deploy-on-kubernetes/overview.md) to deploy the cluster.
-
-:::tip Note
-
-You can use the [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) to create the Kubernetes:
-
-```
-kind create cluster
-```
-
-:::
-
-When the cluster is ready on your Kubernetes, you can use the following commands to expose all the service ports(make sure you already install [kubectl](https://kubernetes.io/docs/tasks/tools/)):
-
-```
-kubectl port-forward svc/mycluster-frontend \
-  4000:4000 \
-  4001:4001 \
-  4002:4002 \
-  4003:4003
-```
+Please refer to [Deploy on Kubernetes](/user-guide/operations/deploy-on-kubernetes/overview.md).
 
 ## Next Steps
 
-Learn how to write data to GreptimeDB in the [Quick Start](../quick-start.md).
+Learn how to write data to GreptimeDB in [Quick Start](../quick-start.md).

--- a/docs/v0.9/en/getting-started/installation/overview.md
+++ b/docs/v0.9/en/getting-started/installation/overview.md
@@ -1,4 +1,4 @@
 # Overview
 
 - [GreptimeDB Standalone](greptimedb-standalone.md) runs as a standalone system in a single process.
-- [GreptimeDB cluster](greptimedb-cluster.md) runs as a distributed, clustered time series database.
+- [GreptimeDB Cluster](greptimedb-cluster.md) runs as a distributed, clustered time series database.

--- a/docs/v0.9/zh/getting-started/installation/greptimedb-cluster.md
+++ b/docs/v0.9/zh/getting-started/installation/greptimedb-cluster.md
@@ -2,69 +2,46 @@
 
 GreptimeDB 可以运行于 [cluster](/contributor-guide/overview.md) 模式以支持水平扩展。
 
-## 安装 gtctl 并运行 playground
+## 使用 Docker Compose
 
-[gtctl](https://github.com/GreptimeTeam/gtctl) 是用于管理 GreptimeDB 的命令行工具。 你可以用如下命令进行安装（只适用于 Linux 和 macOS）:
+### 前置条件
 
-```
-curl -fsSL https://downloads.greptime.cn/releases/scripts/gtctl/install.sh | sh -s -- -s aws
-```
+使用 Docker Compose 是运行 GreptimeDB 集群的最简单方法。开始之前，请确保已经安装了 Docker。
 
-:::tip Note
-
-若您使用 Windows 操作系统，考虑到各组件运行的复杂性和兼容性，我们强烈建议您开启 WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about))，启动一个最新的 Ubuntu 来继续执行 GreptimeDB 集群版的安装。
-
-:::
-
-一旦下载已经完成，`gtctl` 的二进制文件将保存在你的当前目录下。
-
-最快体验 GreptimeDB 分布式集群的方式便是运行 `playground` 命令：
+### 步骤 1: 下载 Docker Compose 的 YAML 文件
 
 ```
-./gtctl playground
+wget https://raw.githubusercontent.com/GreptimeTeam/greptimedb/<%greptimedb-version%>/docker/docker-compose/cluster-with-etcd.yaml
 ```
 
-当命令执行完毕之后，playground 将会在前台启动。你可以使用 `Ctrl+C` 来停止 playground。playground 将会在你的主机上以 bare-metal 模式部署最小的 GreptimeDB 集群。
+### 步骤 2: 启动集群
 
-如果一切正常，你可以使用浏览器访问内置的 Dashboard `http://localhost:4000/dashboard/`。
+```
+GREPTIMEDB_VERSION=<%greptimedb-version%> \
+GREPTIMEDB_REGISTRY=greptime-registry.cn-hangzhou.cr.aliyuncs.com \
+ETCD_REGISTRY=greptime-registry.cn-hangzhou.cr.aliyuncs.com \
+  docker compose -f ./cluster-with-etcd.yaml up 
+```
 
-更多的细节，请参考 [gtctl operations](/reference/gtctl.md)。
+如果集群成功启动，它将监听 4000-4003 端口。你可以通过参考 [快速开始](../quick-start.md#连接到-greptimedb) 访问集群。
+
+### 清理
+
+你可以使用以下命令停止集群：
+
+```
+docker compose -f ./cluster-with-etcd.yaml down
+```
+
+默认情况下，数据将被存储在 `/tmp/greptimedb-cluster-docker-compose`。如果你想清理数据，也可以删除数据目录：
+
+```
+rm -rf /tmp/greptimedb-cluster-docker-compose
+```
 
 ## 在 Kubernetes 中部署 GreptimeDB 集群
 
-如果您的 Kubernetes 集群已经准备就绪（需要 1.18 或更高版本），您可以使用以下命令部署 GreptimeDB 集群：
-
-```
-./gtctl cluster create mycluster --use-greptime-cn-artifacts
-```
-
-创建完成后，你可以使用以下命令连接集群：
-
-```
-./gtctl cluster connect mycluster
-```
-
-您还可以使用 [Helm Charts](/user-guide/operations/deploy-on-kubernetes/overview.md) 来部署集群。
-
-:::tip 提示
-
-您可以使用 [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) 来创建 Kubernetes：
-
-```
-kind create cluster
-```
-
-:::
-
-当集群在您的 Kubernetes 上就绪时，您可以使用以下命令来暴露所有的服务端口（确保您已经安装了 [kubectl](https://kubernetes.io/docs/tasks/tools/)）：
-
-```
-kubectl port-forward svc/mycluster-frontend \
-4000:4000 \
-4001:4001 \
-4002:4002 \
-4003:4003
-```
+请参考 [在 Kubernetes 上部署](/user-guide/operations/deploy-on-kubernetes/overview.md)。
 
 ## 下一步
 


### PR DESCRIPTION
## What's Changed in this PR

**Re-write** the cluster installation in quick-start:

- Use Docker Compose to deploy the greptimedb cluster instead of using `gtctl`(We always prefer to use container instead of pre-built binary);
- Use helm chart to deploy cluster in Kubernetes;

## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `summary.yml` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
