### PR TITLE
chore: examples about custom time index

### DIFF
--- a/docs/user-guide/logs/write-logs.md
+++ b/docs/user-guide/logs/write-logs.md
@@ -217,6 +217,12 @@ DESC pipeline_logs;
 2 rows in set (0.02 sec)
 ```
 
+Here are some example of using `custom_time_index` assuming the time variable is named `input_ts`:
+- 1742814853: `custom_time_index=input_ts;epoch;s`
+- 1752749137000: `custom_time_index=input_ts;epoch;ms`
+- "2025-07-17T10:00:00+0800": `custom_time_index=input_ts;datestr;%Y-%m-%dT%H:%M:%S%z`
+- "2025-06-27T15:02:23.082253908Z": `custom_time_index=input_ts;datestr;%Y-%m-%dT%H:%M:%S%.9f%#z`
+
 ## Variable hints in the pipeline context
 
 Starting from `v0.15`, the pipeline engine now recognizes certain variables, and can set corresponding table options based on the value of the variables.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/write-logs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/write-logs.md
@@ -217,6 +217,12 @@ DESC pipeline_logs;
 2 rows in set (0.02 sec)
 ```
 
+假设时间变量名称为 `input_ts`，以下是一些使用 `custom_time_index` 的示例：
+- 1742814853: `custom_time_index=input_ts;epoch;s`
+- 1752749137000: `custom_time_index=input_ts;epoch;ms`
+- "2025-07-17T10:00:00+0800": `custom_time_index=input_ts;datestr;%Y-%m-%dT%H:%M:%S%z`
+- "2025-06-27T15:02:23.082253908Z": `custom_time_index=input_ts;datestr;%Y-%m-%dT%H:%M:%S%.9f%#z`
+
 ## Pipeline 上下文中的 hint 变量
 
 从 `v0.15` 开始，pipeline 引擎可以识别特定的变量名称，并且通过这些变量对应的值设置相应的建表选项。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/logs/write-logs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/logs/write-logs.md
