### PR TITLE
docs: add quantile, sort, sort_desc etc. to supported list for promql

### DIFF
--- a/docs/user-guide/query-data/promql.md
+++ b/docs/user-guide/query-data/promql.md
@@ -189,21 +189,22 @@ None
 - Supported:
     | Aggregator | Example                   |
     | :--------- | :------------------------ |
-    | sum        | `sum by (foo)(metric)`    |
-    | avg        | `avg by (foo)(metric)`    |
-    | min        | `min by (foo)(metric)`    |
-    | max        | `max by (foo)(metric)`    |
-    | stddev     | `stddev by (foo)(metric)` |
-    | stdvar     | `stdvar by (foo)(metric)` |
+    | sum          | `sum by (foo)(metric)`    |
+    | avg          | `avg by (foo)(metric)`    |
+    | min          | `min by (foo)(metric)`    |
+    | max          | `max by (foo)(metric)`    |
+    | stddev       | `stddev by (foo)(metric)` |
+    | stdvar       | `stdvar by (foo)(metric)` |
+    | topk         | `topk(3, rate(instance_cpu_time_ns[5m]))`   |
+    | bottomk      | `bottomk(3, rate(instance_cpu_time_ns[5m]))`|
+    | count_values | `count_values("version", build_version)`    |
+    | quantile     | `quantile(0.9, cpu_usage)` |
 
 - Unsupported:
     | Aggregator   | Progress |
     | :----------- | :------- |
     | count        | TBD      |
     | grouping     | TBD      |
-    | topk         | TBD      |
-    | bottomk      | TBD      |
-    | count_values | TBD      |
 
 ### Instant Functions
 
@@ -231,6 +232,8 @@ None
     | scalar             | `scalar(metric)`                  |
     | tanh               | `tanh(metric)`                    |
     | timestamp          | `timestamp()`                     |
+    | sort               | `sort(http_requests_total)`       |
+    | sort_desc          | `sort_desc(http_requests_total)`  |
     | histogram_quantile | `histogram_quantile(phi, metric)` |
 
 - Unsupported:
@@ -238,8 +241,6 @@ None
     | :------------------------- | :----------------- |
     | absent                     | TBD                |
     | sgn                        | TBD                |
-    | sort                       | TBD                |
-    | sort_desc                  | TBD                |
     | deg                        | TBD                |
     | rad                        | TBD                |
     | *other multiple input fns* | TBD                |

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/query-data/promql.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/query-data/promql.md
@@ -194,15 +194,16 @@ PromQL 的时间戳精度受制于查询语法的限制，最高只支持毫秒�
     | max        | `max by (foo)(metric)`    |
     | stddev     | `stddev by (foo)(metric)` |
     | stdvar     | `stdvar by (foo)(metric)` |
+    | topk         | `topk(3, rate(instance_cpu_time_ns[5m]))`   |
+    | bottomk      | `bottomk(3, rate(instance_cpu_time_ns[5m]))`|
+    | count_values | `count_values("version", build_version)`    |
+    | quantile     | `quantile(0.9, cpu_usage)` |
 
 - 不支持:
     | Aggregator   | Progress |
     | :----------- | :------- |
     | count        | TBD      |
     | grouping     | TBD      |
-    | topk         | TBD      |
-    | bottomk      | TBD      |
-    | count_values | TBD      |
 
 ### Instant Functions
 
@@ -230,6 +231,8 @@ PromQL 的时间戳精度受制于查询语法的限制，最高只支持毫秒�
     | scalar             | `scalar(metric)`                  |
     | tanh               | `tanh(metric)`                    |
     | timestamp          | `timestamp()`                     |
+    | sort               | `sort(http_requests_total)`       |
+    | sort_desc          | `sort_desc(http_requests_total)`  |
     | histogram_quantile | `histogram_quantile(phi, metric)` |
 
 - 不支持:
@@ -237,8 +240,6 @@ PromQL 的时间戳精度受制于查询语法的限制，最高只支持毫秒�
     | :------------------------- | :------- |
     | absent                     | TBD      |
     | sgn                        | TBD      |
