### PR TITLE
docs: add explain analyze verbose example

### DIFF
--- a/docs/reference/sql/explain.md
+++ b/docs/reference/sql/explain.md
@@ -67,7 +67,7 @@ stage: NULL
 
 The `EXPLAIN ANALYZE` command provides metrics about the execution of each stage. The `SeqScan` plan scans the data from a single region.
 
-Explains the verbose information of the plan execution.
+Explains the verbose information of the plan execution:
 ```sql
 EXPLAIN ANALYZE VERBOSE SELECT * FROM monitor where host='host1';
 ```

--- a/docs/reference/sql/explain.md
+++ b/docs/reference/sql/explain.md
@@ -10,51 +10,85 @@ description: Provides information on the SQL EXPLAIN statement to obtain the exe
 ## Syntax
 
 ```sql
-EXPLAIN [ANALYZE] SELECT ...
+EXPLAIN [ANALYZE] [VERBOSE] SELECT ...
 ```
 
 The `ANALYZE` clause will execute the statement and measure time spent at each plan node and the total rows of the output etc.
+
+The `VERBOSE` clause will provide more detailed information about the execution plan.
 
 ## Examples
 
 Explains the following query:
 
 ```sql
-EXPLAIN SELECT * FROM monitor where host='host1';
+EXPLAIN SELECT * FROM monitor where host='host1'\G
 ```
 
+Example:
+
 ```sql
-| plan_type     | plan                                                                                                                                                                                                                                                         
-| logical_plan  | Projection: monitor.host, monitor.ts, monitor.cpu, monitor.memory
-  Filter: monitor.host = Utf8("host1")
-    TableScan: monitor projection=[host, ts, cpu, memory], partial_filters=[monitor.host = Utf8("host1")]                                           |
-| physical_plan | ProjectionExec: expr=[host@0 as host, ts@1 as ts, cpu@2 as cpu, memory@3 as memory]
-  CoalesceBatchesExec: target_batch_size=4096
-    FilterExec: host@0 = host1
-      RepartitionExec: partitioning=RoundRobinBatch(10)
-        ExecutionPlan(PlaceHolder)
+*************************** 1. row ***************************
+plan_type: logical_plan
+     plan: MergeScan [is_placeholder=false]
+*************************** 2. row ***************************
+plan_type: physical_plan
+     plan: MergeScanExec: peers=[4612794875904(1074, 0), ]
 ```
 
 The column `plan_type` indicates whether it's a`logical_plan` or `physical_plan`. And the column `plan` explains the plan in detail.
 
+The `MergeScan` plan merges the results from multiple regions. The `peers` array in the `MergeScanExec` physical plan contains the IDs of the regions that the plan will scan.
+
 Explains the execution of the plan by `ANALYZE`:
 
 ```sql
-EXPLAIN ANALYZE SELECT * FROM monitor where host='host1';
+EXPLAIN ANALYZE SELECT * FROM monitor where host='host1'\G
 ```
+
+Example:
 
 ```sql
-| plan_type         | plan
-| Plan with Metrics | CoalescePartitionsExec, metrics=[output_rows=1, elapsed_compute=79.167µs, spill_count=0, spilled_bytes=0, mem_used=0]
-  ProjectionExec: expr=[host@0 as host, ts@1 as ts, cpu@2 as cpu, memory@3 as memory], metrics=[output_rows=1, elapsed_compute=17.176µs, spill_count=0, spilled_bytes=0, mem_used=0]
-    CoalesceBatchesExec: target_batch_size=4096, metrics=[output_rows=1, elapsed_compute=14.248µs, spill_count=0, spilled_bytes=0, mem_used=0]
-      CoalesceBatchesExec: target_batch_size=4096, metrics=[output_rows=1, elapsed_compute=17.21µs, spill_count=0, spilled_bytes=0, mem_used=0]
-        FilterExec: host@0 = host1, metrics=[output_rows=1, elapsed_compute=541.801µs, spill_count=0, spilled_bytes=0, mem_used=0]
-          CoalesceBatchesExec: target_batch_size=4096, metrics=[output_rows=3, elapsed_compute=43.004µs, spill_count=0, spilled_bytes=0, mem_used=0]
-            RepartitionExec: partitioning=RoundRobinBatch(10), metrics=[fetch_time=5.832958ms, repart_time=10ns, send_time=2.467µs]
-              RepartitionExec: partitioning=RoundRobinBatch(10), metrics=[fetch_time=386.585µs, repart_time=1ns, send_time=7.833µs]
-                ExecutionPlan(PlaceHolder), metrics=[]
-                
+*************************** 1. row ***************************
+stage: 0
+ node: 0
+ plan:  MergeScanExec: peers=[4612794875904(1074, 0), ] metrics=[output_rows: 0, greptime_exec_read_cost: 0, finish_time: 3301415, first_consume_time: 3299166, ready_time: 3104209, ]
+
+*************************** 2. row ***************************
+stage: 1
+ node: 0
+ plan:  SeqScan: region=4612794875904(1074, 0), partition_count=0 (0 memtable ranges, 0 file 0 ranges) metrics=[output_rows: 0, mem_used: 0, build_parts_cost: 1, build_reader_cost: 1, elapsed_await: 1, elapsed_poll: 21250, scan_cost: 1, yield_cost: 1, ]
+
+*************************** 3. row ***************************
+stage: NULL
+ node: NULL
+ plan: Total rows: 0
 ```
 
