### PR TITLE
docs: emphasis expire after concept

### DIFF
--- a/docs/user-guide/flow-computation/continuous-aggregation.md
+++ b/docs/user-guide/flow-computation/continuous-aggregation.md
@@ -188,7 +188,7 @@ The above query puts the data from the `ngx_access_log` table into the `ngx_coun
 It calculates the distinct country for each time window.
 The `date_bin` function is used to group the data into one-hour intervals.
 The `ngx_country` table will be continuously updated with the aggregated data,
-providing real-time insights into the distinct countries that are accessing the system. The `EXPIRE AFTER` make flow ignore data with `access_time` older than 7 days and no longer update them, see more explain in [manage-flow](manage-flow.md#expire-after).
+providing real-time insights into the distinct countries that are accessing the system. The `EXPIRE AFTER` make flow ignore data with `access_time` older than 7 days and no longer calculate them anymore, see more explain in [manage-flow](manage-flow.md#expire-after).
 
 You can insert some data into the source table `ngx_access_log`:
 

--- a/docs/user-guide/flow-computation/continuous-aggregation.md
+++ b/docs/user-guide/flow-computation/continuous-aggregation.md
@@ -64,7 +64,7 @@ CREATE TABLE `ngx_statistics` (
 
 Then create the flow `ngx_aggregation` to aggregate a series of aggregate functions, including `count`, `min`, `max`, `avg` of the `size` column, and the sum of all packets of size great than 550. The aggregation is calculated in 1-minute fixed windows of `access_time` column and also grouped by the `status` column. So you can be made aware in real time the information about packet size and action upon it, i.e. if the `high_size_count` became too high at a certain point, you can further examine if anything goes wrong, or if the `max_size` column suddenly spike in a 1 minute time window, you can then trying to locate that packet and further inspect it. 
 
-Also notice the `EXPIRE AFTER` clause, it means this flow will reject input data with `access_time` older than `now() - 6` hours, so data in the sink table that is older than 6 hours will no longer be modified by this flow(note the data will **NOT** be deleted),  see more explain in [manage-flow](manage-flow.md#expire-after).
+The `EXPIRE AFTER '6h'` in the following SQL ensures that the flow computation only uses source data from the last 6 hours. Data older than 6 hours in the sink table will not be modified by this flow. For more details, see [manage-flow](manage-flow.md#expire-after).
 
 ```sql
 CREATE FLOW ngx_aggregation
@@ -270,7 +270,7 @@ The above query continuously aggregates data from the `temp_sensor_data` table i
 It calculates the maximum temperature reading for each sensor and location,
 filtering out data where the maximum temperature exceeds 100 degrees.
 The `temp_alerts` table will be continuously updated with the aggregated data,
