### PR TITLE
chore: remove `engine=mito` when creating tables

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -37,8 +37,7 @@ CREATE TABLE grpc_latencies (
   method_name STRING,
   latency DOUBLE,
   PRIMARY KEY (host, method_name)
-)
-engine=mito with('append_mode'='true');
+) with('append_mode'='true');
 ```
 
 - `ts`: The timestamp when the metric was collected. It is the time index column.
@@ -56,8 +55,7 @@ CREATE TABLE app_logs (
   log_level STRING,
   log STRING FULLTEXT,
   PRIMARY KEY (host, log_level)
-)
-engine=mito with('append_mode'='true');
+) with('append_mode'='true');
 ```
 
 - `ts`: The timestamp of the log entry. It is the time index column.

--- a/docs/reference/sql/create.md
+++ b/docs/reference/sql/create.md
@@ -109,7 +109,7 @@ For example, to create a table with the storage data TTL(Time-To-Live) is seven 
 CREATE TABLE IF NOT EXISTS temperatures(
   ts TIMESTAMP TIME INDEX,
   temperature DOUBLE DEFAULT 10,
-) engine=mito with(ttl='7d');
+) with(ttl='7d');
 ```
 
 #### Create a table with custom storage
@@ -119,7 +119,7 @@ Create a table that stores the data in Google Cloud Storage:
 CREATE TABLE IF NOT EXISTS temperatures(
   ts TIMESTAMP TIME INDEX,
   temperature DOUBLE DEFAULT 10,
-) engine=mito with(ttl='7d', storage="Gcs");
+) with(ttl='7d', storage="Gcs");
 ```
 
 #### Create a table with custom compaction options
@@ -132,7 +132,6 @@ CREATE TABLE IF NOT EXISTS temperatures(
   ts TIMESTAMP TIME INDEX,
   temperature DOUBLE DEFAULT 10,
 )
-engine=mito
 with(
   'compaction.type'='twcs',
   'compaction.twcs.time_window'='1d',
@@ -147,7 +146,7 @@ Create an append-only table which disables deduplication.
 CREATE TABLE IF NOT EXISTS temperatures(
   ts TIMESTAMP TIME INDEX,
   temperature DOUBLE DEFAULT 10,
-) engine=mito with('append_mode'='true');
+) with('append_mode'='true');
 ```
 
 #### Create a table with merge mode
@@ -161,7 +160,6 @@ create table if not exists metrics(
     TIME INDEX (ts),
     PRIMARY KEY(host)
 )
-engine=mito
 with('merge_mode'='last_row');
 ```
 
@@ -191,7 +189,6 @@ create table if not exists metrics(
     TIME INDEX (ts),
     PRIMARY KEY(host)
 )
-engine=mito
 with('merge_mode'='last_non_null');
 ```
 
@@ -280,7 +277,7 @@ CREATE TABLE IF NOT EXISTS logs(
   host STRING PRIMARY KEY,
   log STRING FULLTEXT WITH(analyzer = 'Chinese', case_sensitive = 'false'),
   ts TIMESTAMP TIME INDEX
-) ENGINE=mito;
+);
 ```
 
 For more information on using full-text indexing and search, refer to the [Log Query Documentation](/user-guide/logs/query-logs.md).

--- a/docs/user-guide/administration/manage-data/basic-table-operations.md
+++ b/docs/user-guide/administration/manage-data/basic-table-operations.md
@@ -105,7 +105,7 @@ CREATE TABLE monitor (
   cpu FLOAT64 DEFAULT 0,
   memory FLOAT64,
   PRIMARY KEY(host)
-) ENGINE=mito WITH (ttl='7d');
+) WITH (ttl='7d');
 ```
 
 :::warning NOTE
@@ -332,7 +332,7 @@ using the following code to create a table through POST method:
 curl -X POST \
   -H 'authorization: Basic {{authorization if exists}}' \
   -H 'Content-Type: application/x-www-form-urlencoded' \
-  -d 'sql=CREATE TABLE monitor (host STRING, ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP(), cpu FLOAT64 DEFAULT 0, memory FLOAT64, TIME INDEX (ts), PRIMARY KEY(host)) ENGINE=mito' \
+  -d 'sql=CREATE TABLE monitor (host STRING, ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP(), cpu FLOAT64 DEFAULT 0, memory FLOAT64, TIME INDEX (ts), PRIMARY KEY(host))' \
 http://localhost:4000/v1/sql?db=public
 ```
 

--- a/docs/user-guide/administration/remote-wal/cluster-deployment.md
+++ b/docs/user-guide/administration/remote-wal/cluster-deployment.md
@@ -190,7 +190,7 @@ mysql -h 127.0.0.1 -P 4002
 
 Create a distributed table:
 
-```
+```sql
 CREATE TABLE dist_table(
     ts TIMESTAMP DEFAULT current_timestamp(),
     n INT,
@@ -202,8 +202,7 @@ PARTITION ON COLUMNS (n) (
     n < 5,
     n >= 5 AND n < 9,
     n >= 9
-)
-engine=mito;
+);
 ```
 
 Write the data:

--- a/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/quick-start.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/quick-start.md
@@ -37,8 +37,7 @@ CREATE TABLE grpc_latencies (
   method_name STRING,
   latency DOUBLE,
   PRIMARY KEY (host, method_name)
-)
-engine=mito with('append_mode'='true');
+) with('append_mode'='true');
 ```
 
 - `ts`：收集指标时的时间戳，时间索引列。
