### PR TITLE
fix: only commit ts file when bumping nightly version

### DIFF
--- a/.github/workflows/bump-nightly-version.yml
+++ b/.github/workflows/bump-nightly-version.yml
@@ -31,6 +31,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           commit-message: "version docs to ${{ github.event.inputs.version }}"
+          add-paths: "**/*.ts"
           title: "chore: bump nightly version to ${{ github.event.inputs.version }}"
           body: "This PR updates the docs to version ${{ github.event.inputs.version }}."
           branch: "version-docs-${{ github.event.inputs.version }}"


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

do not commit `package-lock.json`


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