-providing real-time alerts (in the form of new rows in the `temp_alerts` table) when the temperature exceeds the threshold. The `EXPIRE AFTER '1h'` makes flow only update for data with `ts` in `(now - 1h, now)` range, see more explain in [manage-flow](manage-flow.md#expire-after).
+providing real-time alerts (in the form of new rows in the `temp_alerts` table) when the temperature exceeds the threshold. The `EXPIRE AFTER '1h'` makes flow only calculate source data with `ts` in `(now - 1h, now)` range, see more explain in [manage-flow](manage-flow.md#expire-after).
 
 Now that we have created the flow task, we can insert some data into the source table `temp_sensor_data`:
 
@@ -354,7 +354,8 @@ GROUP BY
 The query aggregates data from the `ngx_access_log` table into the `ngx_distribution` table.
 It computes the total number of logs for each status code and packet size bucket (bucket size of 10, as specified by `trunc` with a second argument of -1) within each time window.
 The `date_bin` function groups the data into one-minute intervals.
-Consequently, the `ngx_distribution` table is continuously updated, offering real-time insights into the distribution of packet sizes per status code. And data that arrive too late (a too old `access_time` from now, '6h' as declared in `EXPIRE AFTER`) will be safely ignore by flow, see more explain in [manage-flow](manage-flow.md#expire-after).
+The `EXPIRE AFTER '6h'` ensures that the flow computation only uses source data from the last 6 hours. See more details in [manage-flow](manage-flow.md#expire-after).
+Consequently, the `ngx_distribution` table is continuously updated, offering real-time insights into the distribution of packet sizes per status code.
 
 Now that we have created the flow task, we can insert some data into the source table `ngx_access_log`:
 

--- a/docs/user-guide/flow-computation/continuous-aggregation.md
+++ b/docs/user-guide/flow-computation/continuous-aggregation.md
@@ -64,7 +64,7 @@ CREATE TABLE `ngx_statistics` (
 
 Then create the flow `ngx_aggregation` to aggregate a series of aggregate functions, including `count`, `min`, `max`, `avg` of the `size` column, and the sum of all packets of size great than 550. The aggregation is calculated in 1-minute fixed windows of `access_time` column and also grouped by the `status` column. So you can be made aware in real time the information about packet size and action upon it, i.e. if the `high_size_count` became too high at a certain point, you can further examine if anything goes wrong, or if the `max_size` column suddenly spike in a 1 minute time window, you can then trying to locate that packet and further inspect it. 
 
-Also notice the `EXPIRE AFTER` clause, it means this flow will reject input data with `access_time` older than `now()` - 6 hours, so data in the sink table that is older than 6 hours will no longer be modified by this flow(note the data will **NOT** be deleted),  see more explain in [manage-flow](manage-flow.md#expire-after).
+Also notice the `EXPIRE AFTER` clause, it means this flow will reject input data with `access_time` older than `now() - 6` hours, so data in the sink table that is older than 6 hours will no longer be modified by this flow(note the data will **NOT** be deleted),  see more explain in [manage-flow](manage-flow.md#expire-after).
 
 ```sql
 CREATE FLOW ngx_aggregation
@@ -270,7 +270,7 @@ The above query continuously aggregates data from the `temp_sensor_data` table i
 It calculates the maximum temperature reading for each sensor and location,
 filtering out data where the maximum temperature exceeds 100 degrees.
 The `temp_alerts` table will be continuously updated with the aggregated data,
-providing real-time alerts (in the form of new rows in the `temp_alerts` table) when the temperature exceeds the threshold. The `EXPIRE AFTER '1h'` makes flow only update for data with `ts` in (now - 1h, now) range, see more explain in [manage-flow](manage-flow.md#expire-after).
+providing real-time alerts (in the form of new rows in the `temp_alerts` table) when the temperature exceeds the threshold. The `EXPIRE AFTER '1h'` makes flow only update for data with `ts` in `(now - 1h, now)` range, see more explain in [manage-flow](manage-flow.md#expire-after).
 
 Now that we have created the flow task, we can insert some data into the source table `temp_sensor_data`:
 
@@ -354,7 +354,7 @@ GROUP BY
 The query aggregates data from the `ngx_access_log` table into the `ngx_distribution` table.
 It computes the total number of logs for each status code and packet size bucket (bucket size of 10, as specified by `trunc` with a second argument of -1) within each time window.
 The `date_bin` function groups the data into one-minute intervals.
-Consequently, the `ngx_distribution` table is continuously updated, offering real-time insights into the distribution of packet sizes per status code. And data that arrive too late(a too old `access_time` from now, '6h' as declared in `EXPIRE AFTER`) will be safely ignore by flow, see more explain in [manage-flow](manage-flow.md#expire-after).
+Consequently, the `ngx_distribution` table is continuously updated, offering real-time insights into the distribution of packet sizes per status code. And data that arrive too late (a too old `access_time` from now, '6h' as declared in `EXPIRE AFTER`) will be safely ignore by flow, see more explain in [manage-flow](manage-flow.md#expire-after).
 
 Now that we have created the flow task, we can insert some data into the source table `ngx_access_log`:
 

--- a/docs/user-guide/flow-computation/manage-flow.md
+++ b/docs/user-guide/flow-computation/manage-flow.md
@@ -143,14 +143,16 @@ The created flow will compute `max(temperature)` for every 10 seconds and store 
 
 The `EXPIRE AFTER` clause specifies the interval after which data will expire from the flow engine. 
 
-By expire, we mean data in sink table that's older than this time will no longer be modified by this flow, nor will it be deleted. This help limit the state size with stateful query(like `GROUP BY`).
+Data in the source table that exceeds the specified expiration time will no longer be included in the flow's calculations.
+Similarly, data in the sink table that is older than the expiration time will not be updated. 
+This means the flow engine will ignore data older than the specified interval during aggregation.
+This mechanism helps to manage the state size for stateful queries, such as those involving `GROUP BY`.
 
-Hence, setting a reasonable time interval for `EXPIRE AFTER` is helpful to limit state size and avoid memory overflow. This is somewhere similar to the ["Watermarks"](https://docs.risingwave.com/processing/watermarks) concept in streaming processing.
+It is important to note that the `EXPIRE AFTER` clause does not delete data from either the source table or the sink table.
+It only controls how the flow engine processes the data.
+If you want to delete data from the source or sink table, please [set the `TTL` option](/user-guide/manage-data/overview.md#manage-data-retention-with-ttl-policies) when creating tables.
 
-Internally, when the flow engine processes the aggregation operation,
-data with a time index older than the specified interval will expire, that is, no longer be process by flow engine. This doesn't remove old data from sink table, it's just that flow engine will no longer updating them.
-
-Note that EXPIRE AFTER` and `ttl` serve different purposes: `ttl` defines the lifespan of data within a table, whereas `EXPIRE AFTER` governs the duration for which data get processed in the flow engine.
+Setting a reasonable time interval for `EXPIRE AFTER` is helpful to limit state size and avoid memory overflow. This is somewhere similar to the ["Watermarks"](https://docs.risingwave.com/processing/watermarks) concept in streaming processing.
 
 For example, if the flow engine processes the aggregation at 10:00:00 and the `'1 hour'::INTERVAL` is set,
 any input data that arrive now with a time index older than 1 hour (before 09:00:00) will expire and be ignore.

--- a/docs/user-guide/flow-computation/manage-flow.md
+++ b/docs/user-guide/flow-computation/manage-flow.md
@@ -150,6 +150,8 @@ Hence, setting a reasonable time interval for `EXPIRE AFTER` is helpful to limit
 Internally, when the flow engine processes the aggregation operation,
 data with a time index older than the specified interval will expire, that is, no longer be process by flow engine. This doesn't remove old data from sink table, it's just that flow engine will no longer updating them.
 
+Note that EXPIRE AFTER` and `ttl` serve different purposes: `ttl` defines the lifespan of data within a table, whereas `EXPIRE AFTER` governs the duration for which data get processed in the flow engine.
+
 For example, if the flow engine processes the aggregation at 10:00:00 and the `'1 hour'::INTERVAL` is set,
 any input data that arrive now with a time index older than 1 hour (before 09:00:00) will expire and be ignore.
 Only data timestamped from 09:00:00 onwards will be used in the aggregation and update to sink table.

--- a/docs/user-guide/flow-computation/manage-flow.md
+++ b/docs/user-guide/flow-computation/manage-flow.md
@@ -143,10 +143,12 @@ The created flow will compute `max(temperature)` for every 10 seconds and store 
 
 The `EXPIRE AFTER` clause specifies the interval after which data will expire from the flow engine. 
 
-By expire, we mean data in sink table that's older than this time will no longer be modified by this flow, nor will it be deleted. This help limit the state size with stateful query(like `GROUP BY`). Hence, setting a reasonable time interval for `EXPIRE AFTER` is helpful to limit state size and avoid memory overflow. This is somewhere similar to the ["Watermarks"](https://docs.risingwave.com/processing/watermarks) concept in streaming processing.
+By expire, we mean data in sink table that's older than this time will no longer be modified by this flow, nor will it be deleted. This help limit the state size with stateful query(like `GROUP BY`).
 
-So when the flow engine processes the aggregation operation,
-data with a time index older than the specified interval will expire, that is, no longer be process by flow engine.
+Hence, setting a reasonable time interval for `EXPIRE AFTER` is helpful to limit state size and avoid memory overflow. This is somewhere similar to the ["Watermarks"](https://docs.risingwave.com/processing/watermarks) concept in streaming processing.
+
+Internally, when the flow engine processes the aggregation operation,
+data with a time index older than the specified interval will expire, that is, no longer be process by flow engine. This doesn't remove old data from sink table, it's just that flow engine will no longer updating them.
 
 For example, if the flow engine processes the aggregation at 10:00:00 and the `'1 hour'::INTERVAL` is set,
 any input data that arrive now with a time index older than 1 hour (before 09:00:00) will expire and be ignore.

--- a/docs/user-guide/flow-computation/manage-flow.md
+++ b/docs/user-guide/flow-computation/manage-flow.md
@@ -139,17 +139,18 @@ GROUP BY time_window;
 
 The created flow will compute `max(temperature)` for every 10 seconds and store the result in `my_sink_table`. All data comes within 1 hour will be used in the flow.
 
-### `EXPIRE AFTER` clause
+### EXPIRE AFTER
 
-The `EXPIRE AFTER` clause specifies the interval after which data will expire from the flow engine.
-This expiration only affects the data in the flow engine and does not impact the data in the source table.
+The `EXPIRE AFTER` clause specifies the interval after which data will expire from the flow engine. 
 
-When the flow engine processes the aggregation operation (the `update_at` time),
-data with a time index older than the specified interval will expire.
+By expire, we mean data in sink table that's older than this time will no longer be modified by this flow, nor will it be deleted. This help limit the state size with stateful query(like `GROUP BY`). Hence, setting a reasonable time interval for `EXPIRE AFTER` is helpful to limit state size and avoid memory overflow. This is somewhere similar to the ["Watermarks"](https://docs.risingwave.com/processing/watermarks) concept in streaming processing.
+
+So when the flow engine processes the aggregation operation,
+data with a time index older than the specified interval will expire, that is, no longer be process by flow engine.
 
 For example, if the flow engine processes the aggregation at 10:00:00 and the `'1 hour'::INTERVAL` is set,
-any data older than 1 hour (before 09:00:00) will expire.
-Only data timestamped from 09:00:00 onwards will be used in the aggregation.
+any input data that arrive now with a time index older than 1 hour (before 09:00:00) will expire and be ignore.
+Only data timestamped from 09:00:00 onwards will be used in the aggregation and update to sink table.
 
 ### Write a SQL query
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/flow-computation/continuous-aggregation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/flow-computation/continuous-aggregation.md
@@ -61,7 +61,7 @@ CREATE TABLE `ngx_statistics` (
 
 然后创建名为 `ngx_aggregation` 的 flow 任务，包括 `count`、`min`、`max`、`avg` `size` 列的聚合函数，以及大于 550 的所有数据包的大小总和。聚合是在 `access_time` 列的 1 分钟固定窗口中计算的，并且还按 `status` 列分组。因此，你可以实时了解有关数据包大小和对其的操作的信息，例如，如果 `high_size_count` 在某个时间点变得太高，你可以进一步检查是否有任何问题，或者如果 `max_size` 列在 1 分钟时间窗口内突然激增，你可以尝试定位该数据包并进一步检查。
 
-下方 SQL 语句中的 `EXPIRE AFTER '6h'` 参数确保 flow 计算仅使用过去 6 小时内的源数据。对于接收表中超过 6 小时的历史数据，本流程不会对其进行修改。有关`EXPIRE AFTER`的详细信息，请参阅[管理 Flow](manage-flow.md#expire-after)
+下方 SQL 语句中的 `EXPIRE AFTER '6h'` 参数确保 flow 计算仅使用过去 6 小时内的源数据。对于 sink 表中超过 6 小时的历史数据，本 flow 不会对其进行修改。有关`EXPIRE AFTER`的详细信息，请参阅[管理 Flow](manage-flow.md#expire-after)
 
 ```sql
 CREATE FLOW ngx_aggregation

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/flow-computation/continuous-aggregation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/flow-computation/continuous-aggregation.md
@@ -61,9 +61,13 @@ CREATE TABLE `ngx_statistics` (
 
 然后创建名为 `ngx_aggregation` 的 flow 任务，包括 `count`、`min`、`max`、`avg` `size` 列的聚合函数，以及大于 550 的所有数据包的大小总和。聚合是在 `access_time` 列的 1 分钟固定窗口中计算的，并且还按 `status` 列分组。因此，你可以实时了解有关数据包大小和对其的操作的信息，例如，如果 `high_size_count` 在某个时间点变得太高，你可以进一步检查是否有任何问题，或者如果 `max_size` 列在 1 分钟时间窗口内突然激增，你可以尝试定位该数据包并进一步检查。
 
+下方 SQL 语句中的 `EXPIRE AFTER '6h'` 参数确保 flow 计算仅使用过去 6 小时内的源数据。对于接收表中超过 6 小时的历史数据，本流程不会对其进行修改。有关`EXPIRE AFTER`的详细信息，请参阅[管理 Flow](manage-flow.md#expire-after)
+
 ```sql
 CREATE FLOW ngx_aggregation
 SINK TO ngx_statistics
+EXPIRE AFTER '6h'
+COMMENT 'aggregate nginx access logs'
 AS
 SELECT
     status,
@@ -165,6 +169,8 @@ CREATE TABLE ngx_country (
 /* 创建 flow 任务以计算不同的国家 */
 CREATE FLOW calc_ngx_country
 SINK TO ngx_country
+EXPIRE AFTER '7days'::INTERVAL
+COMMENT 'aggregate for distinct country'
 AS
 SELECT
     DISTINCT country,
@@ -177,7 +183,7 @@ GROUP BY
 
 上述查询将 `ngx_access_log` 表中的数据聚合到 `ngx_country` 表中，它计算了每个时间窗口内的不同国家。
 `date_bin` 函数用于将数据聚合到一小时的间隔中。
-`ngx_country` 表将不断更新聚合数据，以监控访问系统的不同国家。
+`ngx_country` 表将不断更新聚合数据，以监控访问系统的不同国家。`EXPIRE AFTER` 参数将确保流式处理流程自动忽略 `access_time` 超过 7 天的数据且不再参与 flow 计算，详见 请参阅[管理 Flow](manage-flow.md#expire-after) 中的说明。
 
 你可以向 source 表 `ngx_access_log` 插入一些数据：
 
@@ -240,6 +246,7 @@ CREATE TABLE temp_alerts (
 );
 
 CREATE FLOW temp_monitoring
+EXPIRE AFTER '1h'
 SINK TO temp_alerts
 AS
 SELECT
@@ -258,7 +265,7 @@ HAVING max_temp > 100;
 上述查询将 `temp_sensor_data` 表中的数据不断聚合到 `temp_alerts` 表中。
 它计算每个传感器和位置的最大温度读数，并过滤出最大温度超过 100 度的数据。
 `temp_alerts` 表将不断更新聚合数据，
-当温度超过阈值时提供实时警报（即 `temp_alerts` 表中的新行）。
+当温度超过阈值时提供实时警报（即 `temp_alerts` 表中的新行）。`EXPIRE AFTER '1h'` 使 flow 仅计算 `ts` 列处于 `(now - 1h, now)` 时间范围内的源数据，详见 [管理 Flow](manage-flow.md#expire-after) 中的说明。
 
 现在我们已经创建了 flow 任务，可以向 source 表 `temp_sensor_data` 插入一些数据：
 
@@ -323,7 +330,9 @@ CREATE TABLE ngx_distribution (
     PRIMARY KEY(stat, bucket_size)
 );
 /* 创建 flow 任务以计算每个状态码的包大小分布 */
-CREATE FLOW calc_ngx_distribution SINK TO ngx_distribution AS
+CREATE FLOW calc_ngx_distribution SINK TO ngx_distribution 
+EXPIRE AFTER '6h'
+AS
 SELECT
     stat,
     trunc(size, -1)::INT as bucket_size,
@@ -341,7 +350,7 @@ GROUP BY
 它计算每个时间窗口内的状态代码和数据包大小存储桶（存储桶大小为 10，由 `trunc` 指定，第二个参数为 -1）的日志总数。
 `date_bin` 函数将数据分组为一分钟的间隔。
 因此，`ngx_distribution` 表会不断更新，
-提供每个状态代码的数据包大小分布的实时洞察。
+提供每个状态代码的数据包大小分布的实时洞察。`EXPIRE AFTER '6h'` 使 flow 仅计算 `access_time` 列处于 `(now - 6h, now)` 时间范围内的源数据，详见 [管理 Flow](manage-flow.md#expire-after)。
 
 现在我们已经创建了 flow 任务，可以向 source 表 `ngx_access_log` 插入一些数据：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/flow-computation/manage-flow.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/flow-computation/manage-flow.md
@@ -126,17 +126,23 @@ GROUP BY time_window;
 创建的 flow 将每 10 秒计算一次 `max(temperature)` 并将结果存储在 `my_sink_table` 中。
 所有在 1 小时内的数据都将用于 flow 计算。
 
-### `EXPIRE AFTER` 子句
+### EXPIRE AFTER
 
 `EXPIRE AFTER` 子句指定数据将在 flow 引擎中过期的时间间隔。
-此过期仅影响 flow 引擎中的数据，不影响 source 表中的数据。
 
-当 flow 引擎处理聚合操作（`update_at` 时间）时，
-时间索引早于指定间隔的数据将过期。
+源表中超出指定过期时间的数据将不再被包含在 flow 的计算范围内。  
+同理，目标表中超过过期时间的历史数据也不会被更新。  
+这意味着 flow 引擎在聚合计算时会自动忽略早于该时间间隔的数据。这一机制有助于管理有状态查询（例如涉及 `GROUP BY` 的查询）的状态存储规模。
+
+需特别注意的是：  
+- `EXPIRE AFTER` 子句**不会删除**源表或目标表中的数据，它仅控制 flow 引擎对数据的处理范围  
+- 若需删除表数据，请在创建表时通过 [`TTL` 策略](/user-guide/manage-data/overview.md#manage-data-retention-with-ttl-policies)实现  
+
+为 `EXPIRE AFTER` 设置合理的时间间隔，可有效限制 flow 的状态存储规模并避免内存溢出。该机制与流处理中的 ["水位线"](https://docs.risingwave.com/processing/watermarks) 概念有相似之处——两者均通过时间边界定义计算的有效数据范围，过期数据将不再参与流式计算过程。
 
 例如，如果 flow 引擎在 10:00:00 处理聚合，并且设置了 `'1 hour'::INTERVAL`，
-则早于 09:00:00 的数据将过期。
-只有从 09:00:00 开始的数据将用于聚合。
+当前时刻若输入数据的 Time Index 超过 1 小时（即早于 09:00:00），则会被判定为过期数据并被忽略。
+仅时间戳为 09:00:00 及之后的数据会参与聚合计算，并更新到目标表。
 
 ### 编写 SQL 查询
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/flow-computation/manage-flow.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/flow-computation/manage-flow.md
@@ -130,13 +130,13 @@ GROUP BY time_window;
 
 `EXPIRE AFTER` 子句指定数据将在 flow 引擎中过期的时间间隔。
 
-源表中超出指定过期时间的数据将不再被包含在 flow 的计算范围内。  
-同理，目标表中超过过期时间的历史数据也不会被更新。  
+source 表中超出指定过期时间的数据将不再被包含在 flow 的计算范围内。  
+同理，sink 表中超过过期时间的历史数据也不会被更新。  
 这意味着 flow 引擎在聚合计算时会自动忽略早于该时间间隔的数据。这一机制有助于管理有状态查询（例如涉及 `GROUP BY` 的查询）的状态存储规模。
 
 需特别注意的是：  
-- `EXPIRE AFTER` 子句**不会删除**源表或目标表中的数据，它仅控制 flow 引擎对数据的处理范围  
-- 若需删除表数据，请在创建表时通过 [`TTL` 策略](/user-guide/manage-data/overview.md#manage-data-retention-with-ttl-policies)实现  
+- `EXPIRE AFTER` 子句**不会删除** source 表或 sink 表中的数据，它仅控制 flow 引擎对数据的处理范围  
+- 若需删除表数据，请在创建表时通过 [`TTL` 策略](/user-guide/manage-data/overview.md#使用-ttl-策略保留数据)实现  
 
 为 `EXPIRE AFTER` 设置合理的时间间隔，可有效限制 flow 的状态存储规模并避免内存溢出。该机制与流处理中的 ["水位线"](https://docs.risingwave.com/processing/watermarks) 概念有相似之处——两者均通过时间边界定义计算的有效数据范围，过期数据将不再参与流式计算过程。
 


### PR DESCRIPTION
## What's Changed in this PR

emphasis expire after concept in user guide examples, and in manage flows.md



## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
