### PR TITLE
refactor: move architecture to user guide

### DIFF
--- a/docs/contributor-guide/overview.md
+++ b/docs/contributor-guide/overview.md
@@ -11,59 +11,7 @@ DeepWiki provides a detailed and clear explanation of GreptimeDB's architecture 
 
 ## Architecture
 
-`GreptimeDB` consists of the following key components:
-
-- `Frontend` that exposes read and write service in various protocols, forwards requests to
-  `Datanode`.
-- `Datanode` is responsible for storing data to persistent storage such as local disk or object storage in the cloud such as AWS S3, Azure Blob Storage etc.
-- `Metasrv` server that coordinates the operations between the `Frontend` and `Datanode`.
-
-![Architecture](/architecture-3.png)
-
-## Concepts
-
-To better understand `GreptimeDB`, a few concepts need to be introduced:
-
-- A `table` is where user data is stored in `GreptimeDB`. A `table` has a schema and a totally
-  ordered primary key. A `table` is split into segments called `region` by its partition key.
-- A `region` is a contiguous segment of a table, and also could be regarded as a partition in some
-  relational databases. A `region` could be replicated on multiple `datanode` and only one of these
-  replicas is writable and can serve write requests, while any replica can serve read requests.
-- A `datanode` stores and serves `region` to `frontends`. One `datanode` can serve multiple `regions`
-  and one `region` can be served by multiple `datanodes`.
-- The `metasrv` stores the metadata of the cluster, such as tables, `datanodes`, `regions` of each
-  table, etc. It also coordinates `frontends` and `datanodes`.
-- The `frontend` has a catalog implementation, which fetches the metadata from
-  `metasrv`, tells which `region` of a `table` is served by which `datanode`.
-- A `frontend` is a stateless service that serves requests from client. It acts as a proxy to
-  forward read and write requests to corresponding `datanode`, according to the mapping from catalog.
-- Table engines (also called storage engines) determine how data is stored, managed, and processed within the database. Each engine offers different features, performance characteristics, and trade-offs. See [Table Engines](/reference/about-greptimedb-engines.md) for more information.
-- A timeseries of a `table` is identified by its primary key. Each `table` must have a timestamp
-  column, as `GreptimeDB` is a timeseries database. Data in `table` will be sorted by its primary key
-  and
-  timestamp, but the actual order is implementation specific and may change in the future.
-
-## How it works
-
-![Interactions between components](/how-it-works.png)
-
-Before diving into each component, let's take a high level view of how the database works.
-
-- Users can interact with the database via various protocols, such as ingesting data using
-  `InfluxDB line protocol`, then exploring the data using SQL or PromQL. The `frontend` is the
-  component users or clients connect to and operate, thus hide `datanode` and `metasrv` behind it.
-- Assumes a user uses the HTTP API to insert data into the database, by sending a HTTP request to a
-  `frontend` instance. When the `frontend` receives the request, it then parses the request body using
-  corresponding protocol parser, and finds the table to write to from a catalog manager based on
-  `metasrv`.
-- The `frontend` relies on a push-pull strategy to cache metadata from `metasrv`, thus it knows which
-  `datanode`, or more precisely, the `region` a request should be sent to. A request may be split and
-  sent to multiple `region`s, if its contents need to be stored in different `region`s.
-- When `datanode` receives the request, it writes the data to the `region`, and then sends response
-  back to the `frontend`. Writing to the `region` will then write to the underlying storage engine,
-  which will eventually put the data to persistent device.
-- Once `frontend` has received all responses from the target `datanode`s, it then sends the result
-  back to the user.
+For the architecture and components of GreptimeDB, please see the [Architecture](/user-guide/deployments-administration/architecture.md) document in the user guide.
 
 For more details on each component, see the following guides:
 
@@ -71,6 +19,7 @@ For more details on each component, see the following guides:
 - [datanode][2]
 - [metasrv][3]
 
