### PR TITLE
docs: update promql function list to include clamp, count and predicate_linear

### DIFF
--- a/docs/user-guide/query-data/promql.md
+++ b/docs/user-guide/query-data/promql.md
@@ -189,24 +189,24 @@ None
 ### Aggregators
 
 - Supported:
-    | Aggregator | Example                   |
-    | :--------- | :------------------------ |
-    | sum          | `sum by (foo)(metric)`    |
-    | avg          | `avg by (foo)(metric)`    |
-    | min          | `min by (foo)(metric)`    |
-    | max          | `max by (foo)(metric)`    |
-    | stddev       | `stddev by (foo)(metric)` |
-    | stdvar       | `stdvar by (foo)(metric)` |
-    | topk         | `topk(3, rate(instance_cpu_time_ns[5m]))`   |
-    | bottomk      | `bottomk(3, rate(instance_cpu_time_ns[5m]))`|
-    | count_values | `count_values("version", build_version)`    |
-    | quantile     | `quantile(0.9, cpu_usage)` |
+    | Aggregator   | Example                                      |
+    | :----------- | :------------------------------------------- |
+    | sum          | `sum by (foo)(metric)`                       |
+    | avg          | `avg by (foo)(metric)`                       |
+    | min          | `min by (foo)(metric)`                       |
+    | max          | `max by (foo)(metric)`                       |
+    | stddev       | `stddev by (foo)(metric)`                    |
+    | stdvar       | `stdvar by (foo)(metric)`                    |
+    | topk         | `topk(3, rate(instance_cpu_time_ns[5m]))`    |
+    | bottomk      | `bottomk(3, rate(instance_cpu_time_ns[5m]))` |
+    | count_values | `count_values("version", build_version)`     |
+    | count        | `count (metric)`                             |
+    | quantile     | `quantile(0.9, cpu_usage)`                   |
 
 - Unsupported:
-    | Aggregator   | Progress |
-    | :----------- | :------- |
-    | count        | TBD      |
-    | grouping     | TBD      |
+    | Aggregator | Progress |
+    | :--------- | :------- |
+    | grouping   | TBD      |
 
 ### Instant Functions
 
@@ -237,6 +237,7 @@ None
     | sort               | `sort(http_requests_total)`       |
     | sort_desc          | `sort_desc(http_requests_total)`  |
     | histogram_quantile | `histogram_quantile(phi, metric)` |
+    | clamp              | `clamp(metric, 0, 1)`             |
 
 - Unsupported:
     | Function                   | Progress / Example |
@@ -271,13 +272,13 @@ None
 ### Other Functions
 
 - Supported:
-    | Function           | Example                        |
-    | :----------------- | :----------------------------- |
-    | label_join             | `label_join(up{job="api-server",src1="a",src2="b",src3="c"}, "foo", ",", "src1", "src2", "src3")`           |
-    | label_replace | `label_replace(up{job="api-server",service="a:c"}, "foo", "$1", "service", "(.*):.*")`  |
+    | Function      | Example                                                                                           |
+    | :------------ | :------------------------------------------------------------------------------------------------ |
+    | label_join    | `label_join(up{job="api-server",src1="a",src2="b",src3="c"}, "foo", ",", "src1", "src2", "src3")` |
+    | label_replace | `label_replace(up{job="api-server",service="a:c"}, "foo", "$1", "service", "(.*):.*")`            |
 
 - Unsupported:
-    | Function           | Example                        |
-    | :----------------- | :----------------------------- |
-    | sort_by_label      | TBD           |
-    | sort_by_label_desc | TBD           |
+    | Function           | Example |
+    | :----------------- | :------ |
+    | sort_by_label      | TBD     |
+    | sort_by_label_desc | TBD     |

--- a/docs/user-guide/query-data/promql.md
+++ b/docs/user-guide/query-data/promql.md
@@ -237,6 +237,7 @@ None
     | sort               | `sort(http_requests_total)`       |
     | sort_desc          | `sort_desc(http_requests_total)`  |
     | histogram_quantile | `histogram_quantile(phi, metric)` |
+    | predicate_linear   | `predict_linear(metric, 120)`     |
     | clamp              | `clamp(metric, 0, 1)`             |
 
 - Unsupported:

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/query-data/promql.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/query-data/promql.md
@@ -188,24 +188,25 @@ PromQL 的时间戳精度受制于查询语法的限制，最高只支持毫秒�
 ### Aggregators
 
 - 支持：
