### PR TITLE
docs: release v0.11.2 and update cache related docs

### DIFF
--- a/blog/release-0-11-2.md
+++ b/blog/release-0-11-2.md
@@ -1,0 +1,108 @@
+---
+keywords: [release, GreptimeDB, changelog, v0.11.2]
+description: GreptimeDB v0.11.2 Changelog
+date: 2024-12-21
+---
+
+# v0.11.2
+
+Release date: January 04, 2025
+
+
+This version fixes the following critical issues:
+- Automatic alteration of the table may lead to inconsistent metadata.
+- Compaction doesn't use files in the local cache.
+
+
+### Notices
+This version modifies the default object storage cache paths:
+- The path for write cache has changed from the default `{data_home}/object_cache/write` to `{data_home}/cache/object/write`.
+- The path for read cache has changed from the default `{data_home}/object_cache/read` to `{data_home}/cache/object/read`.
+- When configuring write cache and read cache, only the root directory of the cache needs to be specified, which defaults to `{data_home}`.
+
+
+We recommend that users no longer manually configure the cache paths after version 0.11, as the database can automatically set appropriate paths.
+
+
+### 🚀 Features
+
+* feat(bloom-filter): add memory control for creator by [@zhongzc](https://github.com/zhongzc) in [#5185](https://github.com/GreptimeTeam/greptimedb/pull/5185)
+* feat(bloom-filter): add bloom filter reader by [@zhongzc](https://github.com/zhongzc) in [#5204](https://github.com/GreptimeTeam/greptimedb/pull/5204)
+* feat(index-cache): abstract `IndexCache` to be shared by multi types of indexes by [@zhongzc](https://github.com/zhongzc) in [#5219](https://github.com/GreptimeTeam/greptimedb/pull/5219)
+* feat: logs query endpoint by [@waynexia](https://github.com/waynexia) in [#5202](https://github.com/GreptimeTeam/greptimedb/pull/5202)
+* feat(mito): parquet memtable reader by [@v0y4g3r](https://github.com/v0y4g3r) in [#4967](https://github.com/GreptimeTeam/greptimedb/pull/4967)
+* feat(bloom-filter): impl batch push to creator by [@zhongzc](https://github.com/zhongzc) in [#5225](https://github.com/GreptimeTeam/greptimedb/pull/5225)
+* feat: introduce the Limiter in frontend to limit the requests by in-flight write bytes size. by [@zyy17](https://github.com/zyy17) in [#5231](https://github.com/GreptimeTeam/greptimedb/pull/5231)
+* feat: add some critical metrics to flownode by [@waynexia](https://github.com/waynexia) in [#5235](https://github.com/GreptimeTeam/greptimedb/pull/5235)
+* feat(flow): check sink table mismatch on flow creation by [@discord9](https://github.com/discord9) in [#5112](https://github.com/GreptimeTeam/greptimedb/pull/5112)
+* feat: Add `vec_mul` function. by [@linyihai](https://github.com/linyihai) in [#5205](https://github.com/GreptimeTeam/greptimedb/pull/5205)
+* feat(bloom-filter): integrate indexer with mito2  by [@zhongzc](https://github.com/zhongzc) in [#5236](https://github.com/GreptimeTeam/greptimedb/pull/5236)
+* feat(bloom-filter): bloom filter applier by [@waynexia](https://github.com/waynexia) in [#5220](https://github.com/GreptimeTeam/greptimedb/pull/5220)
+* feat(config): add bloom filter config by [@zhongzc](https://github.com/zhongzc) in [#5237](https://github.com/GreptimeTeam/greptimedb/pull/5237)
+* feat(mito): add bloom filter read metrics by [@zhongzc](https://github.com/zhongzc) in [#5239](https://github.com/GreptimeTeam/greptimedb/pull/5239)
+* feat: init PgElection with candidate registration by [@CookiePieWw](https://github.com/CookiePieWw) in [#5209](https://github.com/GreptimeTeam/greptimedb/pull/5209)
+* feat(vector): add vector functions `vec_sub` & `vec_sum` & `vec_elem_sum` by [@KKould](https://github.com/KKould) in [#5230](https://github.com/GreptimeTeam/greptimedb/pull/5230)
+* feat: add sqlness test for bloom filter index by [@waynexia](https://github.com/waynexia) in [#5240](https://github.com/GreptimeTeam/greptimedb/pull/5240)
+* feat: add `vec_div` function by [@linyihai](https://github.com/linyihai) in [#5245](https://github.com/GreptimeTeam/greptimedb/pull/5245)
+* feat: update partition duration of memtable using compaction window by [@evenyag](https://github.com/evenyag) in [#5197](https://github.com/GreptimeTeam/greptimedb/pull/5197)
+* feat: override `__sequence` on creating SST to save space and CPU by [@waynexia](https://github.com/waynexia) in [#5252](https://github.com/GreptimeTeam/greptimedb/pull/5252)
+* feat(log-query): implement pagination with limit and offset parameters by [@waynexia](https://github.com/waynexia) in [#5241](https://github.com/GreptimeTeam/greptimedb/pull/5241)
+* feat: hints all in one by [@fengjiachun](https://github.com/fengjiachun) in [#5194](https://github.com/GreptimeTeam/greptimedb/pull/5194)
+* feat: support add if not exists in the gRPC alter kind by [@evenyag](https://github.com/evenyag) in [#5273](https://github.com/GreptimeTeam/greptimedb/pull/5273)
+* feat: bump opendal and switch prometheus layer to the upstream impl by [@waynexia](https://github.com/waynexia) in [#5179](https://github.com/GreptimeTeam/greptimedb/pull/5179)
+
+### 🐛 Bug Fixes
+
+* fix: dead links by [@nicecui](https://github.com/nicecui) in [#5212](https://github.com/GreptimeTeam/greptimedb/pull/5212)
+* fix: correct write cache's metric labels by [@waynexia](https://github.com/waynexia) in [#5227](https://github.com/GreptimeTeam/greptimedb/pull/5227)
+* fix: flow compare null values by [@discord9](https://github.com/discord9) in [#5234](https://github.com/GreptimeTeam/greptimedb/pull/5234)
+* fix: disable path label in opendal for now by [@shuiyisong](https://github.com/shuiyisong) in [#5247](https://github.com/GreptimeTeam/greptimedb/pull/5247)
+* fix: implement a CacheStrategy to ensure compaction use cache correctly by [@evenyag](https://github.com/evenyag) in [#5254](https://github.com/GreptimeTeam/greptimedb/pull/5254)
+* fix(bloom-filter): skip applying for non-indexed columns by [@zhongzc](https://github.com/zhongzc) in [#5246](https://github.com/GreptimeTeam/greptimedb/pull/5246)
+* fix: correct invalid testing feature gate usage by [@sunng87](https://github.com/sunng87) in [#5258](https://github.com/GreptimeTeam/greptimedb/pull/5258)
+* fix: import tokio-metrics and tokio-metrics-collector by [@chenmortal](https://github.com/chenmortal) in [#5264](https://github.com/GreptimeTeam/greptimedb/pull/5264)
+* fix(flow): flow's table schema cache by [@discord9](https://github.com/discord9) in [#5251](https://github.com/GreptimeTeam/greptimedb/pull/5251)
+* fix: flow handle reordered inserts by [@discord9](https://github.com/discord9) in [#5275](https://github.com/GreptimeTeam/greptimedb/pull/5275)
+* fix: better fmt check from 40s to 4s by [@yihong0618](https://github.com/yihong0618) in [#5279](https://github.com/GreptimeTeam/greptimedb/pull/5279)
+
+### 🚜 Refactor
+
+* refactor: remove unnecessary wrap by [@WenyXu](https://github.com/WenyXu) in [#5221](https://github.com/GreptimeTeam/greptimedb/pull/5221)
+* refactor: support to convert time string to timestamp in `convert_value()` by [@zyy17](https://github.com/zyy17) in [#5242](https://github.com/GreptimeTeam/greptimedb/pull/5242)
+* refactor: adjust index cache page size by [@CookiePieWw](https://github.com/CookiePieWw) in [#5267](https://github.com/GreptimeTeam/greptimedb/pull/5267)
+* refactor: flow replace check&better error msg by [@discord9](https://github.com/discord9) in [#5277](https://github.com/GreptimeTeam/greptimedb/pull/5277)
+
+### 📚 Documentation
+
+* docs: add greptimedb-operator project link in 'Tools & Extensions' and other small improvements by [@zyy17](https://github.com/zyy17) in [#5216](https://github.com/GreptimeTeam/greptimedb/pull/5216)
+
+### ⚙️ Miscellaneous Tasks
+
+* chore: adjust fuzz tests cfg by [@WenyXu](https://github.com/WenyXu) in [#5207](https://github.com/GreptimeTeam/greptimedb/pull/5207)
+* ci: fix nightly ci task on nix build by [@sunng87](https://github.com/sunng87) in [#5198](https://github.com/GreptimeTeam/greptimedb/pull/5198)
+* chore: bump opendal to fork version to fix prometheus layer by [@waynexia](https://github.com/waynexia) in [#5223](https://github.com/GreptimeTeam/greptimedb/pull/5223)
+* ci: support to pack multiple files in upload-artifacts action by [@zyy17](https://github.com/zyy17) in [#5228](https://github.com/GreptimeTeam/greptimedb/pull/5228)
+* chore: add log for converting region to follower by [@WenyXu](https://github.com/WenyXu) in [#5222](https://github.com/GreptimeTeam/greptimedb/pull/5222)
+* ci: upload .pdb files too for better windows debug by [@discord9](https://github.com/discord9) in [#5224](https://github.com/GreptimeTeam/greptimedb/pull/5224)
+* chore: add more info for pipeline dryrun API by [@paomian](https://github.com/paomian) in [#5232](https://github.com/GreptimeTeam/greptimedb/pull/5232)
+* ci: make sure clippy passes before running tests by [@sunng87](https://github.com/sunng87) in [#5253](https://github.com/GreptimeTeam/greptimedb/pull/5253)
+* ci: disable pyo3 build tasks by [@sunng87](https://github.com/sunng87) in [#5256](https://github.com/GreptimeTeam/greptimedb/pull/5256)
+* chore: typo by [@discord9](https://github.com/discord9) in [#5265](https://github.com/GreptimeTeam/greptimedb/pull/5265)
+* ci: update nix setup by [@sunng87](https://github.com/sunng87) in [#5272](https://github.com/GreptimeTeam/greptimedb/pull/5272)
+* chore: suppress list warning by [@v0y4g3r](https://github.com/v0y4g3r) in [#5280](https://github.com/GreptimeTeam/greptimedb/pull/5280)
+* chore: update greptime-proto to include add_if_not_exists by [@evenyag](https://github.com/evenyag) in [#5289](https://github.com/GreptimeTeam/greptimedb/pull/5289)
+
+### Build
+
+* build: use 8xlarge as arm default by [@evenyag](https://github.com/evenyag) in [#5214](https://github.com/GreptimeTeam/greptimedb/pull/5214)
+
+## New Contributors
+
+* [@yihong0618](https://github.com/yihong0618) made their first contribution in [#5279](https://github.com/GreptimeTeam/greptimedb/pull/5279)
+* [@chenmortal](https://github.com/chenmortal) made their first contribution in [#5264](https://github.com/GreptimeTeam/greptimedb/pull/5264)
+
+## All Contributors
+
+We would like to thank the following contributors from the GreptimeDB community:
+
+[@CookiePieWw](https://github.com/CookiePieWw), [@KKould](https://github.com/KKould), [@WenyXu](https://github.com/WenyXu), [@chenmortal](https://github.com/chenmortal), [@discord9](https://github.com/discord9), [@evenyag](https://github.com/evenyag), [@fengjiachun](https://github.com/fengjiachun), [@linyihai](https://github.com/linyihai), [@nicecui](https://github.com/nicecui), [@paomian](https://github.com/paomian), [@shuiyisong](https://github.com/shuiyisong), [@sunng87](https://github.com/sunng87), [@v0y4g3r](https://github.com/v0y4g3r), [@waynexia](https://github.com/waynexia), [@yihong0618](https://github.com/yihong0618), [@zhongzc](https://github.com/zhongzc), [@zyy17](https://github.com/zyy17)

--- a/blog/release-0-7-2.md
+++ b/blog/release-0-7-2.md
@@ -6,7 +6,7 @@ date: 2024-04-08
 
 Release date: April 08, 2024
 
-This is a patch release, containing a critial bug fix to avoid wrongly delete data files ([#3635](https://github.com/GreptimeTeam/greptimedb/pull/3635)).
+This is a patch release, containing a critical bug fix to avoid wrongly delete data files ([#3635](https://github.com/GreptimeTeam/greptimedb/pull/3635)).
 
 **It's highly recommended to upgrade to this version if you're using v0.7.**
 

--- a/blog/release-0-7-2.md
+++ b/blog/release-0-7-2.md
@@ -1,4 +1,6 @@
 ---
+keywords: [release, GreptimeDB, changelog, v0.7.2]
+description: GreptimeDB v0.7.2 Changelog
 date: 2024-04-08
 ---
 

--- a/docs/user-guide/administration/performance-tuning-tips.md
+++ b/docs/user-guide/administration/performance-tuning-tips.md
@@ -29,7 +29,7 @@ It's highly recommended to enable the object store read cache and the write cach
 
 The read cache stores objects or ranges on the local disk to avoid fetching the same range from the remote again. The following example shows how to enable the read cache for S3.
 
-- The `cache_path` is the directory to store cached objects, defaults to `{data_home}/object_cache/read` since `v0.11`.
+- The `cache_path` is the directory to store cached objects. You don't need to set it since `v0.11`.
 - The `cache_capacity` is the capacity of the cache, defaults to `5Gib` since `v0.11`. It's recommended to leave at least 1/10 of the total disk space for it.
 
 ```toml
@@ -41,7 +41,8 @@ access_key_id = "****"
 secret_access_key = "****"
 endpoint = "https://s3.amazonaws.com/"
 region = "your-region"
-cache_path = "/path/to/s3cache"
+# Sets the path before v0.11
+# cache_path = "/path/to/s3cache"
 cache_capacity = "10G"
 ```
 
@@ -49,7 +50,7 @@ The write cache acts as a write-through cache that stores files on the local dis
 
 - The `enable_experimental_write_cache` flag enables the write cache, enabled by default when configuring remote object stores since `v0.11`.
 - The `experimental_write_cache_size` sets the capacity of the cache, defaults to `5Gib` since `v0.11`.
-- The `experimental_write_cache_path` sets the path to store cached files, defaults to `{data_home}/object_cache/write` since `v0.11`.
+- The `experimental_write_cache_path` sets the path to store cached files. You don't need to set it since `v0.11`.
 - The `experimental_write_cache_ttl` sets the TTL of the cached files.
 
 ```toml
@@ -58,6 +59,7 @@ The write cache acts as a write-through cache that stores files on the local dis
 enable_experimental_write_cache = true
 experimental_write_cache_size = "10G"
 experimental_write_cache_ttl = "8h"
+# Sets the path before v0.11
 # experimental_write_cache_path = "/path/to/write/cache"
 ```
 

--- a/docs/user-guide/administration/performance-tuning-tips.md
+++ b/docs/user-guide/administration/performance-tuning-tips.md
@@ -30,7 +30,7 @@ It's highly recommended to enable the object store read cache and the write cach
 The read cache stores objects or ranges on the local disk to avoid fetching the same range from the remote again. The following example shows how to enable the read cache for S3.
 
 - The `cache_path` is the directory to store cached objects. You don't need to set it since `v0.11`.
-- The `cache_capacity` is the capacity of the cache, defaults to `5Gib` since `v0.11`. It's recommended to leave at least 1/10 of the total disk space for it.
+- The `cache_capacity` is the capacity of the cache, defaults to `5GiB` since `v0.11`. It's recommended to leave at least 1/10 of the total disk space for it.
 
 ```toml
 [storage]
@@ -46,10 +46,13 @@ region = "your-region"
 cache_capacity = "10G"
 ```
 
-The write cache acts as a write-through cache that stores files on the local disk before uploading them to the object store. This reduces the first query latency. The following example shows how to enable the write cache.
+The write cache acts as a write-through cache that stores files on the local disk before uploading them to the object store. This reduces the first query latency.
+
+
+The following example shows how to enable the write cache in versions before `v0.12`.
 
 - The `enable_experimental_write_cache` flag enables the write cache, enabled by default when configuring remote object stores since `v0.11`.
-- The `experimental_write_cache_size` sets the capacity of the cache, defaults to `5Gib` since `v0.11`.
+- The `experimental_write_cache_size` sets the capacity of the cache, defaults to `5GiB` since `v0.11`.
 - The `experimental_write_cache_path` sets the path to store cached files. You don't need to set it since `v0.11`.
 - The `experimental_write_cache_ttl` sets the TTL of the cached files.
 
@@ -69,7 +72,31 @@ You can monitor the `greptime_mito_cache_bytes` and `greptime_mito_cache_miss` m
 
 If the `greptime_mito_cache_miss` metric is consistently high and increasing, or if the `greptime_mito_cache_bytes` metric reaches the cache capacity, you may need to adjust the cache size configurations of the storage engine.
 
-Here's an example:
+
+Here is an example:
+
+
+```toml
+[[region_engine]]
+[region_engine.mito]
+# Cache size for the write cache. The `type` label value for this cache is `file`.
+write_cache_size = "10G"
+# Cache size for SST metadata. The `type` label value for this cache is `sst_meta`.
+sst_meta_cache_size = "128MB"
+# Cache size for vectors and arrow arrays. The `type` label value for this cache is `vector`.
+vector_cache_size = "512MB"
+# Cache size for pages of SST row groups. The `type` label value for this cache is `page`.
+page_cache_size = "512MB"
+# Cache size for time series selector (e.g. `last_value()`). The `type` label value for this cache is `selector_result`.
+selector_result_cache_size = "512MB"
+
+[region_engine.mito.index]
+## The max capacity of the index staging directory.
+staging_size = "10GB"
+```
+
+
+For versions before `v0.12`:
 
 ```toml
 [[region_engine]]
@@ -94,7 +121,7 @@ staging_size = "10GB"
 
 Some tips:
 
-- 1/10 of disk space for the `experimental_write_cache_size` at least
+- 1/10 of disk space for the write cache at least
 - 1/4 of total memory for the `page_cache_size` at least if the memory usage is under 20%
 - Double the cache size if the cache hit ratio is less than 50%
 - If using full-text index, leave 1/10 of disk space for the `staging_size` at least

--- a/docs/user-guide/deployments/configuration.md
+++ b/docs/user-guide/deployments/configuration.md
@@ -302,7 +302,23 @@ For storage from the same provider, if you want to use different S3 buckets as s
 
 When using remote storage services like AWS S3, Alibaba Cloud OSS, or Azure Blob Storage, fetching data during queries can be time-consuming. To address this, GreptimeDB provides a local cache mechanism to speed up repeated data access.
 
-Since version `v0.11`, GreptimeDB enables local file caching for remote object storage by default. The default cache directory is located at `{data_home}/object_cache`, with both read and write cache capacity set to `5GiB`.
+Since version `v0.11`, GreptimeDB enables local file caching for remote object storage by default, with both read and write cache capacity set to `5GiB`.
+
+
+Usually you don't have to configure the cache unless you want to specify the cache capcity.
+```toml
+[storage]
+type = "S3"
+bucket = "test_greptimedb"
+root = "/greptimedb"
+access_key_id = "<access key id>"
+secret_access_key = "<secret access key>"
+cache_capacity = "10GiB"
+```
+
+
+We recommend that you don't set the cache directory because the database can choose it automatically. The default cache directory is under the `{data_home}`.
+
 
 For versions before v0.11, you need to manually enable the read cache by configuring `cache_path` in the storage settings:
 
@@ -315,7 +331,7 @@ access_key_id = "<access key id>"
 secret_access_key = "<secret access key>"
 ## Enable object storage caching
 cache_path = "/var/data/s3_read_cache"
-cache_capacity = "5Gib"
+cache_capacity = "5GiB"
 ```
 
 The `cache_path` specifies the local directory for storing cache files, while `cache_capacity` determines the maximum total file size allowed in the cache directory in bytes. You can disable the read cache by setting `cache_path` to an empty string.
@@ -331,8 +347,7 @@ experimental_write_cache_path = "/var/data/s3_write_cache"
 experimental_write_cache_size = "5GiB"
 ```
 
-The default value of `experimental_write_cache_path` is `{data_home}/object_cache/write`.
-To disable the write cache, set `enable_experimental_write_cache` to `false`.
+The `experimental_write_cache_path` is under `{data_home}` by default. To disable the write cache, set `enable_experimental_write_cache` to `false`.
 
 Read [Performance Tuning Tips](/user-guide/administration/performance-tuning-tips) for more detailed info.
 

--- a/docs/user-guide/deployments/configuration.md
+++ b/docs/user-guide/deployments/configuration.md
@@ -305,7 +305,7 @@ When using remote storage services like AWS S3, Alibaba Cloud OSS, or Azure Blob
 Since version `v0.11`, GreptimeDB enables local file caching for remote object storage by default, with both read and write cache capacity set to `5GiB`.
 
 
-Usually you don't have to configure the cache unless you want to specify the cache capcity.
+Usually you don't have to configure the cache unless you want to specify the cache capacity.
 ```toml
 [storage]
 type = "S3"

--- a/docs/user-guide/deployments/configuration.md
+++ b/docs/user-guide/deployments/configuration.md
@@ -336,6 +336,16 @@ cache_capacity = "5GiB"
 
 The `cache_path` specifies the local directory for storing cache files, while `cache_capacity` determines the maximum total file size allowed in the cache directory in bytes. You can disable the read cache by setting `cache_path` to an empty string.
 
+
+The write cache is no more experimental since `v0.12`. You can configure the cache size in the mito config if you don't want to use the default value.
+```toml
+[[region_engine]]
+[region_engine.mito]
+
+write_cache_size = "10GiB"
+```
+
+
 For write cache in versions before v0.11, you need to enable it by setting `enable_experimental_write_cache` to `true` in the `[region_engine.mito]` section:
 
 ```toml

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.11/user-guide/administration/performance-tuning-tips.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.11/user-guide/administration/performance-tuning-tips.md
@@ -99,14 +99,14 @@ staging_size = "10GB"
 
 ### 避免将高基数的列放到主键中
 
-将高基数的列，如 `trace_id` 和 `uuid` 等列设置为主键会降低写入和查询的性能。建议建表时使用 [append-only](/reference/sql/create.md#create-an-append-only-table) 表并将这些高基数的列设置为 fields。
+将高基数的列，如 `trace_id` 和 `uuid` 等列设置为主键会降低写入和查询的性能。建议建表时使用 [append-only](/reference/sql/create.md#创建-append-only-表) 表并将这些高基数的列设置为 fields。
 
 
 ### 尽可能使用 append-only 表
 
 一般来说，append-only 表具有更高的扫描性能，因为存储引擎可以跳过合并和去重操作。此外，如果表是 append-only 表，查询引擎可以使用统计信息来加速某些查询。
 
-如果表不需要去重或性能优先于去重，我们建议为表启用 [append_mode](/reference/sql/create.md#create-an-append-only-table)。例如，日志表应该是 append-only 表，因为日志消息可能具有相同的时间戳。
+如果表不需要去重或性能优先于去重，我们建议为表启用 [append_mode](/reference/sql/create.md#创建-append-only-表)。例如，日志表应该是 append-only 表，因为日志消息可能具有相同的时间戳。
 
 
 ## 写入
@@ -133,7 +133,7 @@ staging_size = "10GB"
 ### 按时间窗口写入
 虽然 GreptimeDB 可以处理乱序数据，但乱序数据仍然会影响性能。GreptimeDB 从写入的数据中推断出时间窗口的大小，并根据时间戳将数据划分为多个时间窗口。如果写入的行不在同一个时间窗口内，GreptimeDB 需要将它们拆分，这会影响写入性能。
 
-通常，实时数据不会出现上述问题，因为它们始终使用最新的时间戳。如果需要将具有较长时间范围的数据导入数据库，我们建议提前创建表并 [指定 compaction.twcs.time_window 选项](/reference/sql/create.md#create-a-table-with-custom-compaction-options)。
+通常，实时数据不会出现上述问题，因为它们始终使用最新的时间戳。如果需要将具有较长时间范围的数据导入数据库，我们建议提前创建表并 [指定 compaction.twcs.time_window 选项](/reference/sql/create.md#创建自定义-compaction-参数的表)。
 
 
 ## 表结构

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.11/user-guide/concepts/data-model.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.11/user-guide/concepts/data-model.md
@@ -59,14 +59,15 @@ CREATE TABLE access_logs (
   http_refer STRING,
   user_agent STRING,
   request STRING FULLTEXT,
-  PRIMARY KEY (remote_addr, http_status, http_method, http_refer, user_agent)
-)
+  PRIMARY KEY (http_status, http_method)
+) with ('append_mode'='true');
 ```
 其中：
 
 - 时间索引列为 `access_time`。
-- `remote_addr`、`http_status`、`http_method`、`http_refer`、`user_agent` 为 Tag。
-- `request` 是通过 [`FULLTEXT` 列选项](/reference/sql/create.md#fulltext-列选项)启用全文索引的字段。
+- `http_status`、`http_method` 为 Tag。
+- `remote_addr`、`http_refer`、`user_agent`、`request` 为 Field。`request` 是通过 [`FULLTEXT` 列选项](/reference/sql/create.md#fulltext-列选项)启用全文索引的字段。
+- 这个表是一个用于存储日志的 [append-only 表](/reference/sql/create.md#创建-append-only-表)。它允许一个主键下存在重复的时间戳。
 
 要了解如何指定 `Tag`、`Timestamp` 和 `Field` 列，请参见[表管理](/user-guide/administration/manage-data/basic-table-operations.md#创建表)和 [CREATE 语句](/reference/sql/create.md)。
 

--- a/versioned_docs/version-0.11/user-guide/administration/performance-tuning-tips.md
+++ b/versioned_docs/version-0.11/user-guide/administration/performance-tuning-tips.md
@@ -30,7 +30,7 @@ It's highly recommended to enable the object store read cache and the write cach
 The read cache stores objects or ranges on the local disk to avoid fetching the same range from the remote again. The following example shows how to enable the read cache for S3.
 
 - The `cache_path` is the directory to store cached objects. You don't need to set it since `v0.11`.
-- The `cache_capacity` is the capacity of the cache, defaults to `5Gib` since `v0.11`. It's recommended to leave at least 1/10 of the total disk space for it.
+- The `cache_capacity` is the capacity of the cache, defaults to `5GiB` since `v0.11`. It's recommended to leave at least 1/10 of the total disk space for it.
 
 ```toml
 [storage]
@@ -49,7 +49,7 @@ cache_capacity = "10G"
 The write cache acts as a write-through cache that stores files on the local disk before uploading them to the object store. This reduces the first query latency. The following example shows how to enable the write cache.
 
 - The `enable_experimental_write_cache` flag enables the write cache, enabled by default when configuring remote object stores since `v0.11`.
-- The `experimental_write_cache_size` sets the capacity of the cache, defaults to `5Gib` since `v0.11`.
+- The `experimental_write_cache_size` sets the capacity of the cache, defaults to `5GiB` since `v0.11`.
 - The `experimental_write_cache_path` sets the path to store cached files. You don't need to set it since `v0.11`.
 - The `experimental_write_cache_ttl` sets the TTL of the cached files.
 

--- a/versioned_docs/version-0.11/user-guide/administration/performance-tuning-tips.md
+++ b/versioned_docs/version-0.11/user-guide/administration/performance-tuning-tips.md
@@ -29,7 +29,7 @@ It's highly recommended to enable the object store read cache and the write cach
 
 The read cache stores objects or ranges on the local disk to avoid fetching the same range from the remote again. The following example shows how to enable the read cache for S3.
 
-- The `cache_path` is the directory to store cached objects, defaults to `{data_home}/object_cache/read` since `v0.11`.
+- The `cache_path` is the directory to store cached objects. You don't need to set it since `v0.11`.
 - The `cache_capacity` is the capacity of the cache, defaults to `5Gib` since `v0.11`. It's recommended to leave at least 1/10 of the total disk space for it.
 
 ```toml
@@ -41,7 +41,8 @@ access_key_id = "****"
 secret_access_key = "****"
 endpoint = "https://s3.amazonaws.com/"
 region = "your-region"
-cache_path = "/path/to/s3cache"
+# Sets the path before v0.11
+# cache_path = "/path/to/s3cache"
 cache_capacity = "10G"
 ```
 
@@ -49,7 +50,7 @@ The write cache acts as a write-through cache that stores files on the local dis
 
 - The `enable_experimental_write_cache` flag enables the write cache, enabled by default when configuring remote object stores since `v0.11`.
 - The `experimental_write_cache_size` sets the capacity of the cache, defaults to `5Gib` since `v0.11`.
-- The `experimental_write_cache_path` sets the path to store cached files, defaults to `{data_home}/object_cache/write` since `v0.11`.
+- The `experimental_write_cache_path` sets the path to store cached files. You don't need to set it since `v0.11`.
 - The `experimental_write_cache_ttl` sets the TTL of the cached files.
 
 ```toml
@@ -58,6 +59,7 @@ The write cache acts as a write-through cache that stores files on the local dis
 enable_experimental_write_cache = true
 experimental_write_cache_size = "10G"
 experimental_write_cache_ttl = "8h"
+# Sets the path before v0.11
 # experimental_write_cache_path = "/path/to/write/cache"
 ```
 

--- a/versioned_docs/version-0.11/user-guide/concepts/data-model.md
+++ b/versioned_docs/version-0.11/user-guide/concepts/data-model.md
@@ -75,13 +75,14 @@ CREATE TABLE access_logs (
   http_refer STRING,
   user_agent STRING,
   request STRING FULLTEXT,
-  PRIMARY KEY (remote_addr, http_status, http_method, http_refer, user_agent)
-)
+  PRIMARY KEY (http_status, http_method)
+) with ('append_mode'='true');
 ```
 
 - The time index column is `access_time`.
-- `remote_addr`, `http_status`, `http_method`, `http_refer` and `user_agent` are tags.
-- `request` is a field that enables full-text index by the [`FULLTEXT` column option](/reference/sql/create.md#fulltext-column-option).
+- `http_status`, `http_method` are tags.
+- `remote_addr`, `http_refer`, `user_agent` and `request` are fields. `request` is a field that enables full-text index by the [`FULLTEXT` column option](/reference/sql/create.md#fulltext-column-option).
+- The table is an [append-only table](/reference/sql/create.md#create-an-append-only-table) for storing logs that may have duplicate timestamps under the same primary key.
 
 To learn how to indicate `Tag`, `Timestamp`, and `Field` columns, Please refer to [table management](/user-guide/administration/manage-data/basic-table-operations.md#create-a-table) and [CREATE statement](/reference/sql/create.md).
 

--- a/versioned_docs/version-0.11/user-guide/deployments/configuration.md
+++ b/versioned_docs/version-0.11/user-guide/deployments/configuration.md
@@ -302,7 +302,25 @@ For storage from the same provider, if you want to use different S3 buckets as s
 
 When using remote storage services like AWS S3, Alibaba Cloud OSS, or Azure Blob Storage, fetching data during queries can be time-consuming. To address this, GreptimeDB provides a local cache mechanism to speed up repeated data access.
 
-Since version `v0.11`, GreptimeDB enables local file caching for remote object storage by default. The default cache directory is located at `{data_home}/object_cache`, with both read and write cache capacity set to `5GiB`.
+Since version `v0.11`, GreptimeDB enables local file caching for remote object storage by default, with both read and write cache capacity set to `5GiB`.
+
+
+Usually you don't have to configure the cache unless you want to specify the cache capcity.
+```toml
+[storage]
+type = "S3"
+bucket = "test_greptimedb"
+root = "/greptimedb"
+access_key_id = "<access key id>"
+secret_access_key = "<secret access key>"
+cache_capacity = "10GiB"
+```
+
+
+We recommend that you don't set the cache directory because the database can choose it automatically. The default cache root directory is:
+- `{data_home}` (since `v0.11.2`)
+- `{data_home}/object_cache` (before `v0.11.2`)
+
 
 For versions before v0.11, you need to manually enable the read cache by configuring `cache_path` in the storage settings:
 
@@ -315,7 +333,7 @@ access_key_id = "<access key id>"
 secret_access_key = "<secret access key>"
 ## Enable object storage caching
 cache_path = "/var/data/s3_read_cache"
-cache_capacity = "5Gib"
+cache_capacity = "5GiB"
 ```
 
 The `cache_path` specifies the local directory for storing cache files, while `cache_capacity` determines the maximum total file size allowed in the cache directory in bytes. You can disable the read cache by setting `cache_path` to an empty string.
@@ -331,7 +349,10 @@ experimental_write_cache_path = "/var/data/s3_write_cache"
 experimental_write_cache_size = "5GiB"
 ```
 
-The default value of `experimental_write_cache_path` is `{data_home}/object_cache/write`.
+The default value of `experimental_write_cache_path`:
+- `{data_home}` (since `v0.11.2`)
+- `{data_home}/object_cache/write` (before `v0.11.2`)
+
 To disable the write cache, set `enable_experimental_write_cache` to `false`.
 
 Read [Performance Tuning Tips](/user-guide/administration/performance-tuning-tips) for more detailed info.

--- a/versioned_docs/version-0.11/user-guide/deployments/configuration.md
+++ b/versioned_docs/version-0.11/user-guide/deployments/configuration.md
@@ -305,7 +305,7 @@ When using remote storage services like AWS S3, Alibaba Cloud OSS, or Azure Blob
 Since version `v0.11`, GreptimeDB enables local file caching for remote object storage by default, with both read and write cache capacity set to `5GiB`.
 
 
-Usually you don't have to configure the cache unless you want to specify the cache capcity.
+Usually you don't have to configure the cache unless you want to specify the cache capacity.
 ```toml
 [storage]
 type = "S3"


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

This PR adds the change log for v0.11.2 and updates cache-related docs for it.

It also update docs for https://github.com/GreptimeTeam/docs/issues/1423

## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
