### PR TITLE
chore: de-duplication between enterprise and OSS deployments

### DIFF
--- a/docs/enterprise/deployments/deploy-on-kubernetes/installation.md
+++ b/docs/enterprise/deployments/deploy-on-kubernetes/installation.md
@@ -1,8 +1,52 @@
 ---
-keywords: [Installation]
-description: Deploy GreptimeDB on Kubernetes
+keywords: [Kubernetes deployment, GreptimeDB Enterprise, install GreptimeDB, start GreptimeDB, private docker registry, helm chart]
+description: Steps to install GreptimeDB Enterprise on Kubernetes, including obtaining images and starting GreptimeDB.
 ---
 
-# Installation
+# Deploy GreptimeDB Cluster
 
-TODO
+GreptimeDB Enterprise is released as docker images.
+We provide each customer with a separate private docker registry hosted on Cloud,
+which you can pull directly using the docker pull command or configure in helm charts.
+
+## Get GreptimeDB Enterprise
+
+Upon receiving GreptimeDB Enterprise,
+you will be provided with the docker registry address, username, and password via email.
+Please store this information securely!
+
+Each release of GreptimeDB Enterprise has a unique `tag` identifier.
+With this `tag`, plus the registry address `registry`, username `username`, and password `password` provided by our staff,
+you can pull the GreptimeDB Enterprise image:
+
+- Login to docker registry: `docker login --username=<username> --password=<password> <registry>`
+- Pull docker image: `docker pull <registry>:<tag>`
+
+Then configure GreptimeDB Enterprise in the helm chart:
+
+First, create a pull secret for the image registry in k8s
+(for detailed methods and instructions, please refer to the [k8s official documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)).
+
+```bash
+kubectl create secret docker-registry regcred --docker-server=<registry> --docker-username=<username> --docker-password=<password>
+```
+
+For example:
+
+![k8s_pull_secret](/k8s-pull-secret.jpg)
+
+Then add this secret to the helm chart's `values.yaml`:
+
+```yaml
+image:
+  registry: <registry>
+  repository: <repository>
+  tag: <tag>
+  pullSecrets: [ regcred ]
+```
+
+Where `<repository>` is the part after `:` in `<registry>`; `<tag>` is the unique identifier for the GreptimeDB Enterprise image.
+
+## Installation and Startup
+
+Please refer to the [Deploy GreptimeDB Cluster on Kubernetes](/user-guide/deployments-administration/deploy-on-kubernetes/deploy-greptimedb-cluster.md) documentation.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/deployments/deploy-on-kubernetes/installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/deployments/deploy-on-kubernetes/installation.md
@@ -3,7 +3,7 @@ keywords: [Kubernetes 部署, GreptimeDB 企业版, 安装 GreptimeDB, 启动 Gr
 description: 在 Kubernetes 上安装 GreptimeDB 企业版的步骤，包括获取镜像、安装 GreptimeDB Operator 和 etcd 集群、配置 values.yaml 和启动 GreptimeDB。
 ---
 
-# 安装
+# 部署 GreptimeDB 集群
 
 GreptimeDB 企业版以 docker 镜像发布。我们为每位国内的客户提供了一个单独的、托管在阿里云上的私有 docker 仓库，你可以使用 docker pull 命令直接拉取，或在 helm chart 中配置。
 
@@ -40,138 +40,7 @@ image:
 
 其中 `<repository>` 是 `<registry>` 中 `：` 之后的部分；`<tag>` 是 GreptimeDB 企业版镜像的单独标识。
 
-## 启动
+## 安装及启动
 
-我们建议你使用 helm chart 启动 GreptimeDB 企业版。
-
-### 添加 Greptime Helm 仓库
-
-:::tip NOTE
-如你有网络访问问题，可跳过本步骤并直接参考下一步中使用阿里云 OCI 镜像仓库的方式。采用阿里云 OCI 镜像仓库的方式无需手动添加 Helm 仓库。
-:::
-
-我们提供了 GreptimeDB Operator 和 GreptimeDB 集群的[官方 Helm 仓库](https://github.com/GreptimeTeam/helm-charts)。你可以通过运行以下命令来添加仓库：
-
-```bash
-helm repo add greptime https://greptimeteam.github.io/helm-charts/
-helm repo update
-```
-
-### 安装 GreptimeDB Operator
-
-[GreptimeDB Operator](https://github.com/GrepTimeTeam/greptimedb-operator) 是一个用于管理 GreptimeDB 集群生命周期的 Kubernetes operator。
-让我们在 greptimedb-admin 命名空间中安装最新版本的 GreptimeDB Operator：
-
-```shell
-helm install greptimedb-operator greptime/greptimedb-operator -n greptimedb-admin --create-namespace
-```
-
-:::tip NOTE
-如你有网络访问问题，可直接使用阿里云 OCI 镜像仓库的方式安装 GreptimeDB Operator：
-```bash
-helm install greptimedb-operator \
-  oci://greptime-registry.cn-hangzhou.cr.aliyuncs.com/charts/greptimedb-operator \
-  --set image.registry=greptime-registry.cn-hangzhou.cr.aliyuncs.com \
-  -n greptimedb-admin \
-  --create-namespace
-```
-此时我们也将镜像仓库设置为了 Greptime 官方的阿里云镜像仓库。
-:::
-
-### 验证 GreptimeDB Operator 的安装
-
-检查 GreptimeDB Operator 的状态：
-
-```bash
-kubectl get pods -n greptimedb-admin -l app.kubernetes.io/instance=greptimedb-operator
-```
-
-若有类似以下的预期输出，表示 GreptimeDB Operator 安装成功：
-
-```bash
-NAME                                   READY   STATUS    RESTARTS   AGE
-greptimedb-operator-68d684c6cf-qr4q4   1/1     Running   0          4m8s
-```
-
-可参考 [GreptimeDB Operator 的管理文档](/user-guide/deployments-administration/deploy-on-kubernetes/greptimedb-operator-management.md) 来了解 GreptimeDB Operator 的更多功能。
-
-### 安装 etcd 集群
-
-GreptimeDB 集群需要一个 etcd 集群来存储元数据。让我们使用 Bitnami 的 [etcd Helm chart](https://github.com/bitnami/charts/tree/main/bitnami/etcd) 来安装一个 etcd 集群：
-
-```bash
-helm install etcd \
-  oci://registry-1.docker.io/bitnamicharts/etcd \
-  --version 10.2.12 \
-  --set replicaCount=3 \
-  --set auth.rbac.create=false \
-  --set auth.rbac.token.enabled=false \
-  --create-namespace \
-  -n etcd-cluster
-```
-
-:::tip NOTE
-如你有网络访问问题，可直接使用阿里云 OCI 镜像仓库的方式安装 etcd 集群：
-
-```bash
-helm install etcd \
-  oci://greptime-registry.cn-hangzhou.cr.aliyuncs.com/charts/etcd \
-  --set image.registry=greptime-registry.cn-hangzhou.cr.aliyuncs.com \
-  --set image.tag=3.5.12 \
-  --set replicaCount=3 \
-  --set auth.rbac.create=false \
-  --set auth.rbac.token.enabled=false \
-  --create-namespace \
-  -n etcd-cluster
-```
-
-:::
-
-### 配置 `values.yaml`
-
-:::tip NOTE
-chart 版本之间的配置结构已发生变化:
-
-- 旧版本: `meta.etcdEndpoints`
-- 新版本: `meta.backendStorage.etcd.endpoints`
-
-请参考 chart 仓库中配置 [values.yaml](https://github.com/GreptimeTeam/helm-charts/blob/main/charts/greptimedb-cluster/values.yaml) 以获取最新的结构。
-:::
-
-`values.yaml` 文件设置了 GreptimeDB 的一些参数和配置，是定义 helm chart 的关键。例如一个最小规模的 GreptimeDB 集群定义如下：
-
-```yaml
-image:
-  registry: greptime-registry.cn-hangzhou.cr.aliyuncs.com
-  repository: <repository>
-  tag: <tag>
-  pullSecrets: [ regcred ]
-
-initializer:
-  registry: greptime-registry.cn-hangzhou.cr.aliyuncs.com
-  repository: greptime/greptimedb-initializer
-
-frontend:
-  replicas: 1
-
-meta:
-  replicas: 1
-  backendStorage:
-    etcd:
-      endpoints: "etcd.etcd-cluster.svc.cluster.local:2379"
-
-datanode:
-  replicas: 1
-```
-
-可参考[配置文档](/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md)获取完整的 `values.yaml` 的配置项。
-
-### 启动 GreptimeDB
-
-在上述步骤都完成后，就可以用 helm 拉起 GreptimeDB 了：
-
-```bash
-helm upgrade --install my-greptimedb greptime/greptimedb-cluster --values /path/to/values.yaml
-```
-
+请参考[部署 GreptimeDB 集群](/user-guide/deployments-administration/deploy-on-kubernetes/deploy-greptimedb-cluster.md)文档。
 


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

- remove duplicate content between enterprise and oss
- Add EN doc for deploy GreptimeDB enterprise (part 1)

I will also apply these changes to v0.15 after reviewed

## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
