### PR TITLE
fix: broken links to sql example

### DIFF
--- a/docs/user-guide/concepts/why-greptimedb.md
+++ b/docs/user-guide/concepts/why-greptimedb.md
@@ -13,7 +13,7 @@ GreptimeDB unifies the processing of metrics, logs, and traces through:
 - A consistent [data model](./data-model.md) that treats all observability data as timestamped wide events with context
 - Native support for both [SQL](/user-guide/query-data/sql.md) and [PromQL](/user-guide/query-data/promql.md) queries
 - Built-in stream processing capabilities ([Flow](/user-guide/flow-computation/overview.md)) for real-time aggregation and analytics
-- Seamless correlation analysis across different types of observability data (read the [SQL example](/user-guide/overview.md#sql-query-example) for detailed info)
+- Seamless correlation analysis across different types of observability data (read the [SQL example](/getting-started/quick-start.md#correlate-metrics-and-logs) for detailed info)
 
 It replaces complex legacy data stacks with a high-performance single solution.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/why-greptimedb.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/why-greptimedb.md
@@ -13,7 +13,7 @@ GreptimeDB 通过以下方式统一处理指标、日志和链路追踪：
 - 一致的[数据模型](./data-model.md)，将所有可观测数据视为带有上下文的时间戳“宽”事件（Wide Events）
 - 原生支持 [SQL](/user-guide/query-data/sql.md) 和 [PromQL](/user-guide/query-data/promql.md) 查询
 - 内置流处理功能 ([Flow](/user-guide/flow-computation/overview.md))，用于实时聚合和分析等
-- 跨不同类型的可观测数据进行无缝关联分析（阅读 [SQL 示例](/user-guide/overview.md#sql-查询示例) 了解详细信息）
+- 跨不同类型的可观测数据进行无缝关联分析（阅读 [SQL 示例](/getting-started/quick-start.md#指标和日志的关联查询) 了解详细信息）
 
 它用高性能的单一解决方案取代了复杂的传统数据栈。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/concepts/why-greptimedb.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/concepts/why-greptimedb.md
@@ -13,7 +13,7 @@ GreptimeDB 通过以下方式统一处理指标、日志和链路追踪：
 - 一致的[数据模型](./data-model.md)，将所有可观测数据视为带有上下文的时间戳“宽”事件（Wide Events）
 - 原生支持 [SQL](/user-guide/query-data/sql.md) 和 [PromQL](/user-guide/query-data/promql.md) 查询
 - 内置流处理功能 ([Flow](/user-guide/flow-computation/overview.md))，用于实时聚合和分析等
-- 跨不同类型的可观测数据进行无缝关联分析（阅读 [SQL 示例](/user-guide/overview.md#sql-查询示例) 了解详细信息）
+- 跨不同类型的可观测数据进行无缝关联分析（阅读 [SQL 示例](/getting-started/quick-start.md#指标和日志的关联查询) 了解详细信息）
 
 它用高性能的单一解决方案取代了复杂的传统数据栈。
 

--- a/versioned_docs/version-0.14/user-guide/concepts/why-greptimedb.md
+++ b/versioned_docs/version-0.14/user-guide/concepts/why-greptimedb.md
@@ -13,7 +13,7 @@ GreptimeDB unifies the processing of metrics, logs, and traces through:
 - A consistent [data model](./data-model.md) that treats all observability data as timestamped wide events with context
 - Native support for both [SQL](/user-guide/query-data/sql.md) and [PromQL](/user-guide/query-data/promql.md) queries
 - Built-in stream processing capabilities ([Flow](/user-guide/flow-computation/overview.md)) for real-time aggregation and analytics
-- Seamless correlation analysis across different types of observability data (read the [SQL example](/user-guide/overview.md#sql-query-example) for detailed info)
+- Seamless correlation analysis across different types of observability data (read the [SQL example](/getting-started/quick-start.md#correlate-metrics-and-logs) for detailed info)
 
 It replaces complex legacy data stacks with a high-performance single solution.
 


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

*Describe the change in this PR*

The sql in example in user guide overview was removed. Replace it with getting started example.


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
