### PR TITLE
fix: kafka deploy version

### DIFF
--- a/docs/user-guide/administration/remote-wal/cluster-deployment.md
+++ b/docs/user-guide/administration/remote-wal/cluster-deployment.md
@@ -96,7 +96,7 @@ metadata:
 spec:
   kafka:
     version: 3.9.0
-    metadataVersion: 3.9
+    metadataVersion: "3.9"
     listeners:
       - name: plain
         port: 9092

--- a/docs/user-guide/administration/remote-wal/cluster-deployment.md
+++ b/docs/user-guide/administration/remote-wal/cluster-deployment.md
@@ -95,8 +95,8 @@ metadata:
     strimzi.io/kraft: enabled
 spec:
   kafka:
-    version: 3.7.0
-    metadataVersion: 3.7-IV4
+    version: 3.9.0
+    metadataVersion: 3.9
     listeners:
       - name: plain
         port: 9092

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/administration/remote-wal/cluster-deployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/administration/remote-wal/cluster-deployment.md
@@ -96,8 +96,8 @@ metadata:
     strimzi.io/kraft: enabled
 spec:
   kafka:
-    version: 3.7.0
-    metadataVersion: 3.7-IV4
+    version: 3.9.0
+    metadataVersion: 3.9
     listeners:
       - name: plain
         port: 9092

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/administration/remote-wal/cluster-deployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/administration/remote-wal/cluster-deployment.md
@@ -97,7 +97,7 @@ metadata:
 spec:
   kafka:
     version: 3.9.0
-    metadataVersion: 3.9
+    metadataVersion: "3.9"
     listeners:
       - name: plain
         port: 9092

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.11/user-guide/administration/remote-wal/cluster-deployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.11/user-guide/administration/remote-wal/cluster-deployment.md
@@ -96,8 +96,8 @@ metadata:
     strimzi.io/kraft: enabled
 spec:
   kafka:
-    version: 3.7.0
-    metadataVersion: 3.7-IV4
+    version: 3.9.0
+    metadataVersion: 3.9
     listeners:
       - name: plain
         port: 9092

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.11/user-guide/administration/remote-wal/cluster-deployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.11/user-guide/administration/remote-wal/cluster-deployment.md
@@ -97,7 +97,7 @@ metadata:
 spec:
   kafka:
     version: 3.9.0
-    metadataVersion: 3.9
+    metadataVersion: "3.9"
     listeners:
       - name: plain
         port: 9092

--- a/versioned_docs/version-0.11/user-guide/administration/remote-wal/cluster-deployment.md
+++ b/versioned_docs/version-0.11/user-guide/administration/remote-wal/cluster-deployment.md
@@ -96,7 +96,7 @@ metadata:
 spec:
   kafka:
     version: 3.9.0
-    metadataVersion: 3.9
+    metadataVersion: "3.9"
     listeners:
       - name: plain
         port: 9092

--- a/versioned_docs/version-0.11/user-guide/administration/remote-wal/cluster-deployment.md
+++ b/versioned_docs/version-0.11/user-guide/administration/remote-wal/cluster-deployment.md
@@ -95,8 +95,8 @@ metadata:
     strimzi.io/kraft: enabled
 spec:
   kafka:
-    version: 3.7.0
-    metadataVersion: 3.7-IV4
+    version: 3.9.0
+    metadataVersion: 3.9
     listeners:
       - name: plain
         port: 9092


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

Fixed to: `2024-12-24 07:45:12 WARN  AbstractOperator:566 - Reconciliation #4(watch) Kafka(default/kafka-wal): Failed to reconcile io.strimzi.operator.cluster.model.KafkaVersion$UnsupportedKafkaVersionException: Unsupported Kafka.spec.kafka.version: 3.7.0. Supported versions are: [3.8.0, 3.8.1, 3.9.0]`


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
