### PR TITLE
docs: fix header name for custom trace table

### DIFF
--- a/docs/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/docs/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -203,7 +203,7 @@ To send OpenTelemetry traces data to GreptimeDB through OpenTelemetry SDK librar
 * URL: `http{s}://<host>/v1/otlp/v1/traces`
 * Headers: The headers section is the same as the [Logs](#Logs) section, you can refer to the [Logs](#Logs) section for more information.
 
-By default, GreptimeDB will write traces data to the `opentelemetry_traces` table in the `public` database. If you want to write traces data to a different table, you can use the `X-Greptime-DB-Name` and `X-Greptime-Log-Table-Name` headers to specify the database and table name.
+By default, GreptimeDB will write traces data to the `opentelemetry_traces` table in the `public` database. If you want to write traces data to a different table, you can use the `X-Greptime-DB-Name` and `X-Greptime-Trace-Table-Name` headers to specify the database and table name.
 
 GreptimeDB will accept **protobuf encoded traces data** via **HTTP protocol** and the following headers are required:
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -203,7 +203,7 @@ GreptimeDB 支持直接写入 OpenTelemetry 协议的 traces 数据，并内置 
 * URL: `http{s}://<host>/v1/otlp/v1/traces`
 * Headers: headers 与 [Logs](#Logs) 部分相同，你可以参考 [Logs](#Logs) 部分获取更多信息。
 
-默认地，GreptimeDB 会将 traces 数据写入到 `public` 数据库中的 `opentelemetry_traces` 表中。如果想要将 traces 数据写入到不同的表中，你可以使用 `X-Greptime-DB-Name` 和 `X-Greptime-Log-Table-Name` 头部信息来指定数据库和表名。
+默认地，GreptimeDB 会将 traces 数据写入到 `public` 数据库中的 `opentelemetry_traces` 表中。如果想要将 traces 数据写入到不同的表中，你可以使用 `X-Greptime-DB-Name` 和 `X-Greptime-Trace-Table-Name` 头部信息来指定数据库和表名。
 
 GreptimeDB 会接受 **protobuf 编码的 traces 数据** 通过 **HTTP 协议** 发送，其中对 HTTP header 有如下要求：
 


### PR DESCRIPTION
## What's Changed in this PR

- Update the header name from `X-Greptime-Log-Table-Name` to `X-Greptime-Trace-Table-Name` for specifying the table name when writing traces data to a custom table in GreptimeDB.
- This change affects both the English and Chinese documentation files.

*Describe the change in this PR*


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
