### PR TITLE
chore: rename alicloud secret key

### DIFF
--- a/.github/workflows/addDocsToS3BucketAWS.yml
+++ b/.github/workflows/addDocsToS3BucketAWS.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    if: ${{ github.repository == 'GreptimeTeam/docs' }}
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/issue-notifier.yml
+++ b/.github/workflows/issue-notifier.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   notify:
+    if: ${{ github.repository == 'GreptimeTeam/docs' }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/docs/user-guide/deployments/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/docs/user-guide/deployments/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -26,7 +26,7 @@ image:
   # -- The image repository
   repository: greptime/greptimedb
   # -- The image tag
-  tag: "v0.11.3"
+  tag: "v0.13.2"
   # -- The image pull secrets
   pullSecrets: []
 ```
@@ -40,7 +40,7 @@ image:
   # -- The image repository
   repository: greptime/greptimedb
   # -- The image tag
-  tag: "v0.11.3"
+  tag: "v0.13.2"
   # -- The image pull secrets
   pullSecrets: []
 
@@ -379,7 +379,7 @@ objectStorage:
     # AliCloud access key ID
     accessKeyId: ""
     # AliCloud access key secret
-    secretAccessKey: ""
+    accessKeySecret: ""
   oss:
     # AliCloud OSS bucket name
     bucket: ""
@@ -419,7 +419,7 @@ debugPod:
   image:
     registry: docker.io
     repository: greptime/greptime-tool
-    tag: "20241107-9c210d18"
+    tag: "20250317-5281e66"
 
   # -- The debug pod resource
   resources:

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -26,7 +26,7 @@ image:
   # -- The image repository
   repository: greptime/greptimedb
   # -- The image tag
-  tag: "v0.11.3"
+  tag: "v0.13.2"
   # -- The image pull secrets
   pullSecrets: []
 ```
@@ -40,7 +40,7 @@ image:
   # -- The image repository
   repository: greptime/greptimedb
   # -- The image tag
-  tag: "v0.11.3"
+  tag: "v0.13.2"
   # -- The image pull secrets
   pullSecrets: []
 
@@ -379,7 +379,7 @@ objectStorage:
     # AliCloud access key ID
     accessKeyId: ""
     # AliCloud access key secret
-    secretAccessKey: ""
+    accessKeySecret: ""
   oss:
     # AliCloud OSS bucket name
     bucket: ""
@@ -419,7 +419,7 @@ debugPod:
   image:
     registry: docker.io
     repository: greptime/greptime-tool
-    tag: "20241107-9c210d18"
+    tag: "20250317-5281e66"
 
   # -- The debug pod resource
   resources:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.13/user-guide/deployments/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.13/user-guide/deployments/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -26,7 +26,7 @@ image:
   # -- The image repository
   repository: greptime/greptimedb
   # -- The image tag
-  tag: "v0.11.3"
+  tag: "v0.13.2"
   # -- The image pull secrets
   pullSecrets: []
 ```
@@ -40,7 +40,7 @@ image:
   # -- The image repository
   repository: greptime/greptimedb
   # -- The image tag
-  tag: "v0.11.3"
+  tag: "v0.13.2"
   # -- The image pull secrets
   pullSecrets: []
 
@@ -379,7 +379,7 @@ objectStorage:
     # AliCloud access key ID
     accessKeyId: ""
     # AliCloud access key secret
-    secretAccessKey: ""
+    accessKeySecret: ""
   oss:
     # AliCloud OSS bucket name
     bucket: ""
@@ -419,7 +419,7 @@ debugPod:
   image:
     registry: docker.io
     repository: greptime/greptime-tool
-    tag: "20241107-9c210d18"
+    tag: "20250317-5281e66"
 
   # -- The debug pod resource
   resources:

--- a/versioned_docs/version-0.13/user-guide/deployments/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/versioned_docs/version-0.13/user-guide/deployments/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -26,7 +26,7 @@ image:
   # -- The image repository
   repository: greptime/greptimedb
   # -- The image tag
-  tag: "v0.11.3"
+  tag: "v0.13.2"
   # -- The image pull secrets
   pullSecrets: []
 ```
@@ -40,7 +40,7 @@ image:
   # -- The image repository
   repository: greptime/greptimedb
   # -- The image tag
-  tag: "v0.11.3"
+  tag: "v0.13.2"
   # -- The image pull secrets
   pullSecrets: []
 
@@ -379,7 +379,7 @@ objectStorage:
     # AliCloud access key ID
     accessKeyId: ""
     # AliCloud access key secret
-    secretAccessKey: ""
+    accessKeySecret: ""
   oss:
     # AliCloud OSS bucket name
     bucket: ""
@@ -419,7 +419,7 @@ debugPod:
   image:
     registry: docker.io
     repository: greptime/greptime-tool
-    tag: "20241107-9c210d18"
+    tag: "20250317-5281e66"
 
   # -- The debug pod resource
   resources:


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

1. Rename `secretAccessKey` to `accessKeySecret`, related to: https://github.com/GreptimeTeam/helm-charts/pull/244
2. Bump greptimedb and debug pod image version
3. Set github workflow to run only in `GreptimeTeam/docs`

## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
