### PR TITLE
docs: add greptime grafana docker image

### DIFF
--- a/docs/user-guide/integrations/grafana.md
+++ b/docs/user-guide/integrations/grafana.md
@@ -28,6 +28,10 @@ directory](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafa
   ```shell
   grafana cli --pluginUrl https://github.com/GreptimeTeam/greptimedb-grafana-datasource/releases/latest/download/info8fcc-greptimedb-datasource.zip plugins install info8fcc
   ```
+- Use our [prebuilt Grafana docker
+  image](https://hub.docker.com/r/greptime/grafana-greptimedb), which ships the
+  plugin by default: `docker run -p 3000:3000
+  greptime/grafana-greptimedb:latest`
 
 Note that you may need to restart your grafana server after installing the plugin.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/integrations/grafana.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/integrations/grafana.md
@@ -26,6 +26,10 @@ GreptimeDB 数据源插件目前仅支持在本地 Grafana 中的安装，
   ```shell
   grafana cli --pluginUrl https://github.com/GreptimeTeam/greptimedb-grafana-datasource/releases/latest/download/info8fcc-greptimedb-datasource.zip plugins install info8fcc
   ```
+- 使用我们 [预构建的 Grafana 镜
+  像](https://hub.docker.com/r/greptime/grafana-greptimedb)，已经提前包含了
+  GreptimeDB 数据源插件 `docker run -p 3000:3000
+  greptime/grafana-greptimedb:latest`
 
 注意，安装插件后可能需要重新启动 Grafana 服务器。
 


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

*Describe the change in this PR*

Add an alternative installation method for grafana datasource plugin.

## Checklist

- [x] Please confirm that all corresponding versions of the documents have been revised.
- [x] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