-    | Aggregator | Example                   |
-    | :--------- | :------------------------ |
-    | sum        | `sum by (foo)(metric)`    |
-    | avg        | `avg by (foo)(metric)`    |
-    | min        | `min by (foo)(metric)`    |
-    | max        | `max by (foo)(metric)`    |
-    | stddev     | `stddev by (foo)(metric)` |
-    | stdvar     | `stdvar by (foo)(metric)` |
-    | topk         | `topk(3, rate(instance_cpu_time_ns[5m]))`   |
-    | bottomk      | `bottomk(3, rate(instance_cpu_time_ns[5m]))`|
-    | count_values | `count_values("version", build_version)`    |
-    | quantile     | `quantile(0.9, cpu_usage)` |
+    | Aggregator   | Example                                      |
+    | :----------- | :------------------------------------------- |
+    | sum          | `sum by (foo)(metric)`                       |
+    | avg          | `avg by (foo)(metric)`                       |
+    | min          | `min by (foo)(metric)`                       |
+    | max          | `max by (foo)(metric)`                       |
+    | stddev       | `stddev by (foo)(metric)`                    |
+    | stdvar       | `stdvar by (foo)(metric)`                    |
+    | topk         | `topk(3, rate(instance_cpu_time_ns[5m]))`    |
+    | bottomk      | `bottomk(3, rate(instance_cpu_time_ns[5m]))` |
+    | count_values | `count_values("version", build_version)`     |
+    | count        | `count (metric)`                             |
+    | quantile     | `quantile(0.9, cpu_usage)`                   |
 
 - 不支持：
-    | Aggregator   | Progress |
-    | :----------- | :------- |
-    | count        | TBD      |
-    | grouping     | TBD      |
+    | Aggregator | Progress |
+    | :--------- | :------- |
+    | count      | TBD      |
+    | grouping   | TBD      |
 
 ### Instant Functions
 
@@ -236,6 +237,7 @@ PromQL 的时间戳精度受制于查询语法的限制，最高只支持毫秒�
     | sort               | `sort(http_requests_total)`       |
     | sort_desc          | `sort_desc(http_requests_total)`  |
     | histogram_quantile | `histogram_quantile(phi, metric)` |
+    | clamp              | `clamp(metric, 0, 1)`             |
 
 - 不支持：
     | Function                   | Progress |
@@ -270,13 +272,13 @@ PromQL 的时间戳精度受制于查询语法的限制，最高只支持毫秒�
 ### 其他函数
 
 - 支持：
-    | Function           | Example                        |
-    | :----------------- | :----------------------------- |
-    | label_join             | `label_join(up{job="api-server",src1="a",src2="b",src3="c"}, "foo", ",", "src1", "src2", "src3")`           |
-    | label_replace | `label_replace(up{job="api-server",service="a:c"}, "foo", "$1", "service", "(.*):.*")`  |
+    | Function      | Example                                                                                           |
+    | :------------ | :------------------------------------------------------------------------------------------------ |
+    | label_join    | `label_join(up{job="api-server",src1="a",src2="b",src3="c"}, "foo", ",", "src1", "src2", "src3")` |
+    | label_replace | `label_replace(up{job="api-server",service="a:c"}, "foo", "$1", "service", "(.*):.*")`            |
 
 - 不支持：
-    | Function           | Example                        |
-    | :----------------- | :----------------------------- |
-    | sort_by_label      | TBD           |
-    | sort_by_label_desc | TBD           |
+    | Function           | Example |
+    | :----------------- | :------ |
+    | sort_by_label      | TBD     |
+    | sort_by_label_desc | TBD     |

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/query-data/promql.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/query-data/promql.md
@@ -237,6 +237,7 @@ PromQL 的时间戳精度受制于查询语法的限制，最高只支持毫秒�
     | sort               | `sort(http_requests_total)`       |
     | sort_desc          | `sort_desc(http_requests_total)`  |
     | histogram_quantile | `histogram_quantile(phi, metric)` |
+    | predicate_linear   | `predict_linear(metric, 120)`     |
     | clamp              | `clamp(metric, 0, 1)`             |
 
 - 不支持：


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

*Describe the change in this PR*

`count` is missing in https://github.com/GreptimeTeam/docs/pull/1581
`clamp` is from https://github.com/GreptimeTeam/greptimedb/pull/3465
`predicate_linear` is from https://github.com/GreptimeTeam/greptimedb/pull/1362

## Checklist

- [x] Please confirm that all corresponding versions of the documents have been revised.
- [x] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
