### PR TITLE
docs: follow-up update of the zh docs for cache config

### DIFF
--- a/blog/release-0-11-2.md
+++ b/blog/release-0-11-2.md
@@ -14,7 +14,7 @@ This version fixes the following critical issues:
 - Compaction doesn't use files in the local cache.
 
 
-### Notices
+### Notes
 This version modifies the default object storage cache paths:
 - The path for write cache has changed from the default `{data_home}/object_cache/write` to `{data_home}/cache/object/write`.
 - The path for read cache has changed from the default `{data_home}/object_cache/read` to `{data_home}/cache/object/read`.

--- a/docs/user-guide/administration/performance-tuning-tips.md
+++ b/docs/user-guide/administration/performance-tuning-tips.md
@@ -62,7 +62,6 @@ The following example shows how to enable the write cache in versions before `v0
 enable_experimental_write_cache = true
 experimental_write_cache_size = "10G"
 experimental_write_cache_ttl = "8h"
-# Sets the path before v0.11
 # experimental_write_cache_path = "/path/to/write/cache"
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/administration/performance-tuning-tips.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/administration/performance-tuning-tips.md
@@ -29,8 +29,8 @@ GreptimeDB 提供了各种指标来帮助监控和排查性能问题。官方仓
 > 提示: 从 v0.11 版本开始，在使用远程对象存储服务时，系统会默认启用本地缓存（包括读取和写入）。通常情况下，您只需要根据需求调整缓存容量即可。
 
 读取缓存将对象或一段范围的数据存储在本地磁盘上，以避免再次从远程读取相同的数据。以下示例展示了如何为 S3 启用读取缓存。
-- `cache_path` 是存储缓存对象的目录，从 v0.11 版本开始默认值为 `{data_home}/object_cache/read` 目录。
-- `cache_capacity` 是缓存的容量。从 0.11 版本开始，默认初始值为 `5Gib`，建议至少留出总磁盘空间的 1/10 用于缓存。
+- `cache_path` 是存储缓存对象的目录，从 v0.11 版本开始不再需要手动设置。
+- `cache_capacity` 是缓存的容量。从 0.11 版本开始，默认初始值为 `5GiB`，建议至少留出总磁盘空间的 1/10 用于缓存。
 
 ```toml
 [storage]
@@ -41,13 +41,17 @@ access_key_id = "****"
 secret_access_key = "****"
 endpoint = "https://s3.amazonaws.com/"
 region = "your-region"
-cache_path = "/path/to/s3cache"
+# 在 v0.11 前需要设置该路径
+# cache_path = "/path/to/s3cache"
 cache_capacity = "10G"
 ```
 
-写入缓存起到 write-through 缓存的作用，在将文件上传到对象存储之前，会先将它们存储在本地磁盘上。这可以减少第一次查询的延迟。以下示例展示了如何启用写入缓存。
+写入缓存起到 write-through 缓存的作用，在将文件上传到对象存储之前，会先将它们存储在本地磁盘上。这可以减少第一次查询的延迟。
+
+
+以下示例展示了在 `v0.12` 版本之前如何启用写入缓存。
 - `enable_experimental_write_cache` 开关可用来启用写入缓存。从 `v0.11` 版本开始，当配置对象存储服务的时候，该值将默认设置为 `true`，即启用。
-- `experimental_write_cache_size` 用来设置缓存的容量。从 0.11 版本开始，默认初始值为 `5Gib`。
+- `experimental_write_cache_size` 用来设置缓存的容量。从 0.11 版本开始，默认初始值为 `5GiB`。
 - `experimental_write_cache_path` 用来设置存储缓存文件的路径。默认情况下它位于数据主目录下。
 - `experimental_write_cache_ttl` 用来设置缓存文件的 TTL。
 
@@ -68,6 +72,31 @@ experimental_write_cache_ttl = "8h"
 如果 `greptime_mito_cache_miss` 指标一直很高并不断增加，或者 `greptime_mito_cache_bytes` 指标达到缓存容量，可能需要调整存储引擎的缓存大小配置。
 
 以下是一个例子：
+
+```toml
+```toml
+[[region_engine]]
+[region_engine.mito]
+# 写入缓存的缓存大小。此缓存的 `type` 标签值为 `file`。
+write_cache_size = "10G"
+# SST 元数据的缓存大小。此缓存的 `type` 标签值为 `sst_meta`。
+sst_meta_cache_size = "128MB"
+# 向量和箭头数组的缓存大小。此缓存的 `type` 标签值为 `vector`。
+vector_cache_size = "512MB"
+# SST 行组页面的缓存大小。此缓存的 `type` 标签值为 `page`。
+page_cache_size = "512MB"
+# 时间序列查询结果（例如 `last_value()`）的缓存大小。此缓存的 `type` 标签值为 `selector_result`。
+selector_result_cache_size = "512MB"
+
+[region_engine.mito.index]
+## 索引暂存目录的最大容量。
+staging_size = "10GB"
+```
+
+```
+
+
+对于 `v0.12` 之前的版本
 
 ```toml
 [[region_engine]]
