### PR TITLE
docs(i18n): remove English text from Chinese documentation

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/flow-computation/manage-flow.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/flow-computation/manage-flow.md
@@ -211,8 +211,6 @@ ADMIN FLUSH_FLOW('<flow-name>')
 
 请使用以下 `DROP FLOW` 子句删除 flow：
 
-To delete a flow, use the following `DROP FLOW` clause:
-
 ```sql
 DROP FLOW [IF EXISTS] <name>
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.11/user-guide/flow-computation/manage-flow.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.11/user-guide/flow-computation/manage-flow.md
@@ -208,8 +208,6 @@ ADMIN FLUSH_FLOW('<flow-name>')
 
 请使用以下 `DROP FLOW` 子句删除 flow：
 
-To delete a flow, use the following `DROP FLOW` clause:
-
 ```sql
 DROP FLOW [IF EXISTS] <name>
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.12/user-guide/flow-computation/manage-flow.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.12/user-guide/flow-computation/manage-flow.md
@@ -208,8 +208,6 @@ ADMIN FLUSH_FLOW('<flow-name>')
 
 请使用以下 `DROP FLOW` 子句删除 flow：
 
-To delete a flow, use the following `DROP FLOW` clause:
-
 ```sql
 DROP FLOW [IF EXISTS] <name>
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.13/user-guide/flow-computation/manage-flow.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.13/user-guide/flow-computation/manage-flow.md
@@ -208,8 +208,6 @@ ADMIN FLUSH_FLOW('<flow-name>')
 
 请使用以下 `DROP FLOW` 子句删除 flow：
 
-To delete a flow, use the following `DROP FLOW` clause:
-
 ```sql
 DROP FLOW [IF EXISTS] <name>
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/flow-computation/manage-flow.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/flow-computation/manage-flow.md
@@ -211,8 +211,6 @@ ADMIN FLUSH_FLOW('<flow-name>')
 
 请使用以下 `DROP FLOW` 子句删除 flow：
 
-To delete a flow, use the following `DROP FLOW` clause:
-
 ```sql
 DROP FLOW [IF EXISTS] <name>
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.15/user-guide/flow-computation/manage-flow.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.15/user-guide/flow-computation/manage-flow.md
@@ -211,8 +211,6 @@ ADMIN FLUSH_FLOW('<flow-name>')
 
 请使用以下 `DROP FLOW` 子句删除 flow：
 
-To delete a flow, use the following `DROP FLOW` clause:
-
 ```sql
 DROP FLOW [IF EXISTS] <name>
 ```


### PR DESCRIPTION


## What's Changed in this PR

Remove redundant English instruction "To delete a flow, use the following `DROP FLOW` clause:" from Chinese documentation in all versions of manage-flow.md files. The Chinese translation of this instruction was already present.

*Describe the change in this PR*


## Checklist

- [x] Please confirm that all corresponding versions of the documents have been revised.
- [x] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
