### PR TITLE
chore: fix metric engine default table name

### DIFF
--- a/docs/user-guide/ingest-data/for-observability/prometheus.md
+++ b/docs/user-guide/ingest-data/for-observability/prometheus.md
@@ -158,7 +158,7 @@ WHERE greptime_timestamp > "2024-08-07 03:27:26.964000"
 
 ## Performance tuning
 
-By default, the metric engine will automatically create a physical table named `physical_metric_table` if it does not already exist. For performance optimization, you may choose to create a physical table with customized configurations.
+By default, the metric engine will automatically create a physical table named `greptime_physical_table` if it does not already exist. For performance optimization, you may choose to create a physical table with customized configurations.
 
 ### Enable skipping index
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/prometheus.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/prometheus.md
@@ -149,7 +149,7 @@ WHERE greptime_timestamp > "2024-08-07 03:27:26.964000"
 
 ## 性能优化
 
-默认情况下，metric engine 会自动创建一个名为 `physical_metric_table` 的物理表。
+默认情况下，metric engine 会自动创建一个名为 `greptime_physical_table` 的物理表。
 为了优化性能，你可以选择创建一个具有自定义配置的物理表。
 
 ### 启用跳数索引

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/ingest-data/for-observability/prometheus.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/ingest-data/for-observability/prometheus.md
@@ -149,7 +149,7 @@ WHERE greptime_timestamp > "2024-08-07 03:27:26.964000"
 
 ## 性能优化
 
-默认情况下，metric engine 会自动创建一个名为 `physical_metric_table` 的物理表。
+默认情况下，metric engine 会自动创建一个名为 `greptime_physical_table` 的物理表。
 为了优化性能，你可以选择创建一个具有自定义配置的物理表。
 
 ### 启用跳数索引

--- a/versioned_docs/version-0.14/user-guide/ingest-data/for-observability/prometheus.md
+++ b/versioned_docs/version-0.14/user-guide/ingest-data/for-observability/prometheus.md
@@ -158,7 +158,7 @@ WHERE greptime_timestamp > "2024-08-07 03:27:26.964000"
 
 ## Performance tuning
 
-By default, the metric engine will automatically create a physical table named `physical_metric_table` if it does not already exist. For performance optimization, you may choose to create a physical table with customized configurations.
+By default, the metric engine will automatically create a physical table named `greptime_physical_table` if it does not already exist. For performance optimization, you may choose to create a physical table with customized configurations.
 
 ### Enable skipping index
 


### PR DESCRIPTION
## What's Changed in this PR

* Correcting the wrong default metric engine table name


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
