### PR TITLE
ci: make sure main branch is fetched in backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -52,6 +52,11 @@ jobs:
           ref: ${{ steps.pr_info.outputs.head_ref }}
           fetch-depth: 0
 
+      - name: Fetch main branch
+        run: |
+          git fetch origin main:main
+          git branch -a
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## What's Changed in this PR

this patch resolves an issue that github action doesn't have full history of git repo for compare and backport.

## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