-[1]: ./frontend/overview.md
-[2]: ./datanode/overview.md
-[3]: ./metasrv/overview.md
+[1]: /contributor-guide/frontend/overview.md
+[2]: /contributor-guide/datanode/overview.md
+[3]: /contributor-guide/metasrv/overview.md
+

--- a/docs/user-guide/deployments-administration/architecture.md
+++ b/docs/user-guide/deployments-administration/architecture.md
@@ -1,0 +1,78 @@
+---
+keywords: [architecture, key components, user requests, data processing, database components]
+description: Overview of GreptimeDB's architecture, key components, and how they interact to process user requests.
+---
+
+# Architecture
+
+Before diving into the deployment and administration of GreptimeDB,
+it's important to understand its architecture and key components.
+
+## Components
+
+GreptimeDB consists of three key components: `MetaSrv`, `Frontend`, and `Datanode`.
+
+![Architecture](/architecture-3.png)
+
+### MetaSrv
+
+MetaSrv coordinates operations between Frontend and Datanode components,
+stores cluster metadata including tables, datanodes, and region mappings,
+and provides metadata services to Frontend instances.
+
+### Frontend
+
+Frontend is a stateless service that serves client requests via multiple protocols,
+acting as a proxy that forwards read/write requests to appropriate Datanodes.
+It maintains a catalog that maps tables to regions and their corresponding Datanodes,
+caching metadata from MetaSrv for efficient request routing.
+
+### Datanode
+
+Datanode is responsible for persistent data storage to local disk
+or cloud storage services like AWS S3 and Azure Blob Storage,
+serves multiple regions to Frontend instances,
+and handles all data storage and retrieval operations within the distributed system.
+
+### Key Concepts
+
+- **Region**: A contiguous segment of a table, similar to a partition in relational databases.
+  Regions can be replicated across multiple Datanodes,
+  with one writable replica for writes and any replica serving reads.
+- **Table Engines**: Also called storage engines.
+  Determine how data is stored, managed, and processed.
+  Different engines offer varying performance characteristics and trade-offs.
+  See [Table Engines](/reference/about-greptimedb-engines.md) for details.
+
+
+## How it works
+
+![Interactions between components](/how-it-works.png)
+
+- You can interact with the database via various protocols, such as ingesting data using
+  InfluxDB line protocol, then exploring the data using SQL or PromQL. The Frontend is the
+  component that clients connect to and operate, thus hide Datanode and Metasrv behind it.
+- Assumes a user uses the HTTP API to insert data into the database, by sending a HTTP request to a
+  Frontend instance. When the Frontend receives the request, it then parses the request body using
+  corresponding protocol parser, and finds the table to write to from a catalog manager based on
+  Metasrv.
+- The Frontend relies on a push-pull strategy to cache metadata from Metasrv, thus it knows which
+  Datanode, or more precisely, the Region a request should be sent to. A request may be split and
+  sent to multiple Regions, if its contents need to be stored in different Regions.
+- When Datanode receives the request, it writes the data to the Region, and then sends response
+  back to the Frontend. Writing to the Region will then write to the underlying storage engine,
+  which will eventually put the data to persistent device.
+- Once Frontend has received all responses from the target Datanodes, it then sends the result
+  back to the user.
+
+For more details on each component, see the contributor guides:
+
+- [frontend][1]
+- [datanode][2]
+- [metasrv][3]
+
+[1]: /contributor-guide/frontend/overview.md
+[2]: /contributor-guide/datanode/overview.md
+[3]: /contributor-guide/metasrv/overview.md
+
+

--- a/i18n/zh/docusaurus-plugin-content-docs/current/contributor-guide/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/contributor-guide/overview.md
@@ -11,38 +11,7 @@ DeepWiki 对 GreptimeDB 的架构和实现进行了详细且清晰的描述，�
 
 ## 架构
 