-TODO: explains the output of `ANALYZE`.
+The `EXPLAIN ANALYZE` command provides metrics about the execution of each stage. The `SeqScan` plan scans the data from a single region.
+
+Explains the verbose information of the plan execution.
+```sql
+EXPLAIN ANALYZE VERBOSE SELECT * FROM monitor where host='host1';
+```
+
+Example:
+
+```sql
+*************************** 1. row ***************************
+stage: 0
+ node: 0
+ plan:  MergeScanExec: peers=[4612794875904(1074, 0), ] metrics=[output_rows: 0, greptime_exec_read_cost: 0, finish_time: 3479084, first_consume_time: 3476000, ready_time: 3209041, ]
+
+*************************** 2. row ***************************
+stage: 1
+ node: 0
+ plan:  SeqScan: region=4612794875904(1074, 0), partition_count=0 (0 memtable ranges, 0 file 0 ranges), projection=["host", "ts", "cpu", "memory"], filters=[host = Utf8("host1")], metrics_per_partition: [[partition=0, {prepare_scan_cost=579.75µs, build_reader_cost=0ns, scan_cost=0ns, convert_cost=0ns, yield_cost=0ns, total_cost=789.708µs, num_rows=0, num_batches=0, num_mem_ranges=0, num_file_ranges=0, build_parts_cost=0ns, rg_total=0, rg_fulltext_filtered=0, rg_inverted_filtered=0, rg_minmax_filtered=0, rg_bloom_filtered=0, rows_before_filter=0, rows_fulltext_filtered=0, rows_inverted_filtered=0, rows_bloom_filtered=0, rows_precise_filtered=0, num_sst_record_batches=0, num_sst_batches=0, num_sst_rows=0, first_poll=785.041µs}]] metrics=[output_rows: 0, mem_used: 0, build_parts_cost: 1, build_reader_cost: 1, elapsed_await: 1, elapsed_poll: 17208, scan_cost: 1, yield_cost: 1, ]
+
+*************************** 3. row ***************************
+stage: NULL
+ node: NULL
+ plan: Total rows: 0
+```
+
+The `EXPLAIN ANALYZE VERBOSE` command provides the detial metrics about the execution of scan plans.

--- a/docs/reference/sql/explain.md
+++ b/docs/reference/sql/explain.md
@@ -91,4 +91,4 @@ stage: NULL
  plan: Total rows: 0
 ```
 
-The `EXPLAIN ANALYZE VERBOSE` command provides the detial metrics about the execution of scan plans.
+The `EXPLAIN ANALYZE VERBOSE` command provides the detail metrics about the execution of scan plans.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/explain.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/explain.md
@@ -10,49 +10,86 @@ description: EXPLAIN 用于提供语句的执行计划，ANALYZE 子句将执行
 ## Syntax
 
 ```sql
-EXPLAIN [ANALYZE] SELECT ...
+EXPLAIN [ANALYZE] [VERBOSE] SELECT ...
 ```
 
 `ANALYZE` 子句将执行语句并测量每个计划节点花费的时间以及输出的总行数等。
 
+`VERBOSE` 子句可以进一步提供执行计划时详细的信息。
+
 ## 示例
 
-```sql
-EXPLAIN SELECT * FROM monitor where host='host1';
-```
+Explain 以下的查询：
 
 ```sql
-| plan_type     | plan                                                                                                                                                                                                                                                         
-| logical_plan  | Projection: monitor.host, monitor.ts, monitor.cpu, monitor.memory
-  Filter: monitor.host = Utf8("host1")
-    TableScan: monitor projection=[host, ts, cpu, memory], partial_filters=[monitor.host = Utf8("host1")]                                           |
-| physical_plan | ProjectionExec: expr=[host@0 as host, ts@1 as ts, cpu@2 as cpu, memory@3 as memory]
-  CoalesceBatchesExec: target_batch_size=4096
-    FilterExec: host@0 = host1
-      RepartitionExec: partitioning=RoundRobinBatch(10)
-        ExecutionPlan(PlaceHolder)
+EXPLAIN SELECT * FROM monitor where host='host1'\G
+```
+
+样例输出：
+
+```sql
+*************************** 1. row ***************************
+plan_type: logical_plan
+     plan: MergeScan [is_placeholder=false]
+*************************** 2. row ***************************
+plan_type: physical_plan
+     plan: MergeScanExec: peers=[4612794875904(1074, 0), ]
 ```
 
 `plan_type` 列指示了是 `logical_plan` 还是 `physical_plan`，`plan` 列详细说明了执行计划。
 
+`MergeScan` 计划负责合并多个 region 的查询结果。物理计划 `MergeScanExec` 中的 `peers` 数组包含了将要扫描的 region 的 ID。
+
 使用 `ANALYZE` 解释执行计划：
 
 ```sql
