### PR TITLE
feat: add backport script

### DIFF
--- a/docs/user-guide/logs/overview.md
+++ b/docs/user-guide/logs/overview.md
@@ -5,6 +5,9 @@ description: Provides links to various guides on using GreptimeDB's log service,
 
 # Logs
 
+In this chapter, we will walk-through GreptimeDB's features for logs support,
+from basic ingestion/query, to advanced transformation, full-text index topics.
+
 - [Quick Start](./quick-start.md): Provides an introduction on how to quickly get started with GreptimeDB log service.
 - [Pipeline Configuration](./pipeline-config.md): Provides in-depth information on each specific configuration of pipelines in GreptimeDB.
 - [Managing Pipelines](./manage-pipelines.md): Explains how to create and delete pipelines.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/overview.md
@@ -5,6 +5,9 @@ description: 提供了使用 GreptimeDB 日志服务的各种指南，包括快�
 
 # 日志
 
+本节内容将涵盖 GreptimeDB 针对日志的功能介绍，从基本的写入查询，到高级功能，诸如
+数据变换、全文索引等。
+
 - [快速开始](./quick-start.md)：介绍了如何快速开始使用 GreptimeDB 日志服务。
 - [Pipeline 配置](./pipeline-config.md)：深入介绍 GreptimeDB 中的 Pipeline 的每项具体配置。
 - [管理 Pipeline](./manage-pipelines.md)：介绍了如何创建、删除 Pipeline。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/logs/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/logs/overview.md
@@ -5,6 +5,9 @@ description: 提供了使用 GreptimeDB 日志服务的各种指南，包括快�
 
 # 日志
 
+本节内容将涵盖 GreptimeDB 针对日志的功能介绍，从基本的写入查询，到高级功能，诸如
+数据变换、全文索引等。
+
 - [快速开始](./quick-start.md)：介绍了如何快速开始使用 GreptimeDB 日志服务。
 - [Pipeline 配置](./pipeline-config.md)：深入介绍 GreptimeDB 中的 Pipeline 的每项具体配置。
 - [管理 Pipeline](./manage-pipelines.md)：介绍了如何创建、删除 Pipeline。