-`GreptimeDB` 由以下关键组件组成：
-
-- `Frontend`：通过多种协议提供读写服务，并将请求转发到 `Datanode`。
-- `Datanode`：负责数据的持久化存储，例如存储到本地磁盘、S3 和 Azure Blob Storage 等。
-- `Metasrv` 元数据存储和分布式调度：协调 `Frontend` 和 `Datanode` 之间的操作。
-
-![Architecture](/architecture-3.png)
-
-## 概念
-
-为了更好地理解 `GreptimeDB`，需要介绍一些概念：
-
-- `table` 是 `GreptimeDB` 中存储用户数据的地方，有表结构和有序的主键。`table` 通过其分区键被分割成称为 `region`。
-- `region` 是表中的一个连续段，在某些关系型数据库中被视为分区。`region` 可以在多个 `datanode` 上复制，其中任何一个副本都可以支持读请求，但只有一个副本支持写请求。
-- `datanode` 存储并为 `frontend` 提供 `region` 服务。一个 `datanode` 可以服务多个 `region`，一个 `region` 可以由多个 `datanode` 服务。
-- `metasrv` 服务器存储集群的元数据，例如表、`datanode`、每个表的 `region` 等。它还协调 `frontend` 和 `datanode`。
-- `frontend` 有一个 catalog 实现，它从 `metasrv` 中获取元数据，告诉相应的组件哪个 `table` 的 `region` 由哪个 `datanode` 提供服务。
-- `frontend` 是一个无状态服务，用于接收客户端的请求。它作为 proxy 根据 catalog 中的信息将读取和写入请求转发到相应的 `datanode`。
-- 表引擎（也称为存储引擎）决定了数据在数据库中的存储、管理和处理方式。每种引擎提供不同的功能特性、性能表现和权衡取舍。有关更多信息，请参阅[表引擎](/reference/about-greptimedb-engines.md)。
-- 一个 `table` 的时间线 (time-series) 由其主键标识。因为 `GreptimeDB` 是一个时间序列数据库，所以每个 `table` 必须有一个时间戳列。`table` 中的数据将按其主键和时间戳排序，但顺序的实际实现方式比较特殊，可能会在将来发生变化。
-
-## 工作原理
-
-![Interactions between components](/how-it-works.png)
-
-在深入了解每个组件之前，让我们先从高层次上了解一下 GreptimeDB 的工作原理。
-
-- 用户可以通过各种协议与数据库交互，例如使用 `InfluxDB line Protocol` 插入数据，然后使用 SQL 或 PromQL 查询数据。`frontend` 是用户或客户端连接和操作数据库的组件，因此在其后面隐藏了 `datanode` 和 `metasrv`。
-- 假设用户向 `frontend` 实例发送了 HTTP 请求来插入数据。当 `frontend` 接收到请求时，它会使用相应的协议解析器解析请求正文，并从 `metasrv` 的 catalog 中找到要写入的表。
-- `frontend` 依靠推拉结合的策略缓存来自 `metasrv` 的元数据，因此它知道应将请求发送到哪个 `datanode`，或者更准确地说，应该发送到哪个 `region`。如果请求的内容需要存储在不同的 `region` 中，则请求可能会被拆分并发送到多个 `region`。
-- 当 `datanode` 接收到请求时，它将数据写入 `region` 中，然后将响应发送回 `frontend`。写入 `region` 也意味着将数据写入底层的存储引擎中，该引擎最终将数据放置在持久化存储中。
-- 当 `frontend` 从目标 `datanode`s 接收到所有响应时，就会将结果返回给用户。
+有关 GreptimeDB 的架构和组件，请参阅用户指南中的 [架构](/user-guide/deployments-administration/architecture.md) 文档。
 
 有关每个组件的更多详细信息，请参阅以下指南：
 
@@ -50,6 +19,6 @@ DeepWiki 对 GreptimeDB 的架构和实现进行了详细且清晰的描述，�
 - [datanode][2]
 - [metasrv][3]
 
