### PR TITLE
docs: remove to_unixtime references

### DIFF
--- a/docs/reference/sql/functions/overview.md
+++ b/docs/reference/sql/functions/overview.md
@@ -110,7 +110,6 @@ GreptimeDB provides:
 * [date_add](#data_add)
 * [date_sub](#data_sub)
 * [date_format](#date_format)
-* [to_unixtime](#to_unixtime)
 * [timezone](#timezone)
 
 #### date_add
@@ -162,34 +161,6 @@ SELECT date_format('2023-12-06 07:39:46.222'::TIMESTAMP, '%Y-%m-%d %H:%M:%S:%3f'
 ```
 
 Supported specifiers refer to the [chrono::format::strftime](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) module.
-
-#### to_unixtime
-
-* `to_unixtime(expression)` to convert the expression into the Unix timestamp in seconds. The argument can be integers (Unix timestamp in milliseconds), Timestamp, Date, DateTime, or String. If the argument is the string type, the function will first try to convert it into a DateTime, Timestamp, or Date.
-
-```sql
-select to_unixtime('2023-03-01T06:35:02Z');
-```
-
-```
-+-------------------------------------------+
-| to_unixtime(Utf8("2023-03-01T06:35:02Z")) |
-+-------------------------------------------+
-|                                1677652502 |
-+-------------------------------------------+
-```
-
-```sql
-select to_unixtime('2023-03-01'::date);
-```
-
-```
-+---------------------------------+
-| to_unixtime(Utf8("2023-03-01")) |
-+---------------------------------+
-|                      1677628800 |
-+---------------------------------+
-```
 
 #### timezone
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/functions/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/functions/overview.md
@@ -104,7 +104,6 @@ DataFusion [时间和日期函数](./df-functions.md#time-and-date-functions)。
 * [date_add](#data_add)
 * [date_sub](#data_sub)
 * [date_format](#date_format)
-* [to_unixtime](#to_unixtime)
 * [timezone](#timezone)
 
 #### date_add
@@ -158,34 +157,6 @@ SELECT date_format('2023-12-06 07:39:46.222'::TIMESTAMP, '%Y-%m-%d %H:%M:%S:%3f'
 ```
 
 支持的格式化符号请参阅 [chrono::format::strftime](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) 模块。
-
-#### to_unixtime
-
-* `to_unixtime(expression)` 将表达式转换为 Unix 时间戳（秒）。参数可以是整数（毫秒 Unix 时间戳）、Timestamp、Date、DateTime 或字符串类型。如果参数是字符串类型，函数将首先尝试将其转换为 DateTime、Timestamp 或 Date。
-
-```sql
-select to_unixtime('2023-03-01T06:35:02Z');
-```
-
-```
-+-------------------------------------------+
-| to_unixtime(Utf8("2023-03-01T06:35:02Z")) |
-+-------------------------------------------+
-|                                1677652502 |
-+-------------------------------------------+
-```
-
-```sql
-select to_unixtime('2023-03-01'::date);
-```
-
-```
-+---------------------------------+
-| to_unixtime(Utf8("2023-03-01")) |
-+---------------------------------+
-|                      1677628800 |
-+---------------------------------+
-```
 
 #### timezone
 


### PR DESCRIPTION
## What's Changed in this PR

DataFusion already supports `to_unixtime` function, so remove the custom to_unixtime doc https://github.com/GreptimeTeam/greptimedb/pull/6271

## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
