### PR TITLE
docs: add append-only mode desc for log/trace table

### DIFF
--- a/docs/user-guide/ingest-data/for-observability/opentelemetry-traces.md
+++ b/docs/user-guide/ingest-data/for-observability/opentelemetry-traces.md
@@ -116,4 +116,4 @@ You also can use the [Jaeger](https://www.jaegertracing.io/) query interface to 
 ### Append Only
 
 By default, trace table created by OpenTelemetry API are in [append only
-mode](https://docs.greptime.com/user-guide/administration/design-table/#when-to-use-append-only-tables).
+mode](/user-guide/administration/design-table.md#when-to-use-append-only-tables).

--- a/docs/user-guide/ingest-data/for-observability/opentelemetry-traces.md
+++ b/docs/user-guide/ingest-data/for-observability/opentelemetry-traces.md
@@ -112,3 +112,8 @@ span_attributes.net.sock.peer.addr: 1.2.3.4
 ```
 
 You also can use the [Jaeger](https://www.jaegertracing.io/) query interface to query traces data. Please refer to the [Jaeger](/user-guide/query-data/jaeger.md) documentation for more details.
+
+### Append Only
+
+By default, trace table created by OpenTelemetry API are in [append only
+mode](https://docs.greptime.com/user-guide/administration/design-table/#when-to-use-append-only-tables).

--- a/docs/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/docs/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -188,7 +188,7 @@ Default table schema:
 ### Append Only
 
 By default, log table created by OpenTelemetry API are in [append only
-mode](https://docs.greptime.com/user-guide/administration/design-table/#when-to-use-append-only-tables).
+mode](/user-guide/administration/design-table.md#when-to-use-append-only-tables).
 
 ## Traces
 
@@ -253,4 +253,4 @@ By default, the table is partitioned into 16 uniform regions based on the `trace
 ### Append Only
 
 By default, log table created by OpenTelemetry API are in [append only
-mode](https://docs.greptime.com/user-guide/administration/design-table/#when-to-use-append-only-tables).
+mode](/user-guide/administration/design-table.md#when-to-use-append-only-tables).

--- a/docs/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/docs/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -185,6 +185,11 @@ Default table schema:
 - All attributes, including resource attributes, scope attributes, and log attributes, will be stored as a JSON column in the GreptimeDB table.
 - The timestamp of the log will be used as the timestamp index in GreptimeDB, with the column name `timestamp`. It is preferred to use `time_unix_nano` as the timestamp column. If `time_unix_nano` is not provided, `observed_time_unix_nano` will be used instead.
 
+### Append Only
+
+By default, log table created by OpenTelemetry API are in [append only
+mode](https://docs.greptime.com/user-guide/administration/design-table/#when-to-use-append-only-tables).
+
 ## Traces
 
 GreptimeDB supports writing OpenTelemetry traces data directly via the [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp) protocol, and it also provides a table model of OpenTelemetry traces for users to query and analyze traces data conveniently.
@@ -196,7 +201,7 @@ You can use [OpenTelemetry SDK](https://opentelemetry.io/docs/languages/) or oth
 To send OpenTelemetry traces data to GreptimeDB through OpenTelemetry SDK libraries, please use the following information:
 
 * URL: `http{s}://<host>/v1/otlp/v1/traces`
-* Headers: The headers section is the same as the [Logs](#Logs) section, you can refer to the [Logs](#Logs) section for more information. 
+* Headers: The headers section is the same as the [Logs](#Logs) section, you can refer to the [Logs](#Logs) section for more information.
 
 By default, GreptimeDB will write traces data to the `opentelemetry_traces` table in the `public` database. If you want to write traces data to a different table, you can use the `X-Greptime-DB-Name` and `X-Greptime-Log-Table-Name` headers to specify the database and table name.
 
@@ -244,3 +249,8 @@ GreptimeDB will map the OTLP traces data model to the following table schema:
 - `span_events` and `span_links` are stored as JSON data types by default
 
 By default, the table is partitioned into 16 uniform regions based on the `trace_id` to efficiently store and query all trace data.
+
+### Append Only
+
+By default, log table created by OpenTelemetry API are in [append only
+mode](https://docs.greptime.com/user-guide/administration/design-table/#when-to-use-append-only-tables).

--- a/docs/user-guide/logs/write-logs.md
+++ b/docs/user-guide/logs/write-logs.md
@@ -115,4 +115,4 @@ Please refer to the "Writing Logs" section in the [Quick Start](quick-start.md#w
 ## Append Only
 
 By default, logs table created by HTTP ingestion API are in [append only
-mode](https://docs.greptime.com/user-guide/administration/design-table/#when-to-use-append-only-tables).
+mode](/user-guide/administration/design-table.md#when-to-use-append-only-tables).

--- a/docs/user-guide/logs/write-logs.md
+++ b/docs/user-guide/logs/write-logs.md
@@ -48,9 +48,9 @@ Here is an example of JSON format body payload
 ]
 ```
 
-Note the whole JSON is an array (log lines). Each JSON object represents one line to be processed by Pipeline engine. 
+Note the whole JSON is an array (log lines). Each JSON object represents one line to be processed by Pipeline engine.
 
-The name of the key in JSON objects, which is `message` here, is used as field name in Pipeline processors. For example: 
+The name of the key in JSON objects, which is `message` here, is used as field name in Pipeline processors. For example:
 
 ```yaml
 processors:
@@ -111,3 +111,8 @@ It is recommended to use `dissect` or `regex` processor to split the input line 
 ## Example
 
 Please refer to the "Writing Logs" section in the [Quick Start](quick-start.md#write-logs) guide for an example.
+
+## Append Only
+
+By default, logs table created by HTTP ingestion API are in [append only
+mode](https://docs.greptime.com/user-guide/administration/design-table/#when-to-use-append-only-tables).

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry-traces.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry-traces.md
@@ -115,4 +115,4 @@ span_attributes.net.sock.peer.addr: 1.2.3.4
 
 ## 追加模式
 
-通过此接口创建的表，默认为[追加模式](/user-guide/administration/design-table.md#when-to-use-append-only-tables).
+通过此接口创建的表，默认为[追加模式](/user-guide/administration/design-table.md#何时使用-append-only-表).

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry-traces.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry-traces.md
@@ -112,3 +112,7 @@ span_attributes.net.sock.peer.addr: 1.2.3.4
 ```
 
 你也可以使用 [Jaeger](https://www.jaegertracing.io/) 查询界面来查询 traces 数据。更多细节请参考 [Jaeger 文档](/user-guide/query-data/jaeger.md)。
+
+## 追加模式
+
+通过此接口创建的表，默认为[追加模式](https://docs.greptime.com/user-guide/administration/design-table/#when-to-use-append-only-tables).

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry-traces.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry-traces.md
@@ -113,6 +113,6 @@ span_attributes.net.sock.peer.addr: 1.2.3.4
 
 你也可以使用 [Jaeger](https://www.jaegertracing.io/) 查询界面来查询 traces 数据。更多细节请参考 [Jaeger 文档](/user-guide/query-data/jaeger.md)。
 
-## 追加模式
+## Append 模式
 
-通过此接口创建的表，默认为[追加模式](/user-guide/administration/design-table.md#何时使用-append-only-表).
+通过此接口创建的表，默认为[Append 模式](/user-guide/administration/design-table.md#何时使用-append-only-表).

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry-traces.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry-traces.md
@@ -115,4 +115,4 @@ span_attributes.net.sock.peer.addr: 1.2.3.4
 
 ## 追加模式
 
-通过此接口创建的表，默认为[追加模式](https://docs.greptime.com/user-guide/administration/design-table/#when-to-use-append-only-tables).
+通过此接口创建的表，默认为[追加模式](/user-guide/administration/design-table.md#when-to-use-append-only-tables).

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -188,7 +188,7 @@ OTLP 日志数据模型根据以下规则映射到 GreptimeDB 数据模型：
 
 ### 追加模式
 
-通过此接口创建的表，默认为[追加模式](https://docs.greptime.com/user-guide/administration/design-table/#when-to-use-append-only-tables).
+通过此接口创建的表，默认为[追加模式](/user-guide/administration/design-table.md#when-to-use-append-only-tables).
 
 ## Traces
 
@@ -254,4 +254,4 @@ OTLP traces 数据模型根据以下规则映射到 GreptimeDB 数据模型：
 
 ### 追加模式
 
-通过此接口创建的表，默认为[追加模式](https://docs.greptime.com/user-guide/administration/design-table/#when-to-use-append-only-tables).
+通过此接口创建的表，默认为[追加模式](/user-guide/administration/design-table.md#when-to-use-append-only-tables).

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -186,9 +186,9 @@ OTLP 日志数据模型根据以下规则映射到 GreptimeDB 数据模型：
 - 所有属性，包括资源属性、范围属性和日志属性，将作为 JSON 列存储在 GreptimeDB 表中。
 - 日志的时间戳将用作 GreptimeDB 中的时间戳索引，列名为 `timestamp`。建议使用 `time_unix_nano` 作为时间戳列。如果未提供 `time_unix_nano`，将使用 `observed_time_unix_nano`。
 
-### 追加模式
+### Append 模式
 
-通过此接口创建的表，默认为[追加模式](/user-guide/administration/design-table.md#何时使用-append-only-表).
+通过此接口创建的表，默认为[Append 模式](/user-guide/administration/design-table.md#何时使用-append-only-表).
 
 ## Traces
 
@@ -252,6 +252,6 @@ OTLP traces 数据模型根据以下规则映射到 GreptimeDB 数据模型：
 
 默认地，表会根据 `trace_id` 均匀划分为 16 个 Region 以高效地存储和查询所有的 traces 数据。
 
-### 追加模式
+### Append 模式
 
-通过此接口创建的表，默认为[追加模式](/user-guide/administration/design-table.md#何时使用-append-only-表).
+通过此接口创建的表，默认为[Append 模式](/user-guide/administration/design-table.md#何时使用-append-only-表).

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -188,7 +188,7 @@ OTLP 日志数据模型根据以下规则映射到 GreptimeDB 数据模型：
 
 ### 追加模式
 
-通过此接口创建的表，默认为[追加模式](/user-guide/administration/design-table.md#when-to-use-append-only-tables).
+通过此接口创建的表，默认为[追加模式](/user-guide/administration/design-table.md#何时使用-append-only-表).
 
 ## Traces
 
@@ -254,4 +254,4 @@ OTLP traces 数据模型根据以下规则映射到 GreptimeDB 数据模型：
 
 ### 追加模式
 
-通过此接口创建的表，默认为[追加模式](/user-guide/administration/design-table.md#when-to-use-append-only-tables).
+通过此接口创建的表，默认为[追加模式](/user-guide/administration/design-table.md#何时使用-append-only-表).

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -186,6 +186,10 @@ OTLP 日志数据模型根据以下规则映射到 GreptimeDB 数据模型：
 - 所有属性，包括资源属性、范围属性和日志属性，将作为 JSON 列存储在 GreptimeDB 表中。
 - 日志的时间戳将用作 GreptimeDB 中的时间戳索引，列名为 `timestamp`。建议使用 `time_unix_nano` 作为时间戳列。如果未提供 `time_unix_nano`，将使用 `observed_time_unix_nano`。
 
+### 追加模式
+
+通过此接口创建的表，默认为[追加模式](https://docs.greptime.com/user-guide/administration/design-table/#when-to-use-append-only-tables).
+
 ## Traces
 
 GreptimeDB 支持直接写入 OpenTelemetry 协议的 traces 数据，并内置 OpenTelemetry 的 traces 的表模型来让用户方便地查询和分析 traces 数据。
@@ -243,7 +247,11 @@ OTLP traces 数据模型根据以下规则映射到 GreptimeDB 数据模型：
 
 - 每一行代表一个单一的 span；
 - 核心的 OpenTelemetry 字段，如 `trace_id`, `span_id`, 和 `service_name` 等将被单独作为表的列；
-- Resource Attributes 和 Span Attributes 将被自动展平为单独的列，列名为其 JSON 格式表示时的 key（多层嵌套时将用 `.` 连接）；    
+- Resource Attributes 和 Span Attributes 将被自动展平为单独的列，列名为其 JSON 格式表示时的 key（多层嵌套时将用 `.` 连接）；
 - `span_events` 和 `span_links` 默认存储为 JSON 数据类型；
 
 默认地，表会根据 `trace_id` 均匀划分为 16 个 Region 以高效地存储和查询所有的 traces 数据。
+
+### 追加模式
+
+通过此接口创建的表，默认为[追加模式](https://docs.greptime.com/user-guide/administration/design-table/#when-to-use-append-only-tables).

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/write-logs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/write-logs.md
@@ -115,4 +115,4 @@ processors:
 
 ## 追加模式
 
-通过此接口创建的日志表，默认为[追加模式](/user-guide/administration/design-table.md#when-to-use-append-only-tables).
+通过此接口创建的日志表，默认为[追加模式](/user-guide/administration/design-table.md#何时使用-append-only-表).

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/write-logs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/write-logs.md
@@ -115,4 +115,4 @@ processors:
 
 ## 追加模式
 
-通过此接口创建的日志表，默认为[追加模式](https://docs.greptime.com/user-guide/administration/design-table/#when-to-use-append-only-tables).
+通过此接口创建的日志表，默认为[追加模式](/user-guide/administration/design-table.md#when-to-use-append-only-tables).

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/write-logs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/write-logs.md
@@ -113,6 +113,6 @@ processors:
 
 请参考快速开始中的[写入日志](quick-start.md#写入日志)部分。
 
-## 追加模式
+## Append 模式
 
-通过此接口创建的日志表，默认为[追加模式](/user-guide/administration/design-table.md#何时使用-append-only-表).
+通过此接口创建的日志表，默认为[Append 模式](/user-guide/administration/design-table.md#何时使用-append-only-表).

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/write-logs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/write-logs.md
@@ -112,3 +112,7 @@ processors:
 ## 示例
 
 请参考快速开始中的[写入日志](quick-start.md#写入日志)部分。
+
+## 追加模式
+
+通过此接口创建的日志表，默认为[追加模式](https://docs.greptime.com/user-guide/administration/design-table/#when-to-use-append-only-tables).


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

*Describe the change in this PR*

Add description about append_only mode in log/trace ingestion pages.

## Checklist

- [x] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