@@ -91,7 +120,7 @@ staging_size = "10GB"
 ```
 
 一些建议：
-- 至少将 `experimental_write_cache_size` 设置为磁盘空间的 1/10
+- 至少将写入缓存设置为磁盘空间的 1/10
 - 如果数据库内存使用率低于 20%，则可以至少将 `page_cache_size` 设置为总内存大小的 1/4
 - 如果缓存命中率低于 50%，则可以将缓存大小翻倍
 - 如果使用全文索引，至少将 `staging_size` 设置为磁盘空间的 1/10

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments/configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments/configuration.md
@@ -290,7 +290,23 @@ credential_path = "<gcs credential path>"
 
 在使用 AWS S3、阿里云 OSS 或 Azure Blob Storage 等远程存储服务时，查询过程中获取数据通常会很耗时，尤其在公有云环境。为了解决这个问题，GreptimeDB 提供了本地缓存机制来加速重复数据的访问。
 
-从 v0.11 版本开始，GreptimeDB 默认启用远程对象存储的本地文件缓存。默认的缓存目录位于 `{data_home}/object_cache`，读取和写入缓存容量都设置为 `5GiB`。
+从 v0.11 版本开始，GreptimeDB 默认启用远程对象存储的本地文件缓存。读取和写入缓存容量都设置为 `5GiB`。
+
+
+通常你无需专门配置缓存，除非你需要修改缓存的大小
+```toml
+[storage]
+type = "S3"
+bucket = "test_greptimedb"
+root = "/greptimedb"
+access_key_id = "<access key id>"
+secret_access_key = "<secret access key>"
+cache_capacity = "10GiB"
+```
+
+
+我们建议你不用设置缓存的目录，因为数据库会自动创建该目录。默认的缓存目录位于 `{data_home}` 目录下。
+
 
 对于 v0.11 之前的版本，你需要通过在存储设置中配置 `cache_path` 来手动启用读取缓存：
 
@@ -303,10 +319,21 @@ access_key_id = "<access key id>"
 secret_access_key = "<secret access key>"
 ## 启用对象存储缓存
 cache_path = "/var/data/s3_read_cache"
-cache_capacity = "5Gib"
+cache_capacity = "5GiB"
 ```
 
 `cache_path` 指定存储缓存文件的本地目录，而 `cache_capacity` 则决定缓存目录中允许的最大文件总大小（以字节为单位）。你可以通过将 `cache_path` 设置为空字符串来禁用读取缓存。
+
+
+自 `v0.12` 之后，写入缓存不再是实验性的功能。你可以通过修改 mito 的配置调整缓存的大小
+
+```toml
+[[region_engine]]
+[region_engine.mito]
+
+write_cache_size = "10GiB"
+````
+
 
 对于 v0.11 之前版本的写入缓存，你需要在 `[region_engine.mito]` 部分将 `enable_experimental_write_cache` 设置为 `true` 来启用：
 
@@ -319,7 +346,7 @@ experimental_write_cache_path = "/var/data/s3_write_cache"
 experimental_write_cache_size = "5GiB"
 ```
 
-`experimental_write_cache_path` 的默认值是 `{data_home}/object_cache/write`。
+`experimental_write_cache_path` 默认值位于 `{data_home}` 目录下。
 要禁用写入缓存，请将 `enable_experimental_write_cache` 设置为 `false`。
 
 更详细的信息请参阅[性能调优技巧](/user-guide/administration/performance-tuning-tips)。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.11/user-guide/administration/performance-tuning-tips.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.11/user-guide/administration/performance-tuning-tips.md
@@ -29,8 +29,8 @@ GreptimeDB 提供了各种指标来帮助监控和排查性能问题。官方仓
 > 提示: 从 v0.11 版本开始，在使用远程对象存储服务时，系统会默认启用本地缓存（包括读取和写入）。通常情况下，您只需要根据需求调整缓存容量即可。
 
 读取缓存将对象或一段范围的数据存储在本地磁盘上，以避免再次从远程读取相同的数据。以下示例展示了如何为 S3 启用读取缓存。