--- a/package.json
+++ b/package.json
@@ -1,3 +1,4 @@
+
 {
   "name": "my-website",
   "version": "0.0.0",
@@ -12,7 +13,9 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "backport": "node scripts/backport-docs.js",
+    "backport:dry": "node scripts/backport-docs.js --dry-run --verbose"
   },
   "dependencies": {
     "@1stg/common-config": "^10.0.0",

--- a/scripts/backport-docs.js
+++ b/scripts/backport-docs.js
@@ -1,0 +1,391 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+class DocusaurusVersionSync {
+  constructor(options = {}) {
+    this.rootDir = options.rootDir || process.cwd();
+    this.docsDir = options.docsDir || 'docs';
+    this.versionsDir = options.versionsDir || 'versioned_docs';
+    this.i18nDir = options.i18nDir || 'i18n';
+    this.defaultLocale = options.defaultLocale || 'en';
+    this.targetVersion = options.targetVersion;
+    this.dryRun = options.dryRun || false;
+    this.verbose = options.verbose || false;
+
+    // File patterns to include/exclude
+    this.includePatterns = options.includePatterns || ['.md', '.mdx'];
+    this.excludePatterns = options.excludePatterns || ['node_modules', '.git'];
+  }
+
+  log(message, level = 'info') {
+    if (this.verbose || level === 'error') {
+      const timestamp = new Date().toISOString();
+      console.log(`[${timestamp}] [${level.toUpperCase()}] ${message}`);
+    }
+  }
+
+  /**
+   * Get all available versions from versioned_docs directory
+   */
+  getAvailableVersions() {
+    const versionsPath = path.join(this.rootDir, this.versionsDir);
+
+    if (!fs.existsSync(versionsPath)) {
+      this.log('No versioned_docs directory found', 'error');
+      return [];
+    }
+
+    return fs.readdirSync(versionsPath)
+      .filter(item => {
+        const itemPath = path.join(versionsPath, item);
+        return fs.statSync(itemPath).isDirectory();
+      })
+      .filter(version => version.startsWith('version-'))
+      .sort();
+  }
+
+  /**
+   * Get available locales from i18n directory
+   */
+  getAvailableLocales() {
+    const i18nPath = path.join(this.rootDir, this.i18nDir);
+
+    if (!fs.existsSync(i18nPath)) {
+      return [this.defaultLocale];
+    }
+
+    const locales = fs.readdirSync(i18nPath)
+      .filter(item => {
+        const itemPath = path.join(i18nPath, item);
+        return fs.statSync(itemPath).isDirectory();
+      });
+
+    return [this.defaultLocale, ...locales.filter(locale => locale !== this.defaultLocale)];
+  }
+
+  /**
+   * Get git diff for modified files (including i18n current docs)
+   */
+  getModifiedFiles(since = 'HEAD~1') {
+    try {
+      const locales = this.getAvailableLocales();
+      const patterns = [`${this.docsDir}/`];
+
+      // Add i18n current docs patterns for non-default locales
+      locales.forEach(locale => {
+        if (locale !== this.defaultLocale) {
+          patterns.push(`${this.i18nDir}/${locale}/docusaurus-plugin-content-docs/current/`);
+        }
+      });
+
+      const command = `git diff --name-only ${since} -- ${patterns.join(' ')}`;
+      const output = execSync(command, { cwd: this.rootDir, encoding: 'utf8' });
+
+      return output.trim().split('\n').filter(file => {
+        if (!file) return false;
+
+        // Check if file matches include patterns
+        const hasIncludePattern = this.includePatterns.some(pattern =>
+          file.endsWith(pattern)
+        );
+
+        // Check if file matches exclude patterns
+        const hasExcludePattern = this.excludePatterns.some(pattern =>
+          file.includes(pattern)
+        );
+
+        return hasIncludePattern && !hasExcludePattern;
+      });
+    } catch (error) {
+      this.log(`Error getting modified files: ${error.message}`, 'error');
+      return [];
+    }
+  }
+
+  /**
+   * Get the actual diff content for a file
+   */
+  getFileDiff(filePath, since = 'HEAD~1') {
+    try {
+      const command = `git diff ${since} -- "${filePath}"`;
+      return execSync(command, { cwd: this.rootDir, encoding: 'utf8' });
+    } catch (error) {
+      this.log(`Error getting diff for ${filePath}: ${error.message}`, 'error');
+      return '';
+    }
+  }
+
+  /**
+   * Apply diff to a target file
+   */
+  applyDiffToFile(sourcePath, targetPath, diff) {
+    if (!fs.existsSync(targetPath)) {
+      this.log(`Target file doesn't exist: ${targetPath}`, 'error');
+      return false;
+    }
+
+    try {
+      // Create a temporary patch file
+      const tempPatchFile = path.join(this.rootDir, '.temp_patch');
+
+      // Modify the diff to point to the target file
+      const modifiedDiff = diff.replace(
+        new RegExp(`a/${sourcePath}`, 'g'),
+        `a/${targetPath}`
+      ).replace(
+        new RegExp(`b/${sourcePath}`, 'g'),
+        `b/${targetPath}`
+      );
+
+      fs.writeFileSync(tempPatchFile, modifiedDiff);
+
+      if (this.dryRun) {
+        this.log(`[DRY RUN] Would apply patch to: ${targetPath}`);
+        this.log(`Patch content:\n${modifiedDiff}`);
+      } else {
+        // Apply the patch
+        const command = `git apply --ignore-whitespace "${tempPatchFile}"`;
+        execSync(command, { cwd: this.rootDir });
+        this.log(`Successfully applied patch to: ${targetPath}`);
+      }
+
+      // Clean up temp file
+      if (fs.existsSync(tempPatchFile)) {
+        fs.unlinkSync(tempPatchFile);
+      }
+
+      return true;
+    } catch (error) {
+      this.log(`Error applying patch to ${targetPath}: ${error.message}`, 'error');
+
+      // Try manual content replacement as fallback
+      return this.manualContentSync(sourcePath, targetPath);
+    }
+  }
+
+  /**
+   * Fallback method: manually sync content when patch fails
+   */
+  manualContentSync(sourcePath, targetPath) {
+    try {
+      const sourceFullPath = path.join(this.rootDir, sourcePath);
+      const targetFullPath = path.join(this.rootDir, targetPath);
+
+      if (!fs.existsSync(sourceFullPath) || !fs.existsSync(targetFullPath)) {
+        return false;
+      }
+
+      const sourceContent = fs.readFileSync(sourceFullPath, 'utf8');
+
+      if (this.dryRun) {
+        this.log(`[DRY RUN] Would copy content from ${sourcePath} to ${targetPath}`);
+      } else {
+        fs.writeFileSync(targetFullPath, sourceContent);
+        this.log(`Manually synced content: ${sourcePath} → ${targetPath}`);
+      }
+
+      return true;
+    } catch (error) {
+      this.log(`Error in manual sync: ${error.message}`, 'error');
+      return false;
+    }
+  }
+
+  /**
+   * Get target paths for a source file based on source type
+   */
+  getTargetPaths(sourceFile) {
+    const targets = [];
+    const locales = this.getAvailableLocales();
+
+    // Remove source directory prefix from source file
+    const relativePath = sourceFile.replace(/^[^/]+\//, '');
+
+    // Check if this is a default locale docs file or i18n current file
+    if (sourceFile.startsWith(`${this.docsDir}/`)) {
+      // Source is default locale current docs -> target is versioned docs
+      const versionedPath = `${this.versionsDir}/version-${this.targetVersion}/${relativePath}`;
+      targets.push(versionedPath);
+    }
+
+    // Check if this is an i18n current docs file
+    locales.forEach(locale => {
+      if (locale !== this.defaultLocale) {
+        const i18nCurrentPath = `${this.i18nDir}/${locale}/docusaurus-plugin-content-docs/current/`;
+        if (sourceFile.startsWith(i18nCurrentPath)) {
+          // Source is i18n current -> target is i18n versioned
+          const versionedI18nPath = `${this.i18nDir}/${locale}/docusaurus-plugin-content-docs/version-${this.targetVersion}/${relativePath}`;
+          targets.push(versionedI18nPath);
+        }
+      }
+    });
+
+    return targets;
+  }
+
+  /**
+   * Main sync function
+   */
+  async sync(options = {}) {
+    if (!this.targetVersion) {
+      this.log('Target version is required. Use --version option.', 'error');
+      return;
+    }
+
+    // Validate target version exists
+    const versionedPath = path.join(this.rootDir, this.versionsDir, `version-${this.targetVersion}`);
+    if (!fs.existsSync(versionedPath)) {
+      this.log(`Target version directory not found: ${versionedPath}`, 'error');
+      return;
+    }
+
+    const since = options.since || 'HEAD~1';
+    const modifiedFiles = this.getModifiedFiles(since);
+
+    if (modifiedFiles.length === 0) {
+      this.log('No modified documentation files found');
+      return;
+    }
+
+    this.log(`Found ${modifiedFiles.length} modified files:`);
+    modifiedFiles.forEach(file => this.log(`  - ${file}`));
+    this.log(`Target version: ${this.targetVersion}`);
+
+    const results = {
+      successful: [],
+      failed: [],
+      skipped: []
+    };
+
+    for (const sourceFile of modifiedFiles) {
+      this.log(`Processing: ${sourceFile}`);
+
+      const diff = this.getFileDiff(sourceFile, since);
+      if (!diff.trim()) {
+        this.log(`No meaningful diff found for: ${sourceFile}`);
+        results.skipped.push(sourceFile);
+        continue;
+      }
+
+      const targetPaths = this.getTargetPaths(sourceFile);
+
+      if (targetPaths.length === 0) {
+        this.log(`No target paths found for: ${sourceFile}`);
+        results.skipped.push(sourceFile);
+        continue;
+      }
+
+      for (const targetPath of targetPaths) {
+        const fullTargetPath = path.join(this.rootDir, targetPath);
+
+        if (!fs.existsSync(fullTargetPath)) {
+          this.log(`Target file doesn't exist, skipping: ${targetPath}`);
+          continue;
+        }
+
+        const success = this.applyDiffToFile(sourceFile, targetPath, diff);
+
+        if (success) {
+          results.successful.push(`${sourceFile} → ${targetPath}`);
+        } else {
+          results.failed.push(`${sourceFile} → ${targetPath}`);
+        }
+      }
+    }
+
+    // Report results
+    console.log('\n=== SYNC RESULTS ===');
+    console.log(`Target Version: ${this.targetVersion}`);
+    console.log(`Successful: ${results.successful.length}`);
+    console.log(`Failed: ${results.failed.length}`);
+    console.log(`Skipped: ${results.skipped.length}`);
+
+    if (results.successful.length > 0 && this.verbose) {
+      console.log('\nSuccessful syncs:');
+      results.successful.forEach(item => console.log(`  ✓ ${item}`));
+    }
+
+    if (results.failed.length > 0) {
+      console.log('\nFailed syncs:');
+      results.failed.forEach(item => console.log(`  ✗ ${item}`));
+    }
+  }
+}
+
+// CLI Usage
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const options = {};
+
+  // Parse command line arguments
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--version':
+        options.targetVersion = args[++i];
+        break;
+      case '--dry-run':
+        options.dryRun = true;
+        break;
+      case '--verbose':
+        options.verbose = true;
+        break;
+      case '--since':
+        options.since = args[++i];
+        break;
+      case '--docs-dir':
+        options.docsDir = args[++i];
+        break;
+      case '--versions-dir':
+        options.versionsDir = args[++i];
+        break;
+      case '--i18n-dir':
+        options.i18nDir = args[++i];
+        break;
+      case '--help':
+        console.log(`
+Docusaurus Documentation Backport Script
+
+Usage: node backport-docs.js --version <version> [options]
+
+Required:
+  --version <version>    Target version to sync to (e.g., 2.0, 1.5)
+
+Options:
+  --dry-run             Show what would be changed without making changes
+  --verbose             Show detailed logging
+  --since <ref>         Git reference to compare against (default: HEAD~1)
+  --docs-dir <dir>      Docs directory name (default: docs)
+  --versions-dir <dir>  Versioned docs directory name (default: versioned_docs)
+  --i18n-dir <dir>      i18n directory name (default: i18n)
+  --help                Show this help message
+
+Sync Behavior:
+  - docs/* → versioned_docs/version-<version>/*
+  - i18n/*/docusaurus-plugin-content-docs/current/* → i18n/*/docusaurus-plugin-content-docs/version-<version>/*
+
+Examples:
+  node backport-docs.js --version 2.0 --dry-run --verbose
+  node backport-docs.js --version 1.5 --since HEAD~3
+  node backport-docs.js --version 2.0 --since main
+        `);
+        process.exit(0);
+    }
+  }
+
+  if (!options.targetVersion) {
+    console.error('Error: --version is required');
+    console.error('Use --help for usage information');
+    process.exit(1);
+  }
+
+  const syncer = new DocusaurusVersionSync(options);
+  syncer.sync({ since: options.since }).catch(error => {
+    console.error('Sync failed:', error);
+    process.exit(1);
+  });
+}
+
+module.exports = DocusaurusVersionSync;

