### PR TITLE
docs: add docs for replace statement

### DIFF
--- a/docs/reference/sql/overview.md
+++ b/docs/reference/sql/overview.md
@@ -1,3 +1,8 @@
+---
+keywords: [SQL syntax, SQL examples]
+description: GreptimeDB SQL statements.
+---
+
 # Overview
 
 * [Data Types](./data-types)

--- a/docs/reference/sql/overview.md
+++ b/docs/reference/sql/overview.md
@@ -13,6 +13,7 @@
 * [LIMIT](./limit.md)
 * [JOIN](./join.md)
 * [RANGE](./range.md)
+* [REPLACE](./replace.md)
 * [DELETE](./delete.md)
 * [SHOW](./show.md)
 * [TQL](./tql.md)

--- a/docs/reference/sql/replace.md
+++ b/docs/reference/sql/replace.md
@@ -1,0 +1,39 @@
+---
+keywords: [SQL REPLACE, SQL syntax, SQL examples, inserting records, SQL data manipulation]
+description: Describes the SQL REPLACE statement for adding records to a table in GreptimeDB, including syntax, examples for inserting single and multiple records.
+---
+
+# REPLACE
+
+The `REPLACE` statement is used to insert a new record into a table. In GreptimeDB, this statement is exactly the same as the `INSERT` statement. Please refer to [`INSERT`](/reference/sql/insert.md) for more details.
+
+## `REPLACE INTO` Statement
+
+### Syntax
+
+The syntax for the REPLACE INTO statement is as follows:
+
+```sql
+REPLACE INTO table_name (column1, column2, column3, ...)
+VALUES (value1, value2, value3, ...);
+```
+
+### Examples
+
+Here is an example of an `REPLACE INTO` statement that inserts a record into a table named `system_metrics`:
+
+```sql
+REPLACE INTO system_metrics (host, idc, cpu_util, memory_util, disk_util, ts)
+VALUES
+    ("host1", "idc_b", 50.0, 66.7, 40.6, 1667446797462);
+```
+
+Here is an example of an `REPLACE INTO` statement that inserts multiple records into the `system_metrics` table:
+
+```sql
+REPLACE INTO system_metrics (host, idc, cpu_util, memory_util, disk_util, ts)
+VALUES
+    ("host1", "idc_a", 11.8, 10.3, 10.3, 1667446797460),
+    ("host2", "idc_a", 80.1, 70.3, 90.0, 1667446797461),
+    ("host1", "idc_c", 50.1, 66.8, 40.8, 1667446797463);
+```

--- a/docs/reference/sql/replace.md
+++ b/docs/reference/sql/replace.md
@@ -5,7 +5,7 @@ description: Describes the SQL REPLACE statement for adding records to a table i
 
 # REPLACE
 
-The `REPLACE` statement is used to insert a new record into a table. In GreptimeDB, this statement is exactly the same as the `INSERT` statement. Please refer to [`INSERT`](/reference/sql/insert.md) for more details.
+The `REPLACE` statement is used to insert new records into a table. In GreptimeDB, this statement is exactly the same as the `INSERT` statement. Please refer to [`INSERT`](/reference/sql/insert.md) for more details.
 
 ## `REPLACE INTO` Statement
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/overview.md
@@ -1,3 +1,8 @@
+---
+keywords: [SQL 语法, SQL 示例]
+description: GreptimeDB SQL 语句.
+---
+
 # 概述
 
 * [数据类型](./data-types)
@@ -13,6 +18,7 @@
 * [LIMIT](./limit.md)
 * [JOIN](./join.md)
 * [RANGE](./range.md)
+* [REPLACE](./replace.md)
 * [DELETE](./delete.md)
 * [SHOW](./show.md)
 * [TQL](./tql.md)

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/replace.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/replace.md
@@ -1,0 +1,39 @@
+---
+keywords: [SQL REPLACE 语句, SQL 语法, SQL 示例, 插入记录, SQL 数据操作]
+description: 描述在 GreptimeDB 中使用 SQL REPLACE 语句向表中添加记录的方法，包括语法和插入单条及多条记录的示例。
+---
+
+# REPLACE
+
+`REPLACE` 语句用于向表中插入新记录。在 GreptimeDB 中，这个语句与 `INSERT` 语句完全相同。更多详情请参考 [`INSERT`](/reference/sql/insert.md)。
+
+## `REPLACE INTO` 语句
+
+### 语法
+
+REPLACE INTO 语句的语法如下：
+
+```sql
+REPLACE INTO table_name (column1, column2, column3, ...)
+VALUES (value1, value2, value3, ...);
+```
+
+### 示例
+
+以下是使用 `REPLACE INTO` 语句向名为 `system_metrics` 的表中插入一条记录的示例：
+
+```sql
+REPLACE INTO system_metrics (host, idc, cpu_util, memory_util, disk_util, ts)
+VALUES
+    ("host1", "idc_b", 50.0, 66.7, 40.6, 1667446797462);
+```
+
+以下是使用 `REPLACE INTO` 语句向 `system_metrics` 表中插入多条记录的示例：
+
+```sql
+REPLACE INTO system_metrics (host, idc, cpu_util, memory_util, disk_util, ts)
+VALUES
+    ("host1", "idc_a", 11.8, 10.3, 10.3, 1667446797460),
+    ("host2", "idc_a", 80.1, 70.3, 90.0, 1667446797461),
+    ("host1", "idc_c", 50.1, 66.8, 40.8, 1667446797463);
+```

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -424,6 +424,7 @@ const sidebars: SidebarsConfig = {
             'reference/sql/limit',
             'reference/sql/order_by',
             'reference/sql/range',
+            'reference/sql/replace',
             'reference/sql/select',
             'reference/sql/show',
             'reference/sql/tql',


### PR DESCRIPTION
## What's Changed in this PR

This PR adds a document for the `REPLACE` statement. In GreptimeDB, it is identical to `INSERT`. So the document mainly provides some simple examples.

fixes https://github.com/GreptimeTeam/docs/issues/1625


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