-- `cache_path` 是存储缓存对象的目录，从 v0.11 版本开始默认值为 `{data_home}/object_cache/read` 目录。
-- `cache_capacity` 是缓存的容量。从 0.11 版本开始，默认初始值为 `5Gib`，建议至少留出总磁盘空间的 1/10 用于缓存。
+- `cache_path` 是存储缓存对象的目录，从 v0.11 版本开始不再需要手动设置。
+- `cache_capacity` 是缓存的容量。从 0.11 版本开始，默认初始值为 `5GiB`，建议至少留出总磁盘空间的 1/10 用于缓存。
 
 ```toml
 [storage]
@@ -41,13 +41,14 @@ access_key_id = "****"
 secret_access_key = "****"
 endpoint = "https://s3.amazonaws.com/"
 region = "your-region"
-cache_path = "/path/to/s3cache"
+# 在 v0.11 前需要设置该路径
+# cache_path = "/path/to/s3cache"
 cache_capacity = "10G"
 ```
 
 写入缓存起到 write-through 缓存的作用，在将文件上传到对象存储之前，会先将它们存储在本地磁盘上。这可以减少第一次查询的延迟。以下示例展示了如何启用写入缓存。
 - `enable_experimental_write_cache` 开关可用来启用写入缓存。从 `v0.11` 版本开始，当配置对象存储服务的时候，该值将默认设置为 `true`，即启用。
-- `experimental_write_cache_size` 用来设置缓存的容量。从 0.11 版本开始，默认初始值为 `5Gib`。
+- `experimental_write_cache_size` 用来设置缓存的容量。从 0.11 版本开始，默认初始值为 `5GiB`。
 - `experimental_write_cache_path` 用来设置存储缓存文件的路径。默认情况下它位于数据主目录下。
 - `experimental_write_cache_ttl` 用来设置缓存文件的 TTL。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.11/user-guide/deployments/configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.11/user-guide/deployments/configuration.md
@@ -290,7 +290,25 @@ credential_path = "<gcs credential path>"
 
 在使用 AWS S3、阿里云 OSS 或 Azure Blob Storage 等远程存储服务时，查询过程中获取数据通常会很耗时，尤其在公有云环境。为了解决这个问题，GreptimeDB 提供了本地缓存机制来加速重复数据的访问。
 
-从 v0.11 版本开始，GreptimeDB 默认启用远程对象存储的本地文件缓存。默认的缓存目录位于 `{data_home}/object_cache`，读取和写入缓存容量都设置为 `5GiB`。
+从 v0.11 版本开始，GreptimeDB 默认启用远程对象存储的本地文件缓存。读取和写入缓存容量都设置为 `5GiB`。
+
+
+通常你无需专门配置缓存，除非你需要修改缓存的大小
+```toml
+[storage]
+type = "S3"
+bucket = "test_greptimedb"
+root = "/greptimedb"
+access_key_id = "<access key id>"
+secret_access_key = "<secret access key>"
+cache_capacity = "10GiB"
+```
+
+
+我们建议你不用设置缓存的目录，因为数据库会自动创建该目录。默认的缓存目录位于
+- `{data_home}`（`v0.11.2` 之后）
+- `{data_home}/object_cache`（`v0.11.2` 之前）
+
 
 对于 v0.11 之前的版本，你需要通过在存储设置中配置 `cache_path` 来手动启用读取缓存：
 
@@ -303,7 +321,7 @@ access_key_id = "<access key id>"
 secret_access_key = "<secret access key>"
 ## 启用对象存储缓存
 cache_path = "/var/data/s3_read_cache"
-cache_capacity = "5Gib"
+cache_capacity = "5GiB"
 ```
 
 `cache_path` 指定存储缓存文件的本地目录，而 `cache_capacity` 则决定缓存目录中允许的最大文件总大小（以字节为单位）。你可以通过将 `cache_path` 设置为空字符串来禁用读取缓存。
@@ -319,7 +337,11 @@ experimental_write_cache_path = "/var/data/s3_write_cache"
 experimental_write_cache_size = "5GiB"
 ```
 
-`experimental_write_cache_path` 的默认值是 `{data_home}/object_cache/write`。
+`experimental_write_cache_path` 的默认值是
+- `{data_home}`（`v0.11.2` 之后）
+- `{data_home}/object_cache/write`（`v0.11.2` 之前）
+
+
 要禁用写入缓存，请将 `enable_experimental_write_cache` 设置为 `false`。
 
 更详细的信息请参阅[性能调优技巧](/user-guide/administration/performance-tuning-tips)。

--- a/versioned_docs/version-0.11/user-guide/administration/performance-tuning-tips.md
+++ b/versioned_docs/version-0.11/user-guide/administration/performance-tuning-tips.md
@@ -59,7 +59,6 @@ The write cache acts as a write-through cache that stores files on the local dis
 enable_experimental_write_cache = true
 experimental_write_cache_size = "10G"
 experimental_write_cache_ttl = "8h"
-# Sets the path before v0.11
 # experimental_write_cache_path = "/path/to/write/cache"
 ```
 


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

Fixes https://github.com/GreptimeTeam/docs/issues/1423

Updates zh docs for https://github.com/GreptimeTeam/docs/pull/1424

Removes comments on write cache path as it always has a default value so users usually don't set it.


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
