### PR TITLE
fix: always use nightly docs for cloud integration

### DIFF
--- a/docs/greptimecloud/integrations/dbeaver.md
+++ b/docs/greptimecloud/integrations/dbeaver.md
@@ -17,5 +17,4 @@ Input the following connection details:
 
 Click "Test Connection" to verify the connection settings and click "Finish" to save the connection.
 
-For more information on interacting with GreptimeDB using MySQL, refer to the [MySQL protocol documentation](https://docs.greptime.com/user-guide/protocols/mysql.md).
-
+For more information on interacting with GreptimeDB using MySQL, refer to the [MySQL protocol documentation](https://docs.greptime.com/nightly/user-guide/protocols/mysql.md).

--- a/docs/greptimecloud/integrations/grafana.md
+++ b/docs/greptimecloud/integrations/grafana.md
@@ -7,7 +7,7 @@ You have the option to connect GreptimeDB with Grafana using one of three data s
 
 Before using the GreptimeDB data source, it is necessary to manually install the GreptimeDB data source plugin.
 For more information,
-please refer to the [GreptimeDB data source plugin](https://docs.greptime.com/user-guide/integrations/grafana##greptimedb-data-source-plugin) document.
+please refer to the [GreptimeDB data source plugin](https://docs.greptime.com/nightly/user-guide/integrations/grafana##greptimedb-data-source-plugin) document.
 
 Click the Add data source button and select GreptimeDB as the type. Fill in the following URL in the GreptimeDB server URL:
 
@@ -62,5 +62,3 @@ Then click Save & Test button to test the connection.
 Note that you need to use raw SQL editor for panel creation. SQL Builder is not
 supported due to timestamp data type difference between GreptimeDB and vanilla
 MySQL.
-
-

--- a/docs/greptimecloud/integrations/influxdb.md
+++ b/docs/greptimecloud/integrations/influxdb.md
@@ -5,7 +5,7 @@ protocol](https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-proto
 ingestion API over http. The API and authentication is compatible with [InfluxDB
 write protocol
 1.x](https://docs.influxdata.com/influxdb/v1.8/guides/write_data/#write-data-using-the-influxdb-api).
-Please refer to [InfluxDB line protocol](https://docs.greptime.com/user-guide/ingest-data/for-iot/influxdb-line-protocol) of GreptimeDB for more information.
+Please refer to [InfluxDB line protocol](https://docs.greptime.com/nightly/user-guide/ingest-data/for-iot/influxdb-line-protocol) of GreptimeDB for more information.
 
 - URL: `https://<host>/v1/influxdb/write?db=<dbname>`
 - Username: `<username>`

--- a/docs/greptimecloud/integrations/kafka.md
+++ b/docs/greptimecloud/integrations/kafka.md
@@ -8,7 +8,7 @@ Here we are using Vector as the tool to transport data from Kafka to GreptimeDB.
 ## Logs
 
 A sample configuration. Note that you will need to [create your
-pipeline](https://docs.greptime.com/user-guide/logs/pipeline-config/) for log
+pipeline](https://docs.greptime.com/nightly/user-guide/logs/pipeline-config/) for log
 parsing.
 
 ```toml

--- a/docs/greptimecloud/integrations/metabase.md
+++ b/docs/greptimecloud/integrations/metabase.md
@@ -4,7 +4,7 @@
 written in Clojure. You can configure GreptimeDB as a metabase data source from
 a community driver plugin.
 
-See [our docs](https://docs.greptime.com/user-guide/integrations/metabase) for
+See [our docs](https://docs.greptime.com/nightly/user-guide/integrations/metabase) for
 the instructions of plugin installation.
 
 ## Connection information

--- a/docs/greptimecloud/integrations/mysql.md
+++ b/docs/greptimecloud/integrations/mysql.md
@@ -2,7 +2,7 @@
 
 GreptimeCloud exposes GreptimeDB access in MySQL server-client protocol. Most
 standard clients and drivers are compatible and the connection is encrypted with TLS.
-Refer to [MySQL client](https://docs.greptime.com/user-guide/protocols/mysql) of GreptimeDB for more information.
+Refer to [MySQL client](https://docs.greptime.com/nightly/user-guide/protocols/mysql) of GreptimeDB for more information.
 
 To connect to GreptimeCloud in MySQL protocol, using information below:
 

--- a/docs/greptimecloud/integrations/otlp.md
+++ b/docs/greptimecloud/integrations/otlp.md
@@ -13,7 +13,7 @@ use the following information:
 * URL: `https://<host>/v1/otlp/v1/metrics`
 * Headers:
   * `X-Greptime-DB-Name`: `<dbname>`
-  * `Authorization`: `Basic` authentication, which is a Base64 encoded string of `<username>:<password>`. For more information, please refer to [Authentication](https://docs.greptime.com/user-guide/deployments/authentication) and [HTTP API](https://docs.greptime.com/user-guide/protocols/http#authentication)
+  * `Authorization`: `Basic` authentication, which is a Base64 encoded string of `<username>:<password>`. For more information, please refer to [Authentication](https://docs.greptime.com/nightly/user-guide/deployments/authentication) and [HTTP API](https://docs.greptime.com/nightly/user-guide/protocols/http#authentication)
 
 The request uses binary protobuf to encode the payload, so you need to use packages that support `HTTP/protobuf`. For example, in Node.js, you can use [`exporter-trace-otlp-proto`](https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-proto); in Go, you can use [`go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp); in Java, you can use [`io.opentelemetry:opentelemetry-exporter-otlp`](https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-exporter-otlp); and in Python, you can use [`opentelemetry-exporter-otlp-proto-http`](https://pypi.org/project/opentelemetry-exporter-otlp-proto-http/).
 

--- a/docs/greptimecloud/integrations/postgresql.md
+++ b/docs/greptimecloud/integrations/postgresql.md
@@ -4,7 +4,7 @@ GreptimeCloud exposes GreptimeDB access in PostgreSQL v3 wire protocol. Most
 standard clients and drivers are compatible at wire protocol level, and the connection is encrypted with TLS.
 Note that we don't use Postgres' SQL dialect in GreptimeDB, so there can be some statements
 that are unsupported.
-For more information, please refer to [Postgresql documentation](https://docs.greptime.com/user-guide/protocols/postgresql) of GreptimeDB.
+For more information, please refer to [Postgresql documentation](https://docs.greptime.com/nightly/user-guide/protocols/postgresql) of GreptimeDB.
 
 To connect to GreptimeCloud in Postgres wire protocol, using information below:
 

--- a/docs/greptimecloud/integrations/superset.md
+++ b/docs/greptimecloud/integrations/superset.md
@@ -4,7 +4,7 @@
 in Python. You can configure GreptimeDB as a metabase data source from python
 package.
 
-See [our docs](https://docs.greptime.com/user-guide/integrations/superset) for
+See [our docs](https://docs.greptime.com/nightly/user-guide/integrations/superset) for
 the instructions of plugin installation.
 
 ## Connection information

--- a/i18n/zh/docusaurus-plugin-content-docs/current/greptimecloud/integrations/dbeaver.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/greptimecloud/integrations/dbeaver.md
@@ -18,5 +18,4 @@
 
 点击 “Test Connection” 以验证连接设置，然后点击 “Finish” 以保存连接。
 
-有关 MySQL 与 GreptimeDB 交互的更多信息，请参阅 [MySQL 协议文档](https://docs.greptime.cn/user-guide/protocols/mysql.md)。
-
+有关 MySQL 与 GreptimeDB 交互的更多信息，请参阅 [MySQL 协议文档](https://docs.greptime.cn/nightly/user-guide/protocols/mysql.md)。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/greptimecloud/integrations/grafana.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/greptimecloud/integrations/grafana.md
@@ -6,7 +6,7 @@ GreptimeDB 服务可以配置为 [Grafana 数据源](https://grafana.com/docs/gr
 ## GreptimeDB 数据源插件
 
 在使用 GreptimeDB 数据源之前，需要手动安装 GreptimeDB 数据源插件。
-有关更多信息，请参考 [使用 GreptimeDB 数据源文档](https://docs.greptime.cn/user-guide/integrations/grafana#greptimedb-数据源插件)。
+有关更多信息，请参考 [使用 GreptimeDB 数据源文档](https://docs.greptime.cn/nightly/user-guide/integrations/grafana#greptimedb-数据源插件)。
 
 在 Grafana 中单击 Add data source 按钮，选择 GreptimeDB 作为类型。
 
@@ -62,5 +62,3 @@ https://<host>/v1/prometheus
 
 注意目前我们只能使用 SQL 创建 Grafana Panel。由于时间戳数据类型的区别，Grafana
 的 SQL Builder 暂时无法选择时间戳字段。
-
-

--- a/i18n/zh/docusaurus-plugin-content-docs/current/greptimecloud/integrations/influxdb.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/greptimecloud/integrations/influxdb.md
@@ -1,6 +1,6 @@
 # InfluxDB Line Protocol
 
-GreptimeCloud 提供了 [Influxdb line protocol](https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol/) 的 http 接口。该接口和认证与 [InfluxDB write protocol 1.x](https://docs.influxdata.com/influxdb/v1.8/guides/write_data/#write-data-using-the-influxdb-api) 兼容。更多信息请参考 GreptimeDB 的 [InfluxDB 客户端](https://docs.greptime.cn/user-guide/protocols/influxdb-line-protocol)。
+GreptimeCloud 提供了 [Influxdb line protocol](https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol/) 的 http 接口。该接口和认证与 [InfluxDB write protocol 1.x](https://docs.influxdata.com/influxdb/v1.8/guides/write_data/#write-data-using-the-influxdb-api) 兼容。更多信息请参考 GreptimeDB 的 [InfluxDB 客户端](https://docs.greptime.cn/nightly/user-guide/protocols/influxdb-line-protocol)。
 
 - URL: `https://<host>/v1/influxdb/write?db=<dbname>`
 - Username: `<username>`

--- a/i18n/zh/docusaurus-plugin-content-docs/current/greptimecloud/integrations/kafka.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/greptimecloud/integrations/kafka.md
@@ -6,7 +6,7 @@
 ## Logs
 
 以下是一个示例配置。请注意，您需要创建您的
-[Pipeline](https://docs.greptime.com/user-guide/logs/pipeline-config/) 用于日志
+[Pipeline](https://docs.greptime.com/nightly/user-guide/logs/pipeline-config/) 用于日志
 解析。
 
 ```toml

--- a/i18n/zh/docusaurus-plugin-content-docs/current/greptimecloud/integrations/metabase.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/greptimecloud/integrations/metabase.md
@@ -4,7 +4,7 @@
 工具，可以通过社区维护的数据库驱动将 GreptimeDB 添加到 Metabase。
 
 关于插件的安装，请[查看文
-档](https://docs.greptime.com/user-guide/integrations/metabase).
+档](https://docs.greptime.com/nightly/user-guide/integrations/metabase).
 
 ## 连接信息
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/greptimecloud/integrations/mysql.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/greptimecloud/integrations/mysql.md
@@ -1,6 +1,6 @@
 # MySQL
 
-GreptimeCloud 可以通过 MySQL 协议访问，兼容大多数标准客户端和驱动程序，其连接使用 TLS 加密。有关更多信息，请参阅 GreptimeDB 的 [MySQL 客户端](https://docs.greptime.cn/user-guide/clients/mysql)。
+GreptimeCloud 可以通过 MySQL 协议访问，兼容大多数标准客户端和驱动程序，其连接使用 TLS 加密。有关更多信息，请参阅 GreptimeDB 的 [MySQL 客户端](https://docs.greptime.cn/nightly/user-guide/clients/mysql)。
 
 要连接到 GreptimeCloud，使用以下信息：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/greptimecloud/integrations/otlp.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/greptimecloud/integrations/otlp.md
@@ -9,7 +9,7 @@ To send OpenTelemetry Metrics to GreptimeDB through OpenTelemetry SDK libraries,
 * URL: `https://<host>/v1/otlp/v1/metrics`
 * Headers:
   * `X-Greptime-DB-Name`: `<dbname>`
-  * `Authorization`: `Basic` authentication, which is a Base64 encoded string of `<username>:<password>`. For more information, please refer to [Authentication](https://docs.greptime.com/user-guide/deployments/authentication) and [HTTP API](https://docs.greptime.com/user-guide/protocols/http#authentication)
+  * `Authorization`: `Basic` authentication, which is a Base64 encoded string of `<username>:<password>`. For more information, please refer to [Authentication](https://docs.greptime.com/nightly/user-guide/deployments/authentication) and [HTTP API](https://docs.greptime.com/nightly/user-guide/protocols/http#authentication)
 
 The request uses binary protobuf to encode the payload, so you need to use packages that support `HTTP/protobuf`. For example, in Node.js, you can use [`exporter-trace-otlp-proto`](https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-proto); in Go, you can use [`go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp); in Java, you can use [`io.opentelemetry:opentelemetry-exporter-otlp`](https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-exporter-otlp); and in Python, you can use [`opentelemetry-exporter-otlp-proto-http`](https://pypi.org/project/opentelemetry-exporter-otlp-proto-http/).
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/greptimecloud/integrations/postgresql.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/greptimecloud/integrations/postgresql.md
@@ -2,7 +2,7 @@
 
 GreptimeCloud 支持用 PostgreSQL v3 协议访问 GreptimeDB。大多数标准客户端和驱动程序在协议级别上兼容，且连接使用TLS加密。
 请注意，我们在 GreptimeDB 中不使用 Postgres 的 SQL 方言，因此可能有一些不支持的语句。
-有关更多信息，请参考 GreptimeDB 的[Postgresql文档](https://docs.greptime.cn/user-guide/protocols/postgresql)。
+有关更多信息，请参考 GreptimeDB 的[Postgresql文档](https://docs.greptime.cn/nightly/user-guide/protocols/postgresql)。
 
 要使用 Postgres 协议连接到 GreptimeCloud，请使用以下信息：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/greptimecloud/integrations/superset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/greptimecloud/integrations/superset.md
@@ -4,7 +4,7 @@
 以下内容可以帮助你把 GreptimeDB 作为 Superset 的数据源。
 
 关于插件的安装，请[查看文
-档](https://docs.greptime.com/user-guide/integrations/superset).
+档](https://docs.greptime.com/nightly/user-guide/integrations/superset).
 
 ## 连接信息
 


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

*Describe the change in this PR*

Update links in integration section

## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