-[1]: frontend/overview.md
-[2]: datanode/overview.md
-[3]: metasrv/overview.md
+[1]: /contributor-guide/frontend/overview.md
+[2]: /contributor-guide/datanode/overview.md
+[3]: /contributor-guide/metasrv/overview.md

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/architecture.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/architecture.md
@@ -1,0 +1,65 @@
+---
+keywords: [架构, 关键概念, 数据处理, 组件交互, 数据库]
+description: 介绍 GreptimeDB 的架构、关键概念和工作原理，包括各组件的交互方式和数据处理流程。
+---
+
+# 架构
+
+在进行 GreptimeDB 的部署和管理之前，有必要了解其架构和关键组件。
+
+## 组件
+
+GreptimeDB 由三个关键组件组成 Metasrv、Frontend 和 Datanode。
+
+![Architecture](/architecture-3.png)
+
+### Metasrv（元数据服务器）
+
+负责元数据存储和分布式调度，
+协调 Frontend 和 Datanode 之间的操作。
+Metasrv 存储集群的元数据信息，
+包括表结构、Datanode 分布、每个表的 Region 分配等。
+
+### Frontend（前端服务）
+
+作为无状态的代理服务，通过多种协议（如 SQL、PromQL、InfluxDB Line Protocol）为客户端提供读写服务。
+Frontend 从 Metasrv 获取元数据并缓存在 catalog 中，
+根据这些信息将请求转发到相应的 Datanode。
+
+### Datanode（数据节点）
+
+负责数据的持久化存储和管理，支持多种存储后端，
+如本地磁盘、S3、Azure Blob Storage 等。
+每个 Datanode 可以服务多个 Region，并通过表引擎（存储引擎）决定数据的存储、管理和处理方式。
+
+### 关键概念
+
+- **Region（数据分区）**：表中的一个连续数据段，
+  类似于传统关系型数据库中的分区概念。
+  Region 可以在多个 Datanode 上进行复制以提供高可用性，
+  其中任意副本都支持读请求，
+  但只有一个主副本支持写请求。
+- **表引擎（Storage Engine）**：也被称为存储引擎。
+  决定数据在数据库中的存储、管理和处理方式的核心组件。
+  不同的引擎提供不同的功能特性、性能表现和权衡取舍。
+  有关更多信息，请参阅[表引擎](/reference/about-greptimedb-engines.md)。
+
+## 组件交互
+
+![Interactions between components](/how-it-works.png)
+
+- 你可以通过各种协议与数据库交互，例如使用 InfluxDB line Protocol 插入数据，然后使用 SQL 或 PromQL 查询数据。Frontend 是客户端连接和操作数据库的组件，因此在其后面隐藏了 Datanode 和 Metasrv。
+- 假设客户端向 Frontend 实例发送了 HTTP 请求来插入数据。当 Frontend 接收到请求时，它会使用相应的协议解析器解析请求正文，并从 Metasrv 的 catalog 中找到要写入的表。
+- Frontend 依靠推拉结合的策略缓存来自 Metasrv 的元数据，因此它知道应将请求发送到哪个 Datanode，或者更准确地说，应该发送到哪个 Region。如果请求的内容需要存储在不同的 Region 中，则请求可能会被拆分并发送到多个 Region。
+- 当 Datanode 接收到请求时，它将数据写入 Region 中，然后将响应发送回 Frontend。写入 Region 也意味着将数据写入底层的存储引擎中，该引擎最终将数据放置在持久化存储中。
+- 当 Frontend 从目标 Datanode 接收到所有响应时，就会将结果返回给用户。
+
+有关每个组件的更多详细信息，请参阅贡献者指南：
+
+- [frontend][1]
+- [datanode][2]
+- [metasrv][3]
+
+[1]: /contributor-guide/frontend/overview.md
+[2]: /contributor-guide/datanode/overview.md
+[3]: /contributor-guide/metasrv/overview.md

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -269,6 +269,7 @@ const sidebars: SidebarsConfig = {
               id: 'user-guide/deployments-administration/overview',
               label: 'Overview',
             },
+            'user-guide/deployments-administration/architecture',
             {
               type: 'category',
               label: 'Kubernetes',


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

as title.
it is important to let developers know the architecture of GreptimeDB before deployment and administration.


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
