### PR TITLE
docs: grpc tls options

### DIFF
--- a/docs/user-guide/deployments-administration/configuration.md
+++ b/docs/user-guide/deployments-administration/configuration.md
@@ -191,16 +191,16 @@ The following table describes the options in detail:
 |            | addr                 | String  | Server address, "127.0.0.1:4003" by default                                                                                                                                                                                                                                                                                                                                                |
 |            | runtime_size         | Integer | The number of server worker threads, 2 by default                                                                                                                                                                                                                                                                                                                                          |
 
-For MySQL and Postgres interface, TLS can be configured to enable transport
+For MySQL, Postgres and gRPC interface, TLS can be configured to enable transport
 layer security.
 
-| Option                        | Key         | Type    | Description                                                   |
-| ----------------------------- | ----------- | ------- | ------------------------------------------------------------- |
-| `mysql.tls` or `postgres.tls` |             |         | TLS configuration for MySQL and Postgres                      |
-|                               | `mode`      | String  | TLS mode, options are `disable`, `prefer` and `require`       |
-|                               | `cert_path` | String  | File path for TLS certificate                                 |
-|                               | `key_path`  | String  | File path for TLS private key                                 |
-|                               | `watch`     | Boolean | Watch file system changes and reload certificate and key file |
+| Option                                    | Key         | Type    | Description                                                   |
+| ------------------------------------------| ----------- | ------- | ------------------------------------------------------------- |
+| `mysql.tls`, `postgres.tls` or `grpc.tls` |             |         | TLS configuration for MySQL and Postgres                      |
+|                                           | `mode`      | String  | TLS mode, options are `disable`, `prefer` and `require`       |
+|                                           | `cert_path` | String  | File path for TLS certificate                                 |
+|                                           | `key_path`  | String  | File path for TLS private key                                 |
+|                                           | `watch`     | Boolean | Watch file system changes and reload certificate and key file |
 
 ### Query options
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/configuration.md
@@ -179,15 +179,15 @@ enable = true
 |            | addr               | 字符串 | 服务器地址，默认为 "127.0.0.1:4003"                          |
 |            | runtime_size       | 整数   | 服务器工作线程数量，默认为 2                                 |
 
-对 MySQL 和 Postgres 接口，我们支持 TLS 配置
+对 MySQL，Postgres 和 gRPC 接口，我们支持 TLS 配置
 
-| Option                        | Key         | Type    | Description                                      |
-|-------------------------------|-------------|---------|--------------------------------------------------|
-| `mysql.tls` 或 `postgres.tls` |             |         | MySQL 或 Postgres 的 TLS 配置                    |
-|                               | `mode`      | String  | TLS 模式，支持 `disable`, `prefer` and `require` |
-|                               | `cert_path` | String  | TLS 证书文件路径                                 |
-|                               | `key_path`  | String  | TLS 私钥文件路径                                 |
-|                               | `watch`     | Boolean | 监控文件变化，自动重新加载证书或私钥             |
+| Option                                   | Key         | Type    | Description                                      |
+|------------------------------------------|-------------|---------|--------------------------------------------------|
+| `mysql.tls`，`postgres.tls` 或 `grpc.tls` |             |         | MySQL 或 Postgres 的 TLS 配置                    |
+|                                          | `mode`      | String  | TLS 模式，支持 `disable`, `prefer` and `require` |
+|                                          | `cert_path` | String  | TLS 证书文件路径                                 |
+|                                          | `key_path`  | String  | TLS 私钥文件路径                                 |
+|                                          | `watch`     | Boolean | 监控文件变化，自动重新加载证书或私钥             |
 
 ### 查询选项
 


### PR DESCRIPTION


## What's Changed in this PR

 - **Added gRPC TLS Configuration**: Updated TLS configuration options to include gRPC interface in both English and Chinese documentation files.
   - Files affected: `docs/user-guide/deployments-administration/configuration.md`, `i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/configuration.md`

## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