@@ -217,10 +217,74 @@ DESC pipeline_logs;
 2 rows in set (0.02 sec)
 ```
 
+假设时间变量名称为 `input_ts`，以下是一些使用 `custom_time_index` 的示例：
+- 1742814853: `custom_time_index=input_ts;epoch;s`
+- 1752749137000: `custom_time_index=input_ts;epoch;ms`
+- "2025-07-17T10:00:00+0800": `custom_time_index=input_ts;datestr;%Y-%m-%dT%H:%M:%S%z`
+- "2025-06-27T15:02:23.082253908Z": `custom_time_index=input_ts;datestr;%Y-%m-%dT%H:%M:%S%.9f%#z`
+
+## Pipeline 上下文中的 hint 变量
+
+从 `v0.15` 开始，pipeline 引擎可以识别特定的变量名称，并且通过这些变量对应的值设置相应的建表选项。
+通过与 `vrl` 处理器的结合，现在可以非常轻易地通过输入的数据在 pipeline 的执行过程中设置建表选项。
+
+以下是支持的表选项变量名：
+- `greptime_auto_create_table`
+- `greptime_ttl`
+- `greptime_append_mode`
+- `greptime_merge_mode`
+- `greptime_physical_table`
+- `greptime_skip_wal`
+关于这些表选项的含义，可以参考[这份文档](/reference/sql/create.md#表选项)。
+
+以下是 pipeline 特有的变量：
+- `greptime_table_suffix`: 在给定的目标表后增加后缀
+
+以如下 pipeline 文件为例
+```YAML
+processors:
+  - date:
+      field: time
+      formats:
+        - "%Y-%m-%d %H:%M:%S%.3f"
+      ignore_missing: true
+  - vrl:
+      source: |
+        .greptime_table_suffix, err = "_" + .id
+        .greptime_table_ttl = "1d"
+        .
+```
+
+在这份 vrl 脚本中，我们将表后缀变量设置为输入字段中的 `id`（通过一个下划线连接），然后将 ttl 设置成 `1d`。
+然后我们使用如下数据执行写入。
+
+```JSON
+{
+  "id": "2436",
+  "time": "2024-05-25 20:16:37.217"
+}
+```
+
+假设给定的表名为 `d_table`，那么最终的表名就会按照预期被设置成 `d_table_2436`。这个表同样的 ttl 同样会被设置成 1 天。
+
 ## 示例
 
 请参考快速开始中的[写入日志](quick-start.md#写入日志)部分。
 
 ## Append 模式
 
-通过此接口创建的日志表，默认为[Append 模式](/user-guide/administration/design-table.md#何时使用-append-only-表).
+通过此接口创建的日志表，默认为[Append 模式](/user-guide/deployments-administration/performance-tuning/design-table.md#何时使用-append-only-表).
+
+
+## 使用 skip_error 跳过错误
+
+如果你希望在写入日志时跳过错误，可以在 HTTP 请求的 query params 中添加 `skip_error` 参数。比如：
+
+```shell
+curl -X "POST" "http://localhost:4000/v1/events/logs?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>&skip_error=true" \
+     -H "Content-Type: application/x-ndjson" \
+     -H "Authorization: Basic {{authentication}}" \
+     -d "$<log-items>"
+```
+
+这样，GreptimeDB 将在遇到错误时跳过该条日志，并继续处理其他日志。不会因为某一条日志的错误而导致整个请求失败。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.15/user-guide/logs/write-logs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.15/user-guide/logs/write-logs.md
@@ -217,6 +217,12 @@ DESC pipeline_logs;
 2 rows in set (0.02 sec)
 ```
 
+假设时间变量名称为 `input_ts`，以下是一些使用 `custom_time_index` 的示例：
+- 1742814853: `custom_time_index=input_ts;epoch;s`
+- 1752749137000: `custom_time_index=input_ts;epoch;ms`
+- "2025-07-17T10:00:00+0800": `custom_time_index=input_ts;datestr;%Y-%m-%dT%H:%M:%S%z`
+- "2025-06-27T15:02:23.082253908Z": `custom_time_index=input_ts;datestr;%Y-%m-%dT%H:%M:%S%.9f%#z`
+
 ## Pipeline 上下文中的 hint 变量
 
 从 `v0.15` 开始，pipeline 引擎可以识别特定的变量名称，并且通过这些变量对应的值设置相应的建表选项。

--- a/versioned_docs/version-0.14/user-guide/logs/write-logs.md
+++ b/versioned_docs/version-0.14/user-guide/logs/write-logs.md
@@ -223,50 +223,6 @@ Here are some example of using `custom_time_index` assuming the time variable is
 - "2025-07-17T10:00:00+0800": `custom_time_index=input_ts;datestr;%Y-%m-%dT%H:%M:%S%z`
 - "2025-06-27T15:02:23.082253908Z": `custom_time_index=input_ts;datestr;%Y-%m-%dT%H:%M:%S%.9f%#z`
 
-## Variable hints in the pipeline context
-
-Starting from `v0.15`, the pipeline engine now recognizes certain variables, and can set corresponding table options based on the value of the variables.
-Combined with the `vrl` processor, it's now easy to create and set table options during the pipeline execution based on input data.
-
-Here is a list of supported common table option variables:
-- `greptime_auto_create_table`
-- `greptime_ttl`
-- `greptime_append_mode`
-- `greptime_merge_mode`
-- `greptime_physical_table`
-- `greptime_skip_wal`
-You can find the explanation [here](/reference/sql/create.md#table-options).
-
-Here are some pipeline specific variables:
-- `greptime_table_suffix`: add suffix to the destined table name.
-
-Let's use the following pipeline file to demonstrate:
-```YAML
-processors:
-  - date:
-      field: time
-      formats:
-        - "%Y-%m-%d %H:%M:%S%.3f"
-      ignore_missing: true
-  - vrl:
-      source: |
-        .greptime_table_suffix, err = "_" + .id
-        .greptime_table_ttl = "1d"
-        .
-```
-
-In the vrl script, we set the table suffix variable with the input field `.id`(leading with an underscore), and set the ttl to `1d`.
-Then we run the ingestion using the following JSON data.
-
-```JSON
-{
-  "id": "2436",
-  "time": "2024-05-25 20:16:37.217"
-}
-```
-
-Assuming the given table name being `d_table`, the final table name would be `d_table_2436` as we would expected.
-The table is also set with a ttl of 1 day.
 
 ## Examples
 
@@ -275,17 +231,4 @@ Please refer to the "Writing Logs" section in the [Quick Start](quick-start.md#w
 ## Append Only
 
 By default, logs table created by HTTP ingestion API are in [append only
-mode](/user-guide/deployments-administration/performance-tuning/design-table.md#when-to-use-append-only-tables).
-
-## Skip Errors with skip_error
-
-If you want to skip errors when writing logs, you can add the `skip_error` parameter to the HTTP request's query params. For example:
-
-```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>&skip_error=true" \
-     -H "Content-Type: application/x-ndjson" \
-     -H "Authorization: Basic {{authentication}}" \
-     -d "$<log-items>"
-```
-
-With this, GreptimeDB will skip the log entry when an error is encountered and continue processing the remaining logs. The entire request will not fail due to an error in a single log entry.
+mode](/user-guide/administration/design-table.md#when-to-use-append-only-tables).

--- a/versioned_docs/version-0.15/user-guide/logs/write-logs.md
+++ b/versioned_docs/version-0.15/user-guide/logs/write-logs.md
@@ -217,6 +217,12 @@ DESC pipeline_logs;
 2 rows in set (0.02 sec)
 ```
 
+Here are some example of using `custom_time_index` assuming the time variable is named `input_ts`:
+- 1742814853: `custom_time_index=input_ts;epoch;s`
+- 1752749137000: `custom_time_index=input_ts;epoch;ms`
+- "2025-07-17T10:00:00+0800": `custom_time_index=input_ts;datestr;%Y-%m-%dT%H:%M:%S%z`
+- "2025-06-27T15:02:23.082253908Z": `custom_time_index=input_ts;datestr;%Y-%m-%dT%H:%M:%S%.9f%#z`
+
 ## Variable hints in the pipeline context
 
 Starting from `v0.15`, the pipeline engine now recognizes certain variables, and can set corresponding table options based on the value of the variables.


### PR DESCRIPTION
## What's Changed in this PR

This PR adds some config examples about the custom time index.
Backported to v0.15 and v0.14

## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
