### PR TITLE
docs: rename engine introduction and add links to it

### DIFF
--- a/docs/contributor-guide/overview.md
+++ b/docs/contributor-guide/overview.md
@@ -33,6 +33,7 @@ To better understand `GreptimeDB`, a few concepts need to be introduced:
   `metasrv`, tells which `region` of a `table` is served by which `datanode`.
 - A `frontend` is a stateless service that serves requests from client. It acts as a proxy to
   forward read and write requests to corresponding `datanode`, according to the mapping from catalog.
+- Table engines (also called storage engines) determine how data is stored, managed, and processed within the database. Each engine offers different features, performance characteristics, and trade-offs. See [Table Engines](/reference/about-greptimedb-engines.md) for more information.
 - A timeseries of a `table` is identified by its primary key. Each `table` must have a timestamp
   column, as `GreptimeDB` is a timeseries database. Data in `table` will be sorted by its primary key
   and

--- a/docs/reference/about-greptimedb-engines.md
+++ b/docs/reference/about-greptimedb-engines.md
@@ -1,13 +1,13 @@
 ---
-keywords: [greptimedb engine, Mito engine, Metric engine, File engile]
-description: Overview all of the engines in GreptimeDB.
+keywords: [greptimedb engine, Mito engine, Metric engine, File engine, Table engine]
+description: Overview of all the table engines in GreptimeDB.
 ---
 
-# About GreptimeDB Engines
+# GreptimeDB Table Engines
 
 ## Overview
 
-GreptimeDB offers multiple specialized engines, each designed to excel at specific workloads and use cases. This document provides a comprehensive introduction to these engines and guidance on when to use each one.
+GreptimeDB offers multiple specialized table engines, each designed to excel at specific workloads and use cases. This document provides a comprehensive introduction to these engines and guidance on when to use each one.
 
 ### Mito Engine
 

--- a/docs/reference/sql/create.md
+++ b/docs/reference/sql/create.md
@@ -73,6 +73,9 @@ CREATE TABLE [IF NOT EXISTS] [db.]table_name
 ```
 
 The table schema is specified by the brackets before the `ENGINE`. The table schema is a list of column definitions and table constraints.
+
+For information on the `engine` option and table engine selection, please refer to the [Table Engines](/reference/about-greptimedb-engines.md) guide.
+
 A column definition includes the column `column_name`, `type`, and options such as nullable or default values, etc. Please see below.
 
 ### Table constraints
@@ -237,7 +240,7 @@ SELECT * from metrics ORDER BY host, ts;
 
 #### Create a physical table with metric engine
 
-The metric engine use synthetic physical wide tables to store a large amount of small table data, achieving effects such as reuse of the same column and metadata. For details, please refer to the [metric engine document](/contributor-guide/datanode/metric-engine).
+The metric engine use synthetic physical wide tables to store a large amount of small table data, achieving effects such as reuse of the same column and metadata. For details, please refer to the [metric engine document](/contributor-guide/datanode/metric-engine) and [Table Engines](/reference/about-greptimedb-engines.md)  introduction.
 
 Create a physical table with the metric engine.
 ```sql

--- a/docs/user-guide/concepts/key-concepts.md
+++ b/docs/user-guide/concepts/key-concepts.md
@@ -27,6 +27,10 @@ In a distributed deployment, a table can be split into multiple partitions that 
 
 For more information about the data model of the time-series table, please refer to [Data Model](./data-model.md).
 
+## Table Engine
+
+Table engines (also called storage engines) determine how data is stored, managed, and processed within the database. Each engine offers different features, performance characteristics, and trade-offs. GreptimeDB supports `mito` and `metric` engines etc., see [Table Engines](/reference/about-greptimedb-engines.md) for more information.
+
 ## Table Region
 
 Each partition of distributed table is called a region. A region may contain a

