### PR TITLE
chore: remove dissect dynamic key names

### DIFF
--- a/docs/user-guide/logs/pipeline-config.md
+++ b/docs/user-guide/logs/pipeline-config.md
@@ -118,7 +118,7 @@ In the above example, the configuration of the `dissect` processor includes the 
 Similar to Logstash's dissect pattern, the dissect pattern consists of `%{key}`, where `%{key}` is a field name. For example:
 
 ```
-"%{key1} %{key2} %{+key3} %{+key4/2} %{key5->} %{?key6} %{*key7} %{&key8}"
+"%{key1} %{key2} %{+key3} %{+key4/2} %{key5->} %{?key6}"
 ```
 
 #### Dissect modifiers
@@ -131,20 +131,19 @@ The dissect pattern supports the following modifiers:
 | `+` and `/n` | Concatenates two or more fields in the specified order | `%{+key/2} %{+key/1}` |
 | `->`       | Ignores any repeating characters on the right side    | `%{key1->} %{key2->}` |
 | `?`        | Ignores matching values                               | `%{?key}`            |
-| `*` and `&` | Sets the output key as \* and the output value as &   | `%{*key} %{&key}`  |
 
 #### `dissect` examples
 
 For example, given the following log data:
 
 ```
-"key1 key2 key3 key4 key5 key6 key7 key8"
+"key1 key2 key3 key4 key5 key6"
 ```
 
 Using the following Dissect pattern:
 
 ```
-"%{key1} %{key2} %{+key3} %{+key3/2} %{key5->} %{?key6} %{*key} %{&key}"
+"%{key1} %{key2} %{+key3} %{+key3/2} %{key5->} %{?key6}"
 ```
 
 The result will be:
@@ -154,8 +153,7 @@ The result will be:
   "key1": "key1",
   "key2": "key2",
   "key3": "key3 key4",
-  "key5": "key5",
-  "key7": "key8"
+  "key5": "key5"
 }
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/pipeline-config.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/pipeline-config.md
@@ -120,7 +120,7 @@ processors:
 和 Logstash 的 Dissect 模式类似，Dissect 模式由 `%{key}` 组成，其中 `%{key}` 为一个字段名。例如：
 
 ```
-"%{key1} %{key2} %{+key3} %{+key4/2} %{key5->} %{?key6} %{*key7} %{&key8}"
+"%{key1} %{key2} %{+key3} %{+key4/2} %{key5->} %{?key6}"
 ```
 
 #### Dissect 修饰符
@@ -133,20 +133,19 @@ Dissect 模式支持以下修饰符：
 | `+` 和 `/n` | 按照指定的顺序将两个或多个字段追加到一起 | `%{+key/2} %{+key/1}` |
 | `->`        | 忽略右侧的任何重复字符                   | `%{key1->} %{key2->}` |
 | `?`         | 忽略匹配的值                             | `%{?key}`             |
-| `*` 和 `&`  | 将输出键设置为 \*，输出值设置为 &。      | `%{*key} %{&key}`   |
 
 #### `dissect` 示例
 
 例如，对于以下 log 数据：
 
 ```
-"key1 key2 key3 key4 key5 key6 key7 key8"
+"key1 key2 key3 key4 key5 key6"
 ```
 
 使用以下 Dissect 模式：
 
 ```
-"%{key1} %{key2} %{+key3} %{+key3/2} %{key5->} %{?key6} %{*key} %{&key}"
+"%{key1} %{key2} %{+key3} %{+key3/2} %{key5->} %{?key6}"
 ```
 
 将得到以下结果：
@@ -156,8 +155,7 @@ Dissect 模式支持以下修饰符：
   "key1": "key1",
   "key2": "key2",
   "key3": "key3 key4",
-  "key5": "key5",
-  "key7": "key8"
+  "key5": "key5"
 }
 ```
 


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

> remove dissect reference keys. because the resulting key is uncertain, it can't be specified by transform; if it is certain, you can use name matching to get the specified key directly.

* remove dissect dynamic key names. referable https://github.com/GreptimeTeam/greptimedb/pull/4571


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
