### PR TITLE
docs: add support for altering table options in SQL documentation

### DIFF
--- a/docs/reference/sql/alter.md
+++ b/docs/reference/sql/alter.md
@@ -13,6 +13,7 @@ ALTER TABLE [db.]table
     | DROP COLUMN name
     | MODIFY COLUMN name type
     | RENAME name
+    | SET <option_name>=<option_value> [, ...]
    ]
 ```
 
@@ -64,6 +65,17 @@ ALTER TABLE monitor MODIFY COLUMN load_15 STRING;
 ```
 
 The modified column cannot be a tag (primary key) or time index, and it must be nullable to ensure that the data can be safely converted (returns `NULL` on cast failures).
+
+### Alter table options
+
+`ALTER TABLE` statements can also be used to change the options of tables. 
+
+Currently following options are supported:
+- `ttl`: the retention time of data in table
+
+```sql
+ALTER TABLE monitor SET 'ttl'='1d';
+```
 
 ### Rename table
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/alter.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/alter.md
@@ -13,6 +13,7 @@ ALTER TABLE [db.]table
     | DROP COLUMN name
     | MODIFY COLUMN name type
     | RENAME name
+    | SET <option_name>=<option_value> [, ...]
    ]
 ```
 
@@ -65,6 +66,16 @@ ALTER TABLE monitor MODIFY COLUMN load_15 STRING;
 ```
 
 被修改的的列不能是 tag 列（primary key）或 time index 列，同时该列必须允许空值 `NULL` 存在来保证数据能够安全地进行转换（转换失败时返回 `NULL`）。
+
+### 修改表的参数
+
+`ALTER TABLE` 语句也可以用来更改表的选项。
+当前支持修改以下表选项：
+- `ttl`: 表数据的保留时间
+
+```sql
+ALTER TABLE monitor SET 'ttl'='1d';
+```
 
 ### 重命名表
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.9/reference/sql/alter.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.9/reference/sql/alter.md
@@ -13,6 +13,7 @@ ALTER TABLE [db.]table
     | DROP COLUMN name
     | MODIFY COLUMN name type
     | RENAME name
+    | SET <option_name>=<option_value> [, ...]
    ]
 ```
 
@@ -65,6 +66,16 @@ ALTER TABLE monitor MODIFY COLUMN load_15 STRING;
 ```
 
 被修改的的列不能是 tag 列（primary key）或 time index 列，同时该列必须允许空值 `NULL` 存在来保证数据能够安全地进行转换（转换失败时返回 `NULL`）。
+
+### 修改表的参数
+
+`ALTER TABLE` 语句也可以用来更改表的选项。
+当前支持修改以下表选项：
+- `ttl`: 表数据的保留时间
+
+```sql
+ALTER TABLE monitor SET 'ttl'='1d';
+```
 
 ### 重命名表
 

--- a/versioned_docs/version-0.9/reference/sql/alter.md
+++ b/versioned_docs/version-0.9/reference/sql/alter.md
@@ -13,6 +13,7 @@ ALTER TABLE [db.]table
     | DROP COLUMN name
     | MODIFY COLUMN name type
     | RENAME name
+    | SET <option_name>=<option_value> [, ...]
    ]
 ```
 
@@ -64,6 +65,17 @@ ALTER TABLE monitor MODIFY COLUMN load_15 STRING;
 ```
 
 The modified column cannot be a tag (primary key) or time index, and it must be nullable to ensure that the data can be safely converted (returns `NULL` on cast failures).
+
+### Alter table options
+
+`ALTER TABLE` statements can also be used to change the options of tables. 
+
+Currently following options are supported:
+- `ttl`: the retention time of data in table
+
+```sql
+ALTER TABLE monitor SET 'ttl'='1d';
+```
 
 ### Rename table
 


### PR DESCRIPTION

## What's Changed in this PR

closes #1249

 - Introduce `SET <option_name>=<option_value>` syntax for `ALTER TABLE`.
 - Document the `ttl` option for setting data retention time.
 - Update English and Chinese documentation for current and version 0.9.


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
