### PR TITLE
docs: update docs for runnng on android

### DIFF
--- a/docs/user-guide/deployments/run-on-android.md
+++ b/docs/user-guide/deployments/run-on-android.md
@@ -15,7 +15,10 @@ You can install [Termux](https://termux.dev/) from [GitHub release page](https:/
 ## Download GreptimeDB Android binary.
 
 ```bash
-VERSION=$(curl -s -XGET "https://api.github.com/repos/GreptimeTeam/greptimedb/releases" | grep tag_name | grep -v nightly | cut -d: -f 2 | sed 's/.*"\(.*\)".*/\1/' | uniq | sort -r | head -n 1)
+VERSION=$(curl -sL \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/repos/GreptimeTeam/greptimedb/releases/latest" | sed -n 's/.*"tag_name": "\([^"]*\)".*/\1/p')
 
 curl -sOL "https://github.com/GreptimeTeam/greptimedb/releases/download/${VERSION}/greptime-android-arm64-${VERSION}.tar.gz"
 tar zxvf ./greptime-android-arm64-${VERSION}.tar.gz
@@ -37,7 +40,7 @@ cat <<EOF > ./config.toml
 addr = "0.0.0.0:4000"
 
 [grpc]
-addr = "0.0.0.0:4001"
+bind_addr = "0.0.0.0:4001"
 
 [mysql]
 addr = "0.0.0.0:4002"

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments/run-on-android.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments/run-on-android.md
@@ -17,7 +17,11 @@ description: 在安卓平台运行 GreptimeDB 的指南，包括安装终端模�
 
 请执行以下命令来下载安卓平台的 GreptimeDB 二进制：
 ```bash
-VERSION=$(curl -s -XGET "https://api.github.com/repos/GreptimeTeam/greptimedb/releases" | grep tag_name | grep -v nightly | cut -d: -f 2 | sed 's/.*"\(.*\)".*/\1/' | uniq | sort -r | head -n 1)
+VERSION=$(curl -sL \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/repos/GreptimeTeam/greptimedb/releases/latest" | sed -n 's/.*"tag_name": "\([^"]*\)".*/\1/p')
+
 
 curl -sOL "https://github.com/GreptimeTeam/greptimedb/releases/download/${VERSION}/greptime-android-arm64-${VERSION}.tar.gz"
 tar zxvf ./greptime-android-arm64-${VERSION}.tar.gz
@@ -39,7 +43,7 @@ cat <<EOF > ./config.toml
 addr = "0.0.0.0:4000"
 
 [grpc]
-addr = "0.0.0.0:4001"
+bind_addr = "0.0.0.0:4001"
 
 [mysql]
 addr = "0.0.0.0:4002"

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.10/user-guide/deployments/run-on-android.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.10/user-guide/deployments/run-on-android.md
@@ -1,3 +1,8 @@
+---
+keywords: [配置指南, 命令行选项, 配置文件, 环境变量, Android, 嵌入式]
+description: 介绍如何在 Android 平台上运行 GreptimeDB
+---
+
 # 在安卓平台运行
 
 从 v0.4.0 开始，GreptimeDB 支持在采用了 ARM64 CPU 和 Android API 23 版本以上的安卓平台运行。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.10/user-guide/deployments/run-on-android.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.10/user-guide/deployments/run-on-android.md
@@ -12,7 +12,10 @@
 
 请执行以下命令来下载安卓平台的 GreptimeDB 二进制：
 ```bash
-VERSION=$(curl -s -XGET "https://api.github.com/repos/GreptimeTeam/greptimedb/releases" | grep tag_name | grep -v nightly | cut -d: -f 2 | sed 's/.*"\(.*\)".*/\1/' | uniq | sort -r | head -n 1)
+VERSION=$(curl -sL \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/repos/GreptimeTeam/greptimedb/releases/latest" | sed -n 's/.*"tag_name": "\([^"]*\)".*/\1/p')
 
 curl -sOL "https://github.com/GreptimeTeam/greptimedb/releases/download/${VERSION}/greptime-android-arm64-${VERSION}.tar.gz"
 tar zxvf ./greptime-android-arm64-${VERSION}.tar.gz

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.11/user-guide/deployments/run-on-android.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.11/user-guide/deployments/run-on-android.md
@@ -17,7 +17,11 @@ description: 在安卓平台运行 GreptimeDB 的指南，包括安装终端模�
 
 请执行以下命令来下载安卓平台的 GreptimeDB 二进制：
 ```bash
-VERSION=$(curl -s -XGET "https://api.github.com/repos/GreptimeTeam/greptimedb/releases" | grep tag_name | grep -v nightly | cut -d: -f 2 | sed 's/.*"\(.*\)".*/\1/' | uniq | sort -r | head -n 1)
+VERSION=$(curl -sL \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/repos/GreptimeTeam/greptimedb/releases/latest" | sed -n 's/.*"tag_name": "\([^"]*\)".*/\1/p')
+
 
 curl -sOL "https://github.com/GreptimeTeam/greptimedb/releases/download/${VERSION}/greptime-android-arm64-${VERSION}.tar.gz"
 tar zxvf ./greptime-android-arm64-${VERSION}.tar.gz

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.12/user-guide/deployments/run-on-android.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.12/user-guide/deployments/run-on-android.md
@@ -17,7 +17,10 @@ description: 在安卓平台运行 GreptimeDB 的指南，包括安装终端模�
 
 请执行以下命令来下载安卓平台的 GreptimeDB 二进制：
 ```bash
-VERSION=$(curl -s -XGET "https://api.github.com/repos/GreptimeTeam/greptimedb/releases" | grep tag_name | grep -v nightly | cut -d: -f 2 | sed 's/.*"\(.*\)".*/\1/' | uniq | sort -r | head -n 1)
+VERSION=$(curl -sL \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/repos/GreptimeTeam/greptimedb/releases/latest" | sed -n 's/.*"tag_name": "\([^"]*\)".*/\1/p')
 
 curl -sOL "https://github.com/GreptimeTeam/greptimedb/releases/download/${VERSION}/greptime-android-arm64-${VERSION}.tar.gz"
 tar zxvf ./greptime-android-arm64-${VERSION}.tar.gz
@@ -39,7 +42,7 @@ cat <<EOF > ./config.toml
 addr = "0.0.0.0:4000"
 
 [grpc]
-addr = "0.0.0.0:4001"
+bind_addr = "0.0.0.0:4001"
 
 [mysql]
 addr = "0.0.0.0:4002"

--- a/versioned_docs/version-0.10/user-guide/deployments/run-on-android.md
+++ b/versioned_docs/version-0.10/user-guide/deployments/run-on-android.md
@@ -10,7 +10,10 @@ You can install [Termux](https://termux.dev/) from [GitHub release page](https:/
 ## Download GreptimeDB Android binary.
 
 ```bash
-VERSION=$(curl -s -XGET "https://api.github.com/repos/GreptimeTeam/greptimedb/releases" | grep tag_name | grep -v nightly | cut -d: -f 2 | sed 's/.*"\(.*\)".*/\1/' | uniq | sort -r | head -n 1)
+VERSION=$(curl -sL \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/repos/GreptimeTeam/greptimedb/releases/latest" | sed -n 's/.*"tag_name": "\([^"]*\)".*/\1/p')
 
 curl -sOL "https://github.com/GreptimeTeam/greptimedb/releases/download/${VERSION}/greptime-android-arm64-${VERSION}.tar.gz"
 tar zxvf ./greptime-android-arm64-${VERSION}.tar.gz

--- a/versioned_docs/version-0.10/user-guide/deployments/run-on-android.md
+++ b/versioned_docs/version-0.10/user-guide/deployments/run-on-android.md
@@ -1,3 +1,7 @@
+---
+keywords: [Configuration, Embedded Platform, Android]
+description: Step-by-step tutorial for running GreptimeDB on Android devices.
+---
 # Run on Android Platforms
 
 Since v0.4.0, GreptimeDB supports running on Android platforms with ARM64 CPU and Android API level >= 23.

--- a/versioned_docs/version-0.11/user-guide/deployments/run-on-android.md
+++ b/versioned_docs/version-0.11/user-guide/deployments/run-on-android.md
@@ -15,7 +15,10 @@ You can install [Termux](https://termux.dev/) from [GitHub release page](https:/
 ## Download GreptimeDB Android binary.
 
 ```bash
-VERSION=$(curl -s -XGET "https://api.github.com/repos/GreptimeTeam/greptimedb/releases" | grep tag_name | grep -v nightly | cut -d: -f 2 | sed 's/.*"\(.*\)".*/\1/' | uniq | sort -r | head -n 1)
+VERSION=$(curl -sL \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/repos/GreptimeTeam/greptimedb/releases/latest" | sed -n 's/.*"tag_name": "\([^"]*\)".*/\1/p')
 
 curl -sOL "https://github.com/GreptimeTeam/greptimedb/releases/download/${VERSION}/greptime-android-arm64-${VERSION}.tar.gz"
 tar zxvf ./greptime-android-arm64-${VERSION}.tar.gz

--- a/versioned_docs/version-0.12/user-guide/deployments/run-on-android.md
+++ b/versioned_docs/version-0.12/user-guide/deployments/run-on-android.md
@@ -15,7 +15,11 @@ You can install [Termux](https://termux.dev/) from [GitHub release page](https:/
 ## Download GreptimeDB Android binary.
 
 ```bash
-VERSION=$(curl -s -XGET "https://api.github.com/repos/GreptimeTeam/greptimedb/releases" | grep tag_name | grep -v nightly | cut -d: -f 2 | sed 's/.*"\(.*\)".*/\1/' | uniq | sort -r | head -n 1)
+VERSION=$(curl -sL \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/repos/GreptimeTeam/greptimedb/releases/latest" | sed -n 's/.*"tag_name": "\([^"]*\)".*/\1/p')
+
 
 curl -sOL "https://github.com/GreptimeTeam/greptimedb/releases/download/${VERSION}/greptime-android-arm64-${VERSION}.tar.gz"
 tar zxvf ./greptime-android-arm64-${VERSION}.tar.gz
@@ -37,7 +41,7 @@ cat <<EOF > ./config.toml
 addr = "0.0.0.0:4000"
 
 [grpc]
-addr = "0.0.0.0:4001"
+bind_addr = "0.0.0.0:4001"
 
 [mysql]
 addr = "0.0.0.0:4002"


### PR DESCRIPTION

## What's Changed in this PR

- fix the script to fetch latest version of greptimedb
 - **Configuration Update**: Changed the `grpc` configuration parameter from `addr` to `bind_addr` in `run-on-android.md` files.


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
