### PR TITLE
fix:create grammar

### DIFF
--- a/docs/reference/sql/create.md
+++ b/docs/reference/sql/create.md
@@ -63,13 +63,14 @@ CREATE TABLE [IF NOT EXISTS] [db.]table_name
     ...
     [TIME INDEX (column)],
     [PRIMARY KEY(column1, column2, ...)],
-) ENGINE = engine WITH([TTL | storage | ...] = expr, ...)
+)
 [
   PARTITION ON COLUMNS(column1, column2, ...) (
     <PARTITION EXPR>,
     ...
   )
 ]
+ENGINE = engine WITH([TTL | storage | ...] = expr, ...)
 ```
 
 The table schema is specified by the brackets before the `ENGINE`. The table schema is a list of column definitions and table constraints.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/create.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/create.md
@@ -64,13 +64,14 @@ CREATE TABLE [IF NOT EXISTS] [db.]table_name
     ...
     [TIME INDEX (column)],
     [PRIMARY KEY(column1, column2, ...)],
-) ENGINE = engine WITH([TTL | storage | ...] = expr, ...)
+)
 [
   PARTITION ON COLUMNS(column1, column2, ...) (
     <PARTITION EXPR>,
     ...
   )
 ]
+ENGINE = engine WITH([TTL | storage | ...] = expr, ...)
 ```
 
 表 schema 由 `ENGINE` 之前的括号指定，表 schema 是列的定义和表的约束。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.14/reference/sql/create.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.14/reference/sql/create.md
@@ -64,13 +64,14 @@ CREATE TABLE [IF NOT EXISTS] [db.]table_name
     ...
     [TIME INDEX (column)],
     [PRIMARY KEY(column1, column2, ...)],
-) ENGINE = engine WITH([TTL | storage | ...] = expr, ...)
+)
 [
   PARTITION ON COLUMNS(column1, column2, ...) (
     <PARTITION EXPR>,
     ...
   )
 ]
+ENGINE = engine WITH([TTL | storage | ...] = expr, ...)
 ```
 
 表 schema 由 `ENGINE` 之前的括号指定，表 schema 是列的定义和表的约束。

--- a/versioned_docs/version-0.14/reference/sql/create.md
+++ b/versioned_docs/version-0.14/reference/sql/create.md
@@ -63,13 +63,14 @@ CREATE TABLE [IF NOT EXISTS] [db.]table_name
     ...
     [TIME INDEX (column)],
     [PRIMARY KEY(column1, column2, ...)],
-) ENGINE = engine WITH([TTL | storage | ...] = expr, ...)
+)
 [
   PARTITION ON COLUMNS(column1, column2, ...) (
     <PARTITION EXPR>,
     ...
   )
 ]
+ENGINE = engine WITH([TTL | storage | ...] = expr, ...)
 ```
 
 The table schema is specified by the brackets before the `ENGINE`. The table schema is a list of column definitions and table constraints.


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

Fixed the create grammar, which now set the `engine` and `with` table options at last.


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
