### PR TITLE
docs: add observerability 2.0 link to why-greptimedb

### DIFF
--- a/docs/user-guide/concepts/why-greptimedb.md
+++ b/docs/user-guide/concepts/why-greptimedb.md
@@ -94,6 +94,6 @@ However, our definition of schema is not mandatory, but rather leans towards the
 
 
 For more details, explore our blogs:
+- ["Observability 2.0 and the Database for It"](https://greptime.com/blogs/2025-04-25-greptimedb-observability2-new-database)
 - ["This Time, for Real"](https://greptime.com/blogs/2022-11-15-this-time-for-real)
 - ["Unified Storage for Observability - GreptimeDB's Approach"](https://greptime.com/blogs/2024-12-24-observability)
-- ["Unifying Logs and Metrics"](https://greptime.com/blogs/2024-06-25-logs-and-metrics)

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/features-that-you-concern.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/features-that-you-concern.md
@@ -7,7 +7,7 @@ description: 介绍 GreptimeDB 的关键特性，并解答用户关心的常见�
 
 ## GreptimeDB 支持处理日志或事件吗？
 
-是的。从 v0.9.0 版本开始，GreptimeDB 将指标、日志和链路追踪视为带有时间戳的上下文“宽”事件（Wide Event），从而统一了指标、日志和链路追踪的处理。它支持使用 SQL、PromQL 和通过连续聚合进行流式处理来分析指标、日志和追踪。
+是的。从 v0.9.0 版本开始，GreptimeDB 将指标、日志和链路追踪视为带有时间戳的上下文“宽”事件（Wide Events），从而统一了指标、日志和链路追踪的处理。它支持使用 SQL、PromQL 和通过连续聚合进行流式处理来分析指标、日志和追踪。
 
 请阅读[日志处理使用指南](/user-guide/logs/overview.md)。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/why-greptimedb.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/why-greptimedb.md
@@ -10,7 +10,7 @@ GreptimeDB 是一款为云原生环境设计的开源可观测数据库。我们
 ## 统一处理可观测数据
 
 GreptimeDB 通过以下方式统一处理指标、日志和链路追踪：
-- 一致的[数据模型](./data-model.md)，将所有可观测数据视为带有上下文的时间戳“宽”事件（Wide Event）
+- 一致的[数据模型](./data-model.md)，将所有可观测数据视为带有上下文的时间戳“宽”事件（Wide Events）
 - 原生支持 [SQL](/user-guide/query-data/sql.md) 和 [PromQL](/user-guide/query-data/promql.md) 查询
 - 内置流处理功能 ([Flow](/user-guide/flow-computation/overview.md))，用于实时聚合和分析等
 - 跨不同类型的可观测数据进行无缝关联分析（阅读 [SQL 示例](/user-guide/overview.md#sql-查询示例) 了解详细信息）
@@ -95,6 +95,6 @@ GreptimeDB 引入了一种新的数据模型，该模型结合了时序和关系
 表将在数据写入时动态自动创建，并自动添加新出现的列（Tag 和 Field）。更详细的说明，请阅读[数据模型](./data-model.md)。
 
 要了解更多关于我们的方法和架构，请查看博客文章：
+* [《什么是可观测性 2.0？什么是可观测性 2.0 原生数据库？》](https://greptime.cn/blogs/2025-04-24-observability2.0-greptimedb.html)
 * [《专为实时而生》](https://greptime.cn/blogs/2022-11-16-github)
 * [《GreptimeDB 统一存储架构》](https://greptime.cn/blogs/2024-12-24-observability)
-* [《事件管理革命：监控系统中统一日志和指标》](https://greptime.cn/blogs/2024-06-14-events)。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/concepts/why-greptimedb.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/concepts/why-greptimedb.md
@@ -10,7 +10,7 @@ GreptimeDB 是一款为云原生环境设计的开源可观测数据库。我们
 ## 统一处理可观测数据
 
 GreptimeDB 通过以下方式统一处理指标、日志和链路追踪：
-- 一致的[数据模型](./data-model.md)，将所有可观测数据视为带有上下文的时间戳“宽”事件（Wide Event）
+- 一致的[数据模型](./data-model.md)，将所有可观测数据视为带有上下文的时间戳“宽”事件（Wide Events）
 - 原生支持 [SQL](/user-guide/query-data/sql.md) 和 [PromQL](/user-guide/query-data/promql.md) 查询
 - 内置流处理功能 ([Flow](/user-guide/flow-computation/overview.md))，用于实时聚合和分析等
 - 跨不同类型的可观测数据进行无缝关联分析（阅读 [SQL 示例](/user-guide/overview.md#sql-查询示例) 了解详细信息）
@@ -95,6 +95,6 @@ GreptimeDB 引入了一种新的数据模型，该模型结合了时序和关系
 表将在数据写入时动态自动创建，并自动添加新出现的列（Tag 和 Field）。更详细的说明，请阅读[数据模型](./data-model.md)。
 
 要了解更多关于我们的方法和架构，请查看博客文章：
+* [《什么是可观测性 2.0？什么是可观测性 2.0 原生数据库？》](https://greptime.cn/blogs/2025-04-24-observability2.0-greptimedb.html)
 * [《专为实时而生》](https://greptime.cn/blogs/2022-11-16-github)
 * [《GreptimeDB 统一存储架构》](https://greptime.cn/blogs/2024-12-24-observability)
-* [《事件管理革命：监控系统中统一日志和指标》](https://greptime.cn/blogs/2024-06-14-events)。

--- a/versioned_docs/version-0.14/user-guide/concepts/why-greptimedb.md
+++ b/versioned_docs/version-0.14/user-guide/concepts/why-greptimedb.md
@@ -94,6 +94,6 @@ However, our definition of schema is not mandatory, but rather leans towards the
 
 
 For more details, explore our blogs:
+- ["Observability 2.0 and the Database for It"](https://greptime.com/blogs/2025-04-25-greptimedb-observability2-new-database)
 - ["This Time, for Real"](https://greptime.com/blogs/2022-11-15-this-time-for-real)
 - ["Unified Storage for Observability - GreptimeDB's Approach"](https://greptime.com/blogs/2024-12-24-observability)
-- ["Unifying Logs and Metrics"](https://greptime.com/blogs/2024-06-25-logs-and-metrics)


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

*Describe the change in this PR*

* Adds `Observability 2.0 and the Database for It` link to `why greptimedb` doc.
* `Wide Event` -> `Wide Events`.

## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
