### PR TITLE
docs: remove alter options docs from v0.9

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.9/reference/sql/alter.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.9/reference/sql/alter.md
@@ -13,7 +13,6 @@ ALTER TABLE [db.]table
     | DROP COLUMN name
     | MODIFY COLUMN name type
     | RENAME name
-    | SET <option_name>=<option_value> [, ...]
    ]
 ```
 
@@ -66,16 +65,6 @@ ALTER TABLE monitor MODIFY COLUMN load_15 STRING;
 ```
 
 被修改的的列不能是 tag 列（primary key）或 time index 列，同时该列必须允许空值 `NULL` 存在来保证数据能够安全地进行转换（转换失败时返回 `NULL`）。
-
-### 修改表的参数
-
-`ALTER TABLE` 语句也可以用来更改表的选项。
-当前支持修改以下表选项：
-- `ttl`: 表数据的保留时间
-
-```sql
-ALTER TABLE monitor SET 'ttl'='1d';
-```
 
 ### 重命名表
 

--- a/versioned_docs/version-0.9/reference/sql/alter.md
+++ b/versioned_docs/version-0.9/reference/sql/alter.md
@@ -13,7 +13,6 @@ ALTER TABLE [db.]table
     | DROP COLUMN name
     | MODIFY COLUMN name type
     | RENAME name
-    | SET <option_name>=<option_value> [, ...]
    ]
 ```
 
@@ -65,17 +64,6 @@ ALTER TABLE monitor MODIFY COLUMN load_15 STRING;
 ```
 
 The modified column cannot be a tag (primary key) or time index, and it must be nullable to ensure that the data can be safely converted (returns `NULL` on cast failures).
-
-### Alter table options
-
-`ALTER TABLE` statements can also be used to change the options of tables. 
-
-Currently following options are supported:
-- `ttl`: the retention time of data in table
-
-```sql
-ALTER TABLE monitor SET 'ttl'='1d';
-```
 
 ### Rename table
 


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

Remove alter options section from v0.9 docs.

Related to https://github.com/GreptimeTeam/greptimedb/issues/5026

## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