--- a/i18n/zh/docusaurus-plugin-content-docs/current/contributor-guide/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/contributor-guide/overview.md
@@ -25,6 +25,7 @@ description: 介绍 GreptimeDB 的架构、关键概念和工作原理，包括�
 - `metasrv` 服务器存储集群的元数据，例如表、`datanode`、每个表的 `region` 等。它还协调 `frontend` 和 `datanode`。
 - `frontend` 有一个 catalog 实现，它从 `metasrv` 中获取元数据，告诉相应的组件哪个 `table` 的 `region` 由哪个 `datanode` 提供服务。
 - `frontend` 是一个无状态服务，用于接收客户端的请求。它作为 proxy 根据 catalog 中的信息将读取和写入请求转发到相应的 `datanode`。
+- 表引擎（也称为存储引擎）决定了数据在数据库中的存储、管理和处理方式。每种引擎提供不同的功能特性、性能表现和权衡取舍。有关更多信息，请参阅[表引擎](/reference/about-greptimedb-engines.md)。
 - 一个 `table` 的时间线 (time-series) 由其主键标识。因为 `GreptimeDB` 是一个时间序列数据库，所以每个 `table` 必须有一个时间戳列。`table` 中的数据将按其主键和时间戳排序，但顺序的实际实现方式比较特殊，可能会在将来发生变化。
 
 ## 工作原理

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/about-greptimedb-engines.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/about-greptimedb-engines.md
@@ -1,13 +1,13 @@
 ---
-keywords: [greptimedb 引擎, Mito 引擎, Metric 引擎, File 引擎]
-description: GreptimeDB 中所有引擎的概述。
+keywords: [greptimedb 引擎, Mito 引擎, Metric 引擎, File 引擎, 表引擎]
+description: GreptimeDB 中所有表引擎的概述。
 ---
 
-# 关于 GreptimeDB 引擎
+# GreptimeDB 表引擎
 
 ## 概述
 
-GreptimeDB 提供多种专业引擎，每种引擎都针对特定工作负载和使用场景进行了优化设计。本文档全面介绍了这些引擎，并提供了何时使用每种引擎的指导。
+GreptimeDB 提供多种专业的表引擎（Table Engine），每种引擎都针对特定工作负载和使用场景进行了优化设计。本文档全面介绍了这些引擎，并提供了何时使用每种引擎的指导。
 
 ### Mito 引擎
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/create.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/create.md
@@ -76,6 +76,8 @@ CREATE TABLE [IF NOT EXISTS] [db.]table_name
 表 schema 由 `ENGINE` 之前的括号指定，表 schema 是列的定义和表的约束。
 列定义包括列名称和数据类型，以及可选的 `NULL`、`NOT NULL`、`DEFAULT` 等。
 
+关于 `engine` 选项和表引擎的选择，请阅读[表引擎](/reference/about-greptimedb-engines.md)介绍。
+
 ### 表约束
 
 表约束包括以下内容：
@@ -243,7 +245,7 @@ SELECT * from metrics ORDER BY host, ts;
 
 #### 创建 metric engine 的物理表
 
-metric engine 使用合成物理宽表来存储大量的小表数据，实现重用相同列和元数据的效果。详情请参考 [metric engine 文档](/contributor-guide/datanode/metric-engine).
+metric engine 使用合成物理宽表来存储大量的小表数据，实现重用相同列和元数据的效果。详情请参考 [metric engine 文档](/contributor-guide/datanode/metric-engine)和[表引擎](/reference/about-greptimedb-engines.md)介绍。
 
 创建一个使用 metric engine 的物理表。
 ```sql

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/key-concepts.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/key-concepts.md
@@ -26,6 +26,10 @@ GreptimeDB 将时序表设计为数据存储的基本单位。
 
 关于时序表的数据模型的更多信息，请参考[数据模型](./data-model.md)。
 
+## Table Engine
+
+表引擎（也称为存储引擎）决定了数据在数据库中的存储、管理和处理方式。每种引擎提供不同的功能特性、性能表现和权衡取舍。GreptimeDB 提供了 `moto` 和 `metric` 引擎，有关更多信息，请参阅[表引擎](/reference/about-greptimedb-engines.md)。
+
 ## Table Region
 
 分布式表的每个分区被称为一个区域。一个区域可能包含一个连续数据的序列，这取决于分区算法，区域信息由 Metasrv 管理。这对发送写入和查询的用户来说是完全透明的。


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

*Describe the change in this PR*

* Rename engines introduction doc.
* Adds links to the engine intro doc.

## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