--- a/versioned_docs/version-0.14/user-guide/logs/overview.md
+++ b/versioned_docs/version-0.14/user-guide/logs/overview.md
@@ -5,6 +5,9 @@ description: Provides links to various guides on using GreptimeDB's log service,
 
 # Logs
 
+In this chapter, we will walk-through GreptimeDB's features for logs support,
+from basic ingestion/query, to advanced transformation, full-text index topics.
+
 - [Quick Start](./quick-start.md): Provides an introduction on how to quickly get started with GreptimeDB log service.
 - [Pipeline Configuration](./pipeline-config.md): Provides in-depth information on each specific configuration of pipelines in GreptimeDB.
 - [Managing Pipelines](./manage-pipelines.md): Explains how to create and delete pipelines.


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

*Describe the change in this PR*

this patch adds a backport script to copy changes from "current" directory to a particular version.

this script can be called by

```
 npm run backport -- --help

Docusaurus Documentation Backport Script

Usage: node backport-docs.js --version <version> [options]

Options:
  --version <version>    Target version to sync to (e.g., 2.0, 1.5)
  --dry-run             Show what would be changed without making changes
  --verbose             Show detailed logging
  --since <ref>         Git reference to compare against (default: HEAD~1)
  --docs-dir <dir>      Docs directory name (default: docs)
  --versions-dir <dir>  Versioned docs directory name (default: versioned_docs)
  --i18n-dir <dir>      i18n directory name (default: i18n)
  --help                Show this help message

Sync Behavior:
  - docs/* → versioned_docs/version-<version>/*
  - i18n/*/docusaurus-plugin-content-docs/current/* → i18n/*/docusaurus-plugin-content-docs/version-<version>/*

Examples:
  node backport-docs.js --version 2.0 --dry-run --verbose
  node backport-docs.js --version 1.5 --since HEAD~3
  node backport-docs.js --version 2.0 --since main
```

By default, it ports last commit to latest version.

## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
