### PR TITLE
docs: split the otel-collector out of OTLP

### DIFF
--- a/docs/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/docs/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -10,7 +10,7 @@ description: Instructions for integrating OpenTelemetry with GreptimeDB, includi
 ## OpenTelemetry Collectors
 
 You can easily configure GreptimeDB as the target for your OpenTelemetry collector.
-For more information, please refer to the [Grafana Alloy](alloy.md) example.
+For more information, please refer to the [OTel Collector](otel-collector.md) and [Grafana Alloy](alloy.md) example.
 
 ## Metrics
 
@@ -255,71 +255,3 @@ By default, the table is partitioned into 16 uniform regions based on the `trace
 
 By default, log table created by OpenTelemetry API are in [append only
 mode](/user-guide/administration/design-table.md#when-to-use-append-only-tables).
-
-# Sending Data to GreptimeDB Using OpenTelemetry Collector
-
-OpenTelemetry Collector is an extensible service for receiving, processing, and exporting OpenTelemetry data. It can act as an intermediate layer to send data from different sources to GreptimeDB.
-Below is a sample configuration for sending data to GreptimeDB using OpenTelemetry Collector.
-
-```yaml
-extensions:
-  basicauth/client:
-    client_auth:
-      username: <your_username>
-      password: <your_password>
-
-receivers:
-  otlp:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
-      http:
-        endpoint: 0.0.0.0:4318
-
-exporters:
-  otlphttp/traces:
-    endpoint: 'http://127.0.0.1:4000/v1/otlp'
-    # auth:
-    #   authenticator: basicauth/client
-    headers:
-      # x-greptime-db-name: '<your_db_name>'
-      x-greptime-pipeline-name: 'greptime_trace_v1'
-    tls:
-      insecure: true
-  otlphttp/logs:
-    endpoint: 'http://127.0.0.1:4000/v1/otlp'
-    # auth:
-    #   authenticator: basicauth/client
-    headers:
-      # x-greptime-db-name: '<your_db_name>'
-      # x-greptime-log-table-name: "<pipeline_name>"
-    tls:
-      insecure: true
-
-  otlphttp/metrics:
-    endpoint: 'http://127.0.0.1:4000/v1/otlp'
-    # auth:
-    #   authenticator: basicauth/client
-    headers:
-      # x-greptime-db-name: '<your_db_name>'
-    tls:
-      insecure: true
-
-service:
-  # extensions: [basicauth/client]
-  pipelines:
-    traces:
-      receivers: [otlp]
-      exporters: [otlphttp/traces]
-    logs:
-      receivers: [otlp]
-      exporters: [otlphttp/logs]
-    metrics:
-      receivers: [otlp]
-      exporters: [otlphttp/metrics]
-```
-
-In the above configuration, we define a receiver `otlp` that can receive data from OpenTelemetry. We also define three exporters: `otlphttp/traces`, `otlphttp/logs`, and `otlphttp/metrics`, which send data to the OTLP endpoint of GreptimeDB.
-Based on the otlphttp protocol, we have added some headers to specify certain parameters, such as `x-greptime-pipeline-name` and `x-greptime-log-table-name`. The `x-greptime-pipeline-name` header is used to specify the pipeline name to use, and the `x-greptime-log-table-name` header is used to specify the table name in GreptimeDB where the data will be written.
-If you have enabled authentication in GreptimeDB, you need to use the `basicauth/client` extension to handle basic authentication.
-Here, we strongly recommend using different exporters to handle traces, logs, and metrics separately. On one hand, GreptimeDB supports some specific headers to customize processing flows; on the other hand, this also helps with data isolation.

--- a/docs/user-guide/ingest-data/for-observability/otel-collector.md
+++ b/docs/user-guide/ingest-data/for-observability/otel-collector.md
@@ -1,0 +1,75 @@
+# OTel Collector
+
+[OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) offers a vendor-agnostic implementation of how to receive, process and export telemetry data. It can act as an intermediate layer to send data from different sources to GreptimeDB.
+Below is a sample configuration for sending data to GreptimeDB using OpenTelemetry Collector.
+
+```yaml
+extensions:
+  basicauth/client:
+    client_auth:
+      username: <your_username>
+      password: <your_password>
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  otlphttp/traces:
+    endpoint: 'http://127.0.0.1:4000/v1/otlp'
+    # auth:
+    #   authenticator: basicauth/client
+    headers:
+      # x-greptime-db-name: '<your_db_name>'
+      x-greptime-pipeline-name: 'greptime_trace_v1'
+    tls:
+      insecure: true
+  otlphttp/logs:
+    endpoint: 'http://127.0.0.1:4000/v1/otlp'
+    # auth:
+    #   authenticator: basicauth/client
+    headers:
+      # x-greptime-db-name: '<your_db_name>'
+      # x-greptime-log-table-name: '<table_name>'
+      # x-greptime-pipeline-name: '<pipeline_name>'
+    tls:
+      insecure: true
+
+  otlphttp/metrics:
+    endpoint: 'http://127.0.0.1:4000/v1/otlp'
+    # auth:
+    #   authenticator: basicauth/client
+    headers:
+      # x-greptime-db-name: '<your_db_name>'
+    tls:
+      insecure: true
+
+service:
+  # extensions: [basicauth/client]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlphttp/traces]
+    logs:
+      receivers: [otlp]
+      exporters: [otlphttp/logs]
+    metrics:
+      receivers: [otlp]
+      exporters: [otlphttp/metrics]
+```
+
+In the above configuration, we define a receiver `otlp` that can receive data from OpenTelemetry. We also define three exporters: `otlphttp/traces`, `otlphttp/logs`, and `otlphttp/metrics`, which send data to the OTLP endpoint of GreptimeDB.
+
+Based on the otlphttp protocol, we have added some headers to specify certain parameters, such as `x-greptime-pipeline-name` and `x-greptime-log-table-name`:
+* The `x-greptime-pipeline-name` header is used to specify the pipeline name to use, and,
+* the `x-greptime-log-table-name` header is used to specify the table name in GreptimeDB where the data will be written.
+
+If you have enabled [authentication](/user-guide/deployments/authentication/overview.md) in GreptimeDB, you need to use the `basicauth/client` extension to handle basic authentication.
+
+Here, we strongly recommend using different exporters to handle traces, logs, and metrics separately. On one hand, GreptimeDB supports some specific headers to customize processing flows; on the other hand, this also helps with data isolation.
+
+For more about OpenTelemetry protocols, please read the [doc](/user-guide/ingest-data/for-observability/opentelemetry.md).

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -10,8 +10,8 @@ OpenTelemetry Protocol (OTLP) 定义了观测数据在观测源和中间进程�
 
 ## OpenTelemetry Collectors
 
-你可以很简单地将 GreptimeDB 配置为 OpenTelemetry Collector 的目标。
-有关更多信息，请参阅 [Grafana Alloy](alloy.md) 示例。
+你可以很简单地将 GreptimeDB 配置为 OpenTelemetry 采集器写入的目标。
+有关更多信息，请参阅 [OTel Collector](otel-collector.md) 和[Grafana Alloy](alloy.md) 示例。
 
 ## Metrics
 
@@ -256,71 +256,3 @@ OTLP traces 数据模型根据以下规则映射到 GreptimeDB 数据模型：
 ### Append 模式
 
 通过此接口创建的表，默认为[Append 模式](/user-guide/administration/design-table.md#何时使用-append-only-表).
-
-# 使用 OpenTelemetry Collector 将数据发送到 GreptimeDB
-
-OpenTelemetry Collector 是一个可扩展的服务，用于接收、处理和导出 OpenTelemetry 数据。它可以作为数据的中间层，将数据从不同的源发送到 GreptimeDB。
-以下是使用 OpenTelemetry Collector 将数据发送到 GreptimeDB 的配置示例。
-
-```yaml
-extensions:
-  basicauth/client:
-    client_auth:
-      username: <your_username>
-      password: <your_password>
-
-receivers:
-  otlp:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
-      http:
-        endpoint: 0.0.0.0:4318
-
-exporters:
-  otlphttp/traces:
-    endpoint: 'http://127.0.0.1:4000/v1/otlp'
-    # auth:
-    #   authenticator: basicauth/client
-    headers:
-      # x-greptime-db-name: '<your_db_name>'
-      x-greptime-pipeline-name: 'greptime_trace_v1'
-    tls:
-      insecure: true
-  otlphttp/logs:
-    endpoint: 'http://127.0.0.1:4000/v1/otlp'
-    # auth:
-    #   authenticator: basicauth/client
-    headers:
-      # x-greptime-db-name: '<your_db_name>'
-      # x-greptime-log-table-name: "<pipeline_name>"
-    tls:
-      insecure: true
-
-  otlphttp/metrics:
-    endpoint: 'http://127.0.0.1:4000/v1/otlp'
-    # auth:
-    #   authenticator: basicauth/client
-    headers:
-      # x-greptime-db-name: '<your_db_name>'
-    tls:
-      insecure: true
-
-service:
-  # extensions: [basicauth/client]
-  pipelines:
-    traces:
-      receivers: [otlp]
-      exporters: [otlphttp/traces]
-    logs:
-      receivers: [otlp]
-      exporters: [otlphttp/logs]
-    metrics:
-      receivers: [otlp]
-      exporters: [otlphttp/metrics]
-```
-
-在上面的配置中，我们定义了一个接收器 `otlp`，它可以接收来自 OpenTelemetry 的数据。我们还定义了三个导出器 `otlphttp/traces`、`otlphttp/logs` 和 `otlphttp/metrics`，它们将数据发送到 GreptimeDB 的 OTLP 路径。
-在 otlphttp 协议的基础上，我们增加了一些 header 用来指定一些参数，比如 `x-greptime-pipeline-name` 和 `x-greptime-log-table-name`，`x-greptime-pipeline-name` 用来指定要使用的 pipeline 名称，`x-greptime-log-table-name` 用来指定数据将要写入 GreptimeDB 的表名。
-如果你在 GreptimeDB 设置了鉴权。则需要使用 `basicauth/client` 扩展来处理基本的身份验证。
-这里我们强烈建议使用不同的导出器来分别处理 traces、logs 和 metrics 数据，一方面是因为 GreptimeDB 会支持一些特定的 header 来自定义一些处理流程，另一方面也可以做好数据隔离。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/otel-collector.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/otel-collector.md
@@ -1,0 +1,75 @@
+#  OTel Collector
+
+[OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) 提供了一种与供应商无关的 OTEL 实现，用于接收、处理和导出可观测数据。它可以作为数据的中间层，将数据从不同的源发送到 GreptimeDB。
+以下是使用 OpenTelemetry Collector 将数据发送到 GreptimeDB 的配置示例。
+
+```yaml
+extensions:
+  basicauth/client:
+    client_auth:
+      username: <your_username>
+      password: <your_password>
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  otlphttp/traces:
+    endpoint: 'http://127.0.0.1:4000/v1/otlp'
+    # auth:
+    #   authenticator: basicauth/client
+    headers:
+      # x-greptime-db-name: '<your_db_name>'
+      x-greptime-pipeline-name: 'greptime_trace_v1'
+    tls:
+      insecure: true
+  otlphttp/logs:
+    endpoint: 'http://127.0.0.1:4000/v1/otlp'
+    # auth:
+    #   authenticator: basicauth/client
+    headers:
+      # x-greptime-db-name: '<your_db_name>'
+      # x-greptime-log-table-name: '<table_name>'
+      # x-greptime-pipeline-name: '<pipeline_name>'
+    tls:
+      insecure: true
+
+  otlphttp/metrics:
+    endpoint: 'http://127.0.0.1:4000/v1/otlp'
+    # auth:
+    #   authenticator: basicauth/client
+    headers:
+      # x-greptime-db-name: '<your_db_name>'
+    tls:
+      insecure: true
+
+service:
+  # extensions: [basicauth/client]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlphttp/traces]
+    logs:
+      receivers: [otlp]
+      exporters: [otlphttp/logs]
+    metrics:
+      receivers: [otlp]
+      exporters: [otlphttp/metrics]
+```
+
+在上面的配置中，我们定义了一个接收器 `otlp`，它可以接收来自 OpenTelemetry 的数据。我们还定义了三个导出器 `otlphttp/traces`、`otlphttp/logs` 和 `otlphttp/metrics`，它们将数据发送到 GreptimeDB 的 OTLP 路径。
+
+在 otlphttp 协议的基础上，我们增加了一些 header 用来指定一些参数，比如 `x-greptime-pipeline-name` 和 `x-greptime-log-table-name`:
+* `x-greptime-pipeline-name` 用来指定要使用的 pipeline 名称
+* `x-greptime-log-table-name` 用来指定数据将要写入 GreptimeDB 的表名。
+
+如果你在 GreptimeDB 设置了[鉴权](/user-guide/deployments/authentication/overview.md)。则需要使用 `basicauth/client` 扩展来处理基本的身份验证。
+
+这里我们强烈建议使用不同的导出器来分别处理 traces、logs 和 metrics 数据，一方面是因为 GreptimeDB 会支持一些特定的 header 来自定义一些处理流程，另一方面也可以做好数据隔离。
+
+关于 OpenTelemetry 协议的更多信息，请阅读[文档](/user-guide/ingest-data/for-observability/opentelemetry.md)。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -10,8 +10,8 @@ OpenTelemetry Protocol (OTLP) 定义了观测数据在观测源和中间进程�
 
 ## OpenTelemetry Collectors
 
-你可以很简单地将 GreptimeDB 配置为 OpenTelemetry Collector 的目标。
-有关更多信息，请参阅 [Grafana Alloy](alloy.md) 示例。
+你可以很简单地将 GreptimeDB 配置为 OpenTelemetry 采集器写入的目标。
+有关更多信息，请参阅 [OTel Collector](otel-collector.md) 和[Grafana Alloy](alloy.md) 示例。
 
 ## Metrics
 
@@ -256,71 +256,3 @@ OTLP traces 数据模型根据以下规则映射到 GreptimeDB 数据模型：
 ### Append 模式
 
 通过此接口创建的表，默认为[Append 模式](/user-guide/administration/design-table.md#何时使用-append-only-表).
-
-# 使用 OpenTelemetry Collector 将数据发送到 GreptimeDB
-
-OpenTelemetry Collector 是一个可扩展的服务，用于接收、处理和导出 OpenTelemetry 数据。它可以作为数据的中间层，将数据从不同的源发送到 GreptimeDB。
-以下是使用 OpenTelemetry Collector 将数据发送到 GreptimeDB 的配置示例。
-
-```yaml
-extensions:
-  basicauth/client:
-    client_auth:
-      username: <your_username>
-      password: <your_password>
-
-receivers:
-  otlp:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
-      http:
-        endpoint: 0.0.0.0:4318
-
-exporters:
-  otlphttp/traces:
-    endpoint: 'http://127.0.0.1:4000/v1/otlp'
-    # auth:
-    #   authenticator: basicauth/client
-    headers:
-      # x-greptime-db-name: '<your_db_name>'
-      x-greptime-pipeline-name: 'greptime_trace_v1'
-    tls:
-      insecure: true
-  otlphttp/logs:
-    endpoint: 'http://127.0.0.1:4000/v1/otlp'
-    # auth:
-    #   authenticator: basicauth/client
-    headers:
-      # x-greptime-db-name: '<your_db_name>'
-      # x-greptime-log-table-name: "<pipeline_name>"
-    tls:
-      insecure: true
-
-  otlphttp/metrics:
-    endpoint: 'http://127.0.0.1:4000/v1/otlp'
-    # auth:
-    #   authenticator: basicauth/client
-    headers:
-      # x-greptime-db-name: '<your_db_name>'
-    tls:
-      insecure: true
-
-service:
-  # extensions: [basicauth/client]
-  pipelines:
-    traces:
-      receivers: [otlp]
-      exporters: [otlphttp/traces]
-    logs:
-      receivers: [otlp]
-      exporters: [otlphttp/logs]
-    metrics:
-      receivers: [otlp]
-      exporters: [otlphttp/metrics]
-```
-
-在上面的配置中，我们定义了一个接收器 `otlp`，它可以接收来自 OpenTelemetry 的数据。我们还定义了三个导出器 `otlphttp/traces`、`otlphttp/logs` 和 `otlphttp/metrics`，它们将数据发送到 GreptimeDB 的 OTLP 路径。
-在 otlphttp 协议的基础上，我们增加了一些 header 用来指定一些参数，比如 `x-greptime-pipeline-name` 和 `x-greptime-log-table-name`，`x-greptime-pipeline-name` 用来指定要使用的 pipeline 名称，`x-greptime-log-table-name` 用来指定数据将要写入 GreptimeDB 的表名。
-如果你在 GreptimeDB 设置了鉴权。则需要使用 `basicauth/client` 扩展来处理基本的身份验证。
-这里我们强烈建议使用不同的导出器来分别处理 traces、logs 和 metrics 数据，一方面是因为 GreptimeDB 会支持一些特定的 header 来自定义一些处理流程，另一方面也可以做好数据隔离。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/ingest-data/for-observability/otel-collector.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/ingest-data/for-observability/otel-collector.md
@@ -1,0 +1,75 @@
+#  OTel Collector
+
+[OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) 提供了一种与供应商无关的 OTEL 实现，用于接收、处理和导出可观测数据。它可以作为数据的中间层，将数据从不同的源发送到 GreptimeDB。
+以下是使用 OpenTelemetry Collector 将数据发送到 GreptimeDB 的配置示例。
+
+```yaml
+extensions:
+  basicauth/client:
+    client_auth:
+      username: <your_username>
+      password: <your_password>
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  otlphttp/traces:
+    endpoint: 'http://127.0.0.1:4000/v1/otlp'
+    # auth:
+    #   authenticator: basicauth/client
+    headers:
+      # x-greptime-db-name: '<your_db_name>'
+      x-greptime-pipeline-name: 'greptime_trace_v1'
+    tls:
+      insecure: true
+  otlphttp/logs:
+    endpoint: 'http://127.0.0.1:4000/v1/otlp'
+    # auth:
+    #   authenticator: basicauth/client
+    headers:
+      # x-greptime-db-name: '<your_db_name>'
+      # x-greptime-log-table-name: '<table_name>'
+      # x-greptime-pipeline-name: '<pipeline_name>'
+    tls:
+      insecure: true
+
+  otlphttp/metrics:
+    endpoint: 'http://127.0.0.1:4000/v1/otlp'
+    # auth:
+    #   authenticator: basicauth/client
+    headers:
+      # x-greptime-db-name: '<your_db_name>'
+    tls:
+      insecure: true
+
+service:
+  # extensions: [basicauth/client]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlphttp/traces]
+    logs:
+      receivers: [otlp]
+      exporters: [otlphttp/logs]
+    metrics:
+      receivers: [otlp]
+      exporters: [otlphttp/metrics]
+```
+
+在上面的配置中，我们定义了一个接收器 `otlp`，它可以接收来自 OpenTelemetry 的数据。我们还定义了三个导出器 `otlphttp/traces`、`otlphttp/logs` 和 `otlphttp/metrics`，它们将数据发送到 GreptimeDB 的 OTLP 路径。
+
+在 otlphttp 协议的基础上，我们增加了一些 header 用来指定一些参数，比如 `x-greptime-pipeline-name` 和 `x-greptime-log-table-name`:
+* `x-greptime-pipeline-name` 用来指定要使用的 pipeline 名称
+* `x-greptime-log-table-name` 用来指定数据将要写入 GreptimeDB 的表名。
+
+如果你在 GreptimeDB 设置了[鉴权](/user-guide/deployments/authentication/overview.md)。则需要使用 `basicauth/client` 扩展来处理基本的身份验证。
+
+这里我们强烈建议使用不同的导出器来分别处理 traces、logs 和 metrics 数据，一方面是因为 GreptimeDB 会支持一些特定的 header 来自定义一些处理流程，另一方面也可以做好数据隔离。
+
+关于 OpenTelemetry 协议的更多信息，请阅读[文档](/user-guide/ingest-data/for-observability/opentelemetry.md)。

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -83,6 +83,7 @@ const sidebars: SidebarsConfig = {
                 'user-guide/ingest-data/for-observability/influxdb-line-protocol',
                 'user-guide/ingest-data/for-observability/kafka',
                 'user-guide/ingest-data/for-observability/loki',
+                'user-guide/ingest-data/for-observability/otel-collector',
                 'user-guide/ingest-data/for-observability/alloy',
                 'user-guide/ingest-data/for-observability/elasticsearch',
                 'user-guide/ingest-data/for-observability/fluent-bit',

--- a/versioned_docs/version-0.14/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/versioned_docs/version-0.14/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -10,7 +10,7 @@ description: Instructions for integrating OpenTelemetry with GreptimeDB, includi
 ## OpenTelemetry Collectors
 
 You can easily configure GreptimeDB as the target for your OpenTelemetry collector.
-For more information, please refer to the [Grafana Alloy](alloy.md) example.
+For more information, please refer to the [OTel Collector](otel-collector.md) and [Grafana Alloy](alloy.md) example.
 
 ## Metrics
 
@@ -255,71 +255,3 @@ By default, the table is partitioned into 16 uniform regions based on the `trace
 
 By default, log table created by OpenTelemetry API are in [append only
 mode](/user-guide/administration/design-table.md#when-to-use-append-only-tables).
-
-# Sending Data to GreptimeDB Using OpenTelemetry Collector
-
-OpenTelemetry Collector is an extensible service for receiving, processing, and exporting OpenTelemetry data. It can act as an intermediate layer to send data from different sources to GreptimeDB.
-Below is a sample configuration for sending data to GreptimeDB using OpenTelemetry Collector.
-
-```yaml
-extensions:
-  basicauth/client:
-    client_auth:
-      username: <your_username>
-      password: <your_password>
-
-receivers:
-  otlp:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
-      http:
-        endpoint: 0.0.0.0:4318
-
-exporters:
-  otlphttp/traces:
-    endpoint: 'http://127.0.0.1:4000/v1/otlp'
-    # auth:
-    #   authenticator: basicauth/client
-    headers:
-      # x-greptime-db-name: '<your_db_name>'
-      x-greptime-pipeline-name: 'greptime_trace_v1'
-    tls:
-      insecure: true
-  otlphttp/logs:
-    endpoint: 'http://127.0.0.1:4000/v1/otlp'
-    # auth:
-    #   authenticator: basicauth/client
-    headers:
-      # x-greptime-db-name: '<your_db_name>'
-      # x-greptime-log-table-name: "<pipeline_name>"
-    tls:
-      insecure: true
-
-  otlphttp/metrics:
-    endpoint: 'http://127.0.0.1:4000/v1/otlp'
-    # auth:
-    #   authenticator: basicauth/client
-    headers:
-      # x-greptime-db-name: '<your_db_name>'
-    tls:
-      insecure: true
-
-service:
-  # extensions: [basicauth/client]
-  pipelines:
-    traces:
-      receivers: [otlp]
-      exporters: [otlphttp/traces]
-    logs:
-      receivers: [otlp]
-      exporters: [otlphttp/logs]
-    metrics:
-      receivers: [otlp]
-      exporters: [otlphttp/metrics]
-```
-
-In the above configuration, we define a receiver `otlp` that can receive data from OpenTelemetry. We also define three exporters: `otlphttp/traces`, `otlphttp/logs`, and `otlphttp/metrics`, which send data to the OTLP endpoint of GreptimeDB.
-Based on the otlphttp protocol, we have added some headers to specify certain parameters, such as `x-greptime-pipeline-name` and `x-greptime-log-table-name`. The `x-greptime-pipeline-name` header is used to specify the pipeline name to use, and the `x-greptime-log-table-name` header is used to specify the table name in GreptimeDB where the data will be written.
-If you have enabled authentication in GreptimeDB, you need to use the `basicauth/client` extension to handle basic authentication.
-Here, we strongly recommend using different exporters to handle traces, logs, and metrics separately. On one hand, GreptimeDB supports some specific headers to customize processing flows; on the other hand, this also helps with data isolation.

--- a/versioned_docs/version-0.14/user-guide/ingest-data/for-observability/otel-collector.md
+++ b/versioned_docs/version-0.14/user-guide/ingest-data/for-observability/otel-collector.md
@@ -1,0 +1,75 @@
+# OTel Collector
+
+[OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) offers a vendor-agnostic implementation of how to receive, process and export telemetry data. It can act as an intermediate layer to send data from different sources to GreptimeDB.
+Below is a sample configuration for sending data to GreptimeDB using OpenTelemetry Collector.
+
+```yaml
+extensions:
+  basicauth/client:
+    client_auth:
+      username: <your_username>
+      password: <your_password>
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  otlphttp/traces:
+    endpoint: 'http://127.0.0.1:4000/v1/otlp'
+    # auth:
+    #   authenticator: basicauth/client
+    headers:
+      # x-greptime-db-name: '<your_db_name>'
+      x-greptime-pipeline-name: 'greptime_trace_v1'
+    tls:
+      insecure: true
+  otlphttp/logs:
+    endpoint: 'http://127.0.0.1:4000/v1/otlp'
+    # auth:
+    #   authenticator: basicauth/client
+    headers:
+      # x-greptime-db-name: '<your_db_name>'
+      # x-greptime-log-table-name: '<table_name>'
+      # x-greptime-pipeline-name: '<pipeline_name>'
+    tls:
+      insecure: true
+
+  otlphttp/metrics:
+    endpoint: 'http://127.0.0.1:4000/v1/otlp'
+    # auth:
+    #   authenticator: basicauth/client
+    headers:
+      # x-greptime-db-name: '<your_db_name>'
+    tls:
+      insecure: true
+
+service:
+  # extensions: [basicauth/client]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlphttp/traces]
+    logs:
+      receivers: [otlp]
+      exporters: [otlphttp/logs]
+    metrics:
+      receivers: [otlp]
+      exporters: [otlphttp/metrics]
+```
+
+In the above configuration, we define a receiver `otlp` that can receive data from OpenTelemetry. We also define three exporters: `otlphttp/traces`, `otlphttp/logs`, and `otlphttp/metrics`, which send data to the OTLP endpoint of GreptimeDB.
+
+Based on the otlphttp protocol, we have added some headers to specify certain parameters, such as `x-greptime-pipeline-name` and `x-greptime-log-table-name`:
+* The `x-greptime-pipeline-name` header is used to specify the pipeline name to use, and,
+* the `x-greptime-log-table-name` header is used to specify the table name in GreptimeDB where the data will be written.
+
+If you have enabled [authentication](/user-guide/deployments/authentication/overview.md) in GreptimeDB, you need to use the `basicauth/client` extension to handle basic authentication.
+
+Here, we strongly recommend using different exporters to handle traces, logs, and metrics separately. On one hand, GreptimeDB supports some specific headers to customize processing flows; on the other hand, this also helps with data isolation.
+
+For more about OpenTelemetry protocols, please read the [doc](/user-guide/ingest-data/for-observability/opentelemetry.md).

--- a/versioned_sidebars/version-0.14-sidebars.json
+++ b/versioned_sidebars/version-0.14-sidebars.json
@@ -81,6 +81,7 @@
                 "user-guide/ingest-data/for-observability/influxdb-line-protocol",
                 "user-guide/ingest-data/for-observability/kafka",
                 "user-guide/ingest-data/for-observability/loki",
+                "user-guide/ingest-data/for-observability/otel-collector",
                 "user-guide/ingest-data/for-observability/alloy",
                 "user-guide/ingest-data/for-observability/elasticsearch",
                 "user-guide/ingest-data/for-observability/fluent-bit"


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

*Describe the change in this PR*

* Separate the otel-collector documentation from the OTLP documentation into its own document.

## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
