### PR TITLE
fix: docs about the database parameter in HTTP request

### DIFF
--- a/docs/user-guide/protocols/http.md
+++ b/docs/user-guide/protocols/http.md
@@ -527,17 +527,16 @@ For example:
 curl -X GET \
   -H 'Authorization: Basic {{authorization if exists}}' \
   -G \
-  --data-urlencode 'db=public' \
   --data-urlencode 'query=avg(system_metrics{idc="idc_a"})' \
   --data-urlencode 'start=1667446797' \
   --data-urlencode 'end=1667446799' \
   --data-urlencode 'step=1s' \
-  http://localhost:4000/v1/promql
+  'http://localhost:4000/v1/promql?db=public'
 ```
 
 The input parameters are similar to the [`range_query`](https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries) in Prometheus' HTTP API:
 
-- `db=<database name>`: Required when using GreptimeDB with authorization, otherwise can be omitted if you are using the default `public` database.
+- `db=<database name>`: Required when using GreptimeDB with authorization, otherwise can be omitted if you are using the default `public` database. Note this parameter should bet set in the query param, or using a dedicated header `--header 'x-greptime-db-name: <database name>'`.
 - `query=<string>`: Required. Prometheus expression query string.
 - `start=<rfc3339 | unix_timestamp>`: Required. The start timestamp, which is inclusive. It is used to set the range of time in `TIME INDEX` column.
 - `end=<rfc3339 | unix_timestamp>`: Required. The end timestamp, which is inclusive. It is used to set the range of time in `TIME INDEX` column.

--- a/docs/user-guide/query-data/promql.md
+++ b/docs/user-guide/query-data/promql.md
@@ -40,10 +40,10 @@ curl -X POST \
     --data-urlencode 'start=2024-11-24T00:00:00Z' \
     --data-urlencode 'end=2024-11-25T00:00:00Z' \
     --data-urlencode 'step=1h' \
-    --data-urlencode 'db=public' \
-    http://localhost:4000/v1/prometheus/api/v1/query_range
+    'http://localhost:4000/v1/prometheus/api/v1/query_range?db=public'
 ```
 If authentication is enabled in GreptimeDB, the authentication header is required. Refer to the [authentication documentation](/user-guide/protocols/http.md#authentication) for more details.
+You can ignore the `db` parameter if you're using the `public` database; otherwise you have to either set it in the query param like above, or set it using `--header 'x-greptime-db-name: <database name>'`.
 
 The query string parameters for the API are identical to those of the original [Prometheus API](https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries), with the exception of the additional `db` parameter, which specifies the GreptimeDB database name.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/protocols/http.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/protocols/http.md
@@ -518,12 +518,12 @@ curl -X GET \
   --data-urlencode 'start=1667446797' \
   --data-urlencode 'end=1667446799' \
   --data-urlencode 'step=1s' \
-  http://localhost:4000/v1/promql
+  'http://localhost:4000/v1/promql?db=public'
 ```
 
 接口中的参数和 Prometheus' HTTP API 的 [`range_query`](https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries) 接口相似：
 
-- `db=<database>`：在使用 GreptimeDB 进行鉴权操作时必填。
+- `db=<database>`：在使用 GreptimeDB 进行鉴权操作时必填，如果使用的是 `public` 数据库则可以忽略该参数。注意这个参数需要被设置在 query param 中，或者通过 `--header 'x-greptime-db-name: <database name>'` 设置在 HTTP 请求头中。
 - `query=<string>`：必填。Prometheus 表达式查询字符串。
 - `start=<rfc3339 | unix_timestamp>`：必填。开始时间戳，包含在内。它用于设置 `TIME INDEX` 列中的时间范围。
 - `end=<rfc3339 | unix_timestamp>`：必填。结束时间戳，包含在内。它用于设置 `TIME INDEX` 列中的时间范围。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/query-data/promql.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/query-data/promql.md
@@ -39,12 +39,12 @@ curl -X POST \
     --data-urlencode 'start=2024-11-24T00:00:00Z' \
     --data-urlencode 'end=2024-11-25T00:00:00Z' \
     --data-urlencode 'step=1h' \
-    --data-urlencode 'db=public' \
-    http://localhost:4000/v1/prometheus/api/v1/query_range
+    'http://localhost:4000/v1/prometheus/api/v1/query_range?db=public'
 ```
 
 如果你使用启用了身份验证的 GreptimeDB，则需要 Authorization header，请参阅[鉴权](/user-guide/protocols/http.md#鉴权)。
-该 API 的查询字符串参数与原始 [Prometheus API](https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries) 的查询字符串参数相同，但额外的 `db` 参数除外，该参数指定了 GreptimeDB 数据库名称。
+该 API 的查询字符串参数与原始 [Prometheus API](https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries) 的查询字符串参数相同。
+如果你用的是 GreptimeDB 中的 `public` 数据库，那么你可以忽略 `db` 这个参数；否则的话，你需要手动在 query param 中指定它，或者使用 `--header 'x-greptime-db-name: <database name>'` 在 HTTP 请求头中进行指定。
 
 输出格式与 Prometheus API 完全兼容：
 


### PR DESCRIPTION
## What's Changed in this PR

Fix the wrong docs about the db HTTP parameter, which cannot be set using `--data-urlencode`.
Note: After the change is reviewed, backport to all existing versions.


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
