### PR TITLE
docs: log is in sql keywords now

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -58,7 +58,7 @@ CREATE TABLE app_logs (
   host STRING,
   api_path STRING,
   log_level STRING,
-  log STRING,
+  `log` STRING,
   PRIMARY KEY (host, log_level)
 ) with('append_mode'='true');
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/quick-start.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/quick-start.md
@@ -58,7 +58,7 @@ CREATE TABLE app_logs (
   host STRING,
   api_path STRING,
   log_level STRING,
-  log STRING,
+  `log` STRING,
   PRIMARY KEY (host, log_level)
 ) with('append_mode'='true');
 ```


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

```
Invalid SQL syntax: sql parser error: Cannot use keyword 'log' as column name. Hint: add quotes to the name.
```


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
