### PR TITLE
ci: improve the speed of sync files to s3

### DIFF
--- a/.github/workflows/addDocsToS3BucketAWS.yml
+++ b/.github/workflows/addDocsToS3BucketAWS.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload to S3
         run: |
-          s5cmd --numworkers 1000 sync ./build/ s3://${{ secrets.DOCUMENT_BUCKET }}
+          s5cmd --numworkers 1024 sync ./build/ s3://${{ secrets.DOCUMENT_BUCKET }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/addDocsToS3BucketAWS.yml
+++ b/.github/workflows/addDocsToS3BucketAWS.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload to S3
         run: |
-          s5cmd sync --delete ./build/ s3://${{ secrets.DOCUMENT_BUCKET }}
+          s5cmd --numworkers 1000 sync ./build/ s3://${{ secrets.DOCUMENT_BUCKET }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

https://github.com/peak/s5cmd?tab=readme-ov-file#numworkers

The default worker number of the s5cmd tool is 256. Set it to 1024 can help us increase the speed of uploading files.


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