-    | sort                       | TBD      |
-    | sort_desc                  | TBD      |
     | deg                        | TBD      |
     | rad                        | TBD      |
     | *other multiple input fns* | TBD      |

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.13/user-guide/query-data/promql.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.13/user-guide/query-data/promql.md
@@ -194,15 +194,16 @@ PromQL 的时间戳精度受制于查询语法的限制，最高只支持毫秒�
     | max        | `max by (foo)(metric)`    |
     | stddev     | `stddev by (foo)(metric)` |
     | stdvar     | `stdvar by (foo)(metric)` |
+    | topk         | `topk(3, rate(instance_cpu_time_ns[5m]))`   |
+    | bottomk      | `bottomk(3, rate(instance_cpu_time_ns[5m]))`|
+    | count_values | `count_values("version", build_version)`    |
+    | quantile     | `quantile(0.9, cpu_usage)` |
 
 - 不支持:
     | Aggregator   | Progress |
     | :----------- | :------- |
     | count        | TBD      |
     | grouping     | TBD      |
-    | topk         | TBD      |
-    | bottomk      | TBD      |
-    | count_values | TBD      |
 
 ### Instant Functions
 
@@ -230,6 +231,8 @@ PromQL 的时间戳精度受制于查询语法的限制，最高只支持毫秒�
     | scalar             | `scalar(metric)`                  |
     | tanh               | `tanh(metric)`                    |
     | timestamp          | `timestamp()`                     |
+    | sort               | `sort(http_requests_total)`       |
+    | sort_desc          | `sort_desc(http_requests_total)`  |
     | histogram_quantile | `histogram_quantile(phi, metric)` |
 
 - 不支持:
@@ -237,8 +240,6 @@ PromQL 的时间戳精度受制于查询语法的限制，最高只支持毫秒�
     | :------------------------- | :------- |
     | absent                     | TBD      |
     | sgn                        | TBD      |
-    | sort                       | TBD      |
-    | sort_desc                  | TBD      |
     | deg                        | TBD      |
     | rad                        | TBD      |
     | *other multiple input fns* | TBD      |

--- a/versioned_docs/version-0.13/user-guide/query-data/promql.md
+++ b/versioned_docs/version-0.13/user-guide/query-data/promql.md
@@ -189,21 +189,22 @@ None
 - Supported:
     | Aggregator | Example                   |
     | :--------- | :------------------------ |
-    | sum        | `sum by (foo)(metric)`    |
-    | avg        | `avg by (foo)(metric)`    |
-    | min        | `min by (foo)(metric)`    |
-    | max        | `max by (foo)(metric)`    |
-    | stddev     | `stddev by (foo)(metric)` |
-    | stdvar     | `stdvar by (foo)(metric)` |
+    | sum          | `sum by (foo)(metric)`    |
+    | avg          | `avg by (foo)(metric)`    |
+    | min          | `min by (foo)(metric)`    |
+    | max          | `max by (foo)(metric)`    |
+    | stddev       | `stddev by (foo)(metric)` |
+    | stdvar       | `stdvar by (foo)(metric)` |
+    | topk         | `topk(3, rate(instance_cpu_time_ns[5m]))`   |
+    | bottomk      | `bottomk(3, rate(instance_cpu_time_ns[5m]))`|
+    | count_values | `count_values("version", build_version)`    |
+    | quantile     | `quantile(0.9, cpu_usage)` |
 
 - Unsupported:
     | Aggregator   | Progress |
     | :----------- | :------- |
     | count        | TBD      |
     | grouping     | TBD      |
-    | topk         | TBD      |
-    | bottomk      | TBD      |
-    | count_values | TBD      |
 
 ### Instant Functions
 
@@ -231,6 +232,8 @@ None
     | scalar             | `scalar(metric)`                  |
     | tanh               | `tanh(metric)`                    |
     | timestamp          | `timestamp()`                     |
+    | sort               | `sort(http_requests_total)`       |
+    | sort_desc          | `sort_desc(http_requests_total)`  |
     | histogram_quantile | `histogram_quantile(phi, metric)` |
 
 - Unsupported:
@@ -238,8 +241,6 @@ None
     | :------------------------- | :----------------- |
     | absent                     | TBD                |
     | sgn                        | TBD                |
-    | sort                       | TBD                |
-    | sort_desc                  | TBD                |
     | deg                        | TBD                |
     | rad                        | TBD                |
     | *other multiple input fns* | TBD                |


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

*Describe the change in this PR*

Close #1515 
Close #1524
Close #1550
Close  #1551 


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