@@ -56,8 +55,7 @@ CREATE TABLE app_logs (
   log_level STRING,
   log STRING FULLTEXT,
   PRIMARY KEY (host, log_level)
-)
-engine=mito with('append_mode'='true');
+) with('append_mode'='true');
 ```
 
 - `ts`：日志条目的时间戳，时间索引列。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/create.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/create.md
@@ -111,7 +111,7 @@ CREATE TABLE [IF NOT EXISTS] [db.]table_name
 CREATE TABLE IF NOT EXISTS temperatures(
   ts TIMESTAMP TIME INDEX,
   temperature DOUBLE DEFAULT 10,
-) engine=mito with(ttl='7d');
+) with(ttl='7d');
 ```
 
 #### 创建自定义存储的表
@@ -121,7 +121,7 @@ CREATE TABLE IF NOT EXISTS temperatures(
 CREATE TABLE IF NOT EXISTS temperatures(
   ts TIMESTAMP TIME INDEX,
   temperature DOUBLE DEFAULT 10,
-) engine=mito with(ttl='7d', storage="Gcs");
+) with(ttl='7d', storage="Gcs");
 ```
 
 #### 创建自定义 compaction 参数的表
@@ -134,7 +134,6 @@ CREATE TABLE IF NOT EXISTS temperatures(
   ts TIMESTAMP TIME INDEX,
   temperature DOUBLE DEFAULT 10,
 )
-engine=mito
 with(
   'compaction.type'='twcs',
   'compaction.twcs.time_window'='1d',
@@ -149,7 +148,7 @@ with(
 CREATE TABLE IF NOT EXISTS temperatures(
   ts TIMESTAMP TIME INDEX,
   temperature DOUBLE DEFAULT 10,
-) engine=mito with('append_mode'='true');
+) with('append_mode'='true');
 ```
 
 #### 创建带有 merge 模式的表
@@ -165,7 +164,6 @@ create table if not exists metrics(
   TIME INDEX (ts),
   PRIMARY KEY(host)
 )
-engine=mito
 with('merge_mode'='last_row');
 ```
 
@@ -197,7 +195,6 @@ create table if not exists metrics(
   TIME INDEX (ts),
   PRIMARY KEY(host)
 )
-engine=mito
 with('merge_mode'='last_non_null');
 ```
 
@@ -288,7 +285,7 @@ CREATE TABLE IF NOT EXISTS logs(
   host STRING PRIMARY KEY,
   log STRING FULLTEXT WITH(analyzer = 'Chinese', case_sensitive = 'false'),
   ts TIMESTAMP TIME INDEX
-) ENGINE=mito;
+);
 ```
 
 更多关于全文索引和全文搜索的使用，请参阅 [日志查询文档](/user-guide/logs/query-logs.md)。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/administration/manage-data/basic-table-operations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/administration/manage-data/basic-table-operations.md
@@ -87,7 +87,7 @@ CREATE TABLE monitor (
   ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP() TIME INDEX,
   cpu FLOAT64 DEFAULT 0,
   memory FLOAT64,
-  PRIMARY KEY(host)) ENGINE=mito;
+  PRIMARY KEY(host));
 ```
 
 ```sql
@@ -103,7 +103,7 @@ CREATE TABLE monitor (
   cpu FLOAT64 DEFAULT 0,
   memory FLOAT64,
   PRIMARY KEY(host)
-) ENGINE=mito WITH (ttl='7d');
+) WITH (ttl='7d');
 ```
 
 
@@ -329,7 +329,7 @@ DROP DATABASE test;
 curl -X POST \
   -H 'authorization: Basic {{authorization if exists}}' \
   -H 'Content-Type: application/x-www-form-urlencoded' \
-  -d 'sql=CREATE TABLE monitor (host STRING, ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP(), cpu FLOAT64 DEFAULT 0, memory FLOAT64, TIME INDEX (ts), PRIMARY KEY(host)) ENGINE=mito' \
+  -d 'sql=CREATE TABLE monitor (host STRING, ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP(), cpu FLOAT64 DEFAULT 0, memory FLOAT64, TIME INDEX (ts), PRIMARY KEY(host))' \
 http://localhost:4000/v1/sql?db=public
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/administration/remote-wal/cluster-deployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/administration/remote-wal/cluster-deployment.md
@@ -193,7 +193,7 @@ mysql -h 127.0.0.1 -P 4002
 
 创建分布式表：
 
-```
+```sql
 CREATE TABLE dist_table(
     ts TIMESTAMP DEFAULT current_timestamp(),
     n INT,
@@ -205,8 +205,7 @@ PARTITION ON COLUMNS (n) (
     n < 5,
     n >= 5 AND n < 9,
     n >= 9
-)
-engine=mito;
+);
 ```
 
 写入数据：


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

* No need to emphasize the default option
* There is no storage engine documentation yet, and emphasizing `engine=mito` confuse users.


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