-EXPLAIN ANALYZE SELECT * FROM monitor where host='host1';
+EXPLAIN ANALYZE SELECT * FROM monitor where host='host1'\G
 ```
+
+样例输出：
 
 ```sql
-| plan_type         | plan
-| Plan with Metrics | CoalescePartitionsExec, metrics=[output_rows=1, elapsed_compute=79.167µs, spill_count=0, spilled_bytes=0, mem_used=0]
-  ProjectionExec: expr=[host@0 as host, ts@1 as ts, cpu@2 as cpu, memory@3 as memory], metrics=[output_rows=1, elapsed_compute=17.176µs, spill_count=0, spilled_bytes=0, mem_used=0]
-    CoalesceBatchesExec: target_batch_size=4096, metrics=[output_rows=1, elapsed_compute=14.248µs, spill_count=0, spilled_bytes=0, mem_used=0]
-      CoalesceBatchesExec: target_batch_size=4096, metrics=[output_rows=1, elapsed_compute=17.21µs, spill_count=0, spilled_bytes=0, mem_used=0]
-        FilterExec: host@0 = host1, metrics=[output_rows=1, elapsed_compute=541.801µs, spill_count=0, spilled_bytes=0, mem_used=0]
-          CoalesceBatchesExec: target_batch_size=4096, metrics=[output_rows=3, elapsed_compute=43.004µs, spill_count=0, spilled_bytes=0, mem_used=0]
-            RepartitionExec: partitioning=RoundRobinBatch(10), metrics=[fetch_time=5.832958ms, repart_time=10ns, send_time=2.467µs]
-              RepartitionExec: partitioning=RoundRobinBatch(10), metrics=[fetch_time=386.585µs, repart_time=1ns, send_time=7.833µs]
-                ExecutionPlan(PlaceHolder), metrics=[]
-                
+*************************** 1. row ***************************
+stage: 0
+ node: 0
+ plan:  MergeScanExec: peers=[4612794875904(1074, 0), ] metrics=[output_rows: 0, greptime_exec_read_cost: 0, finish_time: 3301415, first_consume_time: 3299166, ready_time: 3104209, ]
+
+*************************** 2. row ***************************
+stage: 1
+ node: 0
+ plan:  SeqScan: region=4612794875904(1074, 0), partition_count=0 (0 memtable ranges, 0 file 0 ranges) metrics=[output_rows: 0, mem_used: 0, build_parts_cost: 1, build_reader_cost: 1, elapsed_await: 1, elapsed_poll: 21250, scan_cost: 1, yield_cost: 1, ]
+
+*************************** 3. row ***************************
+stage: NULL
+ node: NULL
+ plan: Total rows: 0
 ```
 
-<!-- TODO: explains the output of `ANALYZE`. -->
+`EXPLAIN ANALYZE` 语句提供了每个执行阶段的指标。`SeqScan` 计划会扫描一个 region 的数据。
+
+获取查询执行更详细的信息：
+
+```sql
+EXPLAIN ANALYZE VERBOSE SELECT * FROM monitor where host='host1';
+```
+
+样例输出：
+
+```sql
+*************************** 1. row ***************************
+stage: 0
+ node: 0
+ plan:  MergeScanExec: peers=[4612794875904(1074, 0), ] metrics=[output_rows: 0, greptime_exec_read_cost: 0, finish_time: 3479084, first_consume_time: 3476000, ready_time: 3209041, ]
+
+*************************** 2. row ***************************
+stage: 1
+ node: 0
+ plan:  SeqScan: region=4612794875904(1074, 0), partition_count=0 (0 memtable ranges, 0 file 0 ranges), projection=["host", "ts", "cpu", "memory"], filters=[host = Utf8("host1")], metrics_per_partition: [[partition=0, {prepare_scan_cost=579.75µs, build_reader_cost=0ns, scan_cost=0ns, convert_cost=0ns, yield_cost=0ns, total_cost=789.708µs, num_rows=0, num_batches=0, num_mem_ranges=0, num_file_ranges=0, build_parts_cost=0ns, rg_total=0, rg_fulltext_filtered=0, rg_inverted_filtered=0, rg_minmax_filtered=0, rg_bloom_filtered=0, rows_before_filter=0, rows_fulltext_filtered=0, rows_inverted_filtered=0, rows_bloom_filtered=0, rows_precise_filtered=0, num_sst_record_batches=0, num_sst_batches=0, num_sst_rows=0, first_poll=785.041µs}]] metrics=[output_rows: 0, mem_used: 0, build_parts_cost: 1, build_reader_cost: 1, elapsed_await: 1, elapsed_poll: 17208, scan_cost: 1, yield_cost: 1, ]
+
+*************************** 3. row ***************************
+stage: NULL
+ node: NULL
+ plan: Total rows: 0
+```
+
+`EXPLAIN ANALYZE VERBOSE` 语句会展示计划执行阶段更详细的指标信息。


### PR DESCRIPTION
## What's Changed in this PR

Add SQL example for `EXPLAIN VERBOSE`.

Updates all other examples in the document.

fixes https://github.com/GreptimeTeam/docs/issues/1596


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
