### PR TITLE
docs: typo in standalone installation guide

### DIFF
--- a/docs/getting-started/installation/greptimedb-standalone.md
+++ b/docs/getting-started/installation/greptimedb-standalone.md
@@ -36,7 +36,7 @@ You can run GreptimeDB in the standalone mode:
 
 ### Windows
 
-If you have WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about)) enabled, you can lunch a latest Ubuntu and run GreptimeDB like above!
+If you have WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about)) enabled, you can launch a latest Ubuntu and run GreptimeDB like above!
 
 Otherwise please download the GreptimeDB binary for Windows at our [official site](https://greptime.com/resources), and unzip the downloaded artifact.
 

--- a/versioned_docs/version-0.11/getting-started/installation/greptimedb-standalone.md
+++ b/versioned_docs/version-0.11/getting-started/installation/greptimedb-standalone.md
@@ -32,7 +32,7 @@ You can run GreptimeDB in the standalone mode:
 
 ### Windows
 
-If you have WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about)) enabled, you can lunch a latest Ubuntu and run GreptimeDB like above!
+If you have WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about)) enabled, you can launch a latest Ubuntu and run GreptimeDB like above!
 
 Otherwise please download the GreptimeDB binary for Windows at our [official site](https://greptime.com/resources), and unzip the downloaded artifact.
 

--- a/versioned_docs/version-0.12/getting-started/installation/greptimedb-standalone.md
+++ b/versioned_docs/version-0.12/getting-started/installation/greptimedb-standalone.md
@@ -32,7 +32,7 @@ You can run GreptimeDB in the standalone mode:
 
 ### Windows
 
-If you have WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about)) enabled, you can lunch a latest Ubuntu and run GreptimeDB like above!
+If you have WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about)) enabled, you can launch a latest Ubuntu and run GreptimeDB like above!
 
 Otherwise please download the GreptimeDB binary for Windows at our [official site](https://greptime.com/resources), and unzip the downloaded artifact.
 

--- a/versioned_docs/version-0.13/getting-started/installation/greptimedb-standalone.md
+++ b/versioned_docs/version-0.13/getting-started/installation/greptimedb-standalone.md
@@ -32,7 +32,7 @@ You can run GreptimeDB in the standalone mode:
 
 ### Windows
 
-If you have WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about)) enabled, you can lunch a latest Ubuntu and run GreptimeDB like above!
+If you have WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about)) enabled, you can launch a latest Ubuntu and run GreptimeDB like above!
 
 Otherwise please download the GreptimeDB binary for Windows at our [official site](https://greptime.com/resources), and unzip the downloaded artifact.
 

--- a/versioned_docs/version-0.14/getting-started/installation/greptimedb-standalone.md
+++ b/versioned_docs/version-0.14/getting-started/installation/greptimedb-standalone.md
@@ -36,7 +36,7 @@ You can run GreptimeDB in the standalone mode:
 
 ### Windows
 
-If you have WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about)) enabled, you can lunch a latest Ubuntu and run GreptimeDB like above!
+If you have WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about)) enabled, you can launch a latest Ubuntu and run GreptimeDB like above!
 
 Otherwise please download the GreptimeDB binary for Windows at our [official site](https://greptime.com/resources), and unzip the downloaded artifact.
 

--- a/versioned_docs/version-0.15/getting-started/installation/greptimedb-standalone.md
+++ b/versioned_docs/version-0.15/getting-started/installation/greptimedb-standalone.md
@@ -36,7 +36,7 @@ You can run GreptimeDB in the standalone mode:
 
 ### Windows
 
-If you have WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about)) enabled, you can lunch a latest Ubuntu and run GreptimeDB like above!
+If you have WSL([Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about)) enabled, you can launch a latest Ubuntu and run GreptimeDB like above!
 
 Otherwise please download the GreptimeDB binary for Windows at our [official site](https://greptime.com/resources), and unzip the downloaded artifact.
 


### PR DESCRIPTION
## What's Changed in this PR
There was a typo in the sentence `you can lunch a latest Ubuntu and run GreptimeDB like above!`, it should be `you can launch a latest Ubuntu and run GreptimeDB like above!`

## Checklist

- [x] Please confirm that all corresponding versions of the documents have been revised.
- [x] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.