### PR TITLE
docs: alter compaction options

### DIFF
--- a/docs/reference/sql/alter.md
+++ b/docs/reference/sql/alter.md
@@ -71,7 +71,13 @@ The modified column cannot be a tag (primary key) or time index, and it must be 
 `ALTER TABLE` statements can also be used to change the options of tables. 
 
 Currently following options are supported:
-- `ttl`: the retention time of data in table
+- `ttl`: the retention time of data in table.
+- `compaction.twcs.time_window`: the time window parameter of TWCS compaction strategy.
+- `compaction.twcs.max_output_file_size`: the maximum allowed output file size of TWCS compaction strategy.
+- `compaction.twcs.max_active_window_runs`: the maximum allowed sorted runs in the active window of TWCS compaction strategy.
+- `compaction.twcs.max_inactive_window_runs`: the maximum allowed sorted runs in the inactive windows of TWCS compaction strategy.
+- `compaction.twcs.max_active_window_files`: the maximum allowed number of files in the active window of TWCS compaction strategy.
+- `compaction.twcs.max_inactive_window_files`: the maximum allowed number of files in the inactive windows of TWCS compaction strategy.
 
 ```sql
 ALTER TABLE monitor SET 'ttl'='1d';

--- a/docs/reference/sql/alter.md
+++ b/docs/reference/sql/alter.md
@@ -81,6 +81,18 @@ Currently following options are supported:
 
 ```sql
 ALTER TABLE monitor SET 'ttl'='1d';
+
+ALTER TABLE monitor SET 'compaction.twcs.time_window'='2h';
+
+ALTER TABLE monitor SET 'compaction.twcs.max_output_file_size'='500MB';
+
+ALTER TABLE monitor SET 'compaction.twcs.max_inactive_window_files'='2';
+
+ALTER TABLE monitor SET 'compaction.twcs.max_active_window_files'='2';
+
+ALTER TABLE monitor SET 'compaction.twcs.max_active_window_runs'='6';
+
+ALTER TABLE monitor SET 'compaction.twcs.max_inactive_window_runs'='6';
 ```
 
 ### Rename table

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/alter.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/alter.md
@@ -82,6 +82,18 @@ ALTER TABLE monitor MODIFY COLUMN load_15 STRING;
 
 ```sql
 ALTER TABLE monitor SET 'ttl'='1d';
+
+ALTER TABLE monitor SET 'compaction.twcs.time_window'='2h';
+
+ALTER TABLE monitor SET 'compaction.twcs.max_output_file_size'='500MB';
+
+ALTER TABLE monitor SET 'compaction.twcs.max_inactive_window_files'='2';
+
+ALTER TABLE monitor SET 'compaction.twcs.max_active_window_files'='2';
+
+ALTER TABLE monitor SET 'compaction.twcs.max_active_window_runs'='6';
+
+ALTER TABLE monitor SET 'compaction.twcs.max_inactive_window_runs'='6';
 ```
 
 ### 重命名表

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/alter.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/alter.md
@@ -71,7 +71,14 @@ ALTER TABLE monitor MODIFY COLUMN load_15 STRING;
 
 `ALTER TABLE` 语句也可以用来更改表的选项。
 当前支持修改以下表选项：
-- `ttl`: 表数据的保留时间
+- `ttl`: 表数据的保留时间。
+- `compaction.twcs.time_window`: TWCS compaction 策略的时间窗口。
+- `compaction.twcs.max_output_file_size`: TWCS compaction 策略的最大允许输出文件大小。
+- `compaction.twcs.max_active_window_runs`: TWCS compaction 策略的活跃窗口中最多允许的有序组数量。
+- `compaction.twcs.max_inactive_window_runs`: TWCS compaction 策略的非活跃窗口中最多允许的有序组数量。
+- `compaction.twcs.max_active_window_files`: TWCS compaction 策略的活跃窗口中最多允许的文件数量。
+- `compaction.twcs.max_inactive_window_files`: TWCS compaction 策略的非活跃窗口中最多允许的文件数量。
+
 
 ```sql
 ALTER TABLE monitor SET 'ttl'='1d';


### PR DESCRIPTION

## What's Changed in this PR

- closes #1283 

Enhance ALTER TABLE documentation with TWCS options

 • Updated English and Chinese documentation for ALTER TABLE to include new options related to TWCS (Time Window Compaction Strategy).
 • Added descriptions for compaction.twcs.time_window, max_output_file_size, max_active_window_runs, max_inactive_window_runs, max_active_window_files, and
   max_inactive_window_files.


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
