### PR TITLE
docs: update Metasrv Admin API default port from 3002 to 4000

### DIFF
--- a/docs/contributor-guide/metasrv/admin-api.md
+++ b/docs/contributor-guide/metasrv/admin-api.md
@@ -6,7 +6,7 @@ description: Details the Admin API for Metasrv, including endpoints for health c
 # Admin API
 
 :::tip
-Note that all Admin API endpoints in this document listen on Metasrv's `RPC_PORT`, which defaults to `3002`.
+Note that all Admin API endpoints in this document listen on Metasrv's `HTTP_PORT`, which defaults to `4000`.
 :::
 
 The Admin API provides a simple way to view cluster information, including metasrv health detection, metasrv leader query, database metadata query, and datanode heartbeat detection.
@@ -21,7 +21,7 @@ Available APIs:
 
 All these APIs are under the parent resource `/admin`.
 
-In the following sections, we assume that your metasrv instance is running on localhost port 3002.
+In the following sections, we assume that your metasrv instance is running on localhost port 4000.
 
 ## /health HTTP endpoint  
 
@@ -30,7 +30,7 @@ The `/health` endpoint accepts GET HTTP requests and you can use this endpoint t
 ### Definition
 
 ```bash
-curl -X GET http://localhost:3002/admin/health
+curl -X GET http://localhost:4000/admin/health
 ```
 
 ### Examples
@@ -38,7 +38,7 @@ curl -X GET http://localhost:3002/admin/health
 #### Request
 
 ```bash
-curl -X GET http://localhost:3002/admin/health
+curl -X GET http://localhost:4000/admin/health
 ```
 
 #### Response
@@ -54,7 +54,7 @@ The `/leader` endpoint accepts GET HTTP requests and you can use this endpoint t
 ### Definition
 
 ```bash
-curl -X GET http://localhost:3002/admin/leader
+curl -X GET http://localhost:4000/admin/leader
 ```
 
 ### Examples
@@ -62,13 +62,13 @@ curl -X GET http://localhost:3002/admin/leader
 #### Request
 
 ```bash
-curl -X GET http://localhost:3002/admin/leader
+curl -X GET http://localhost:4000/admin/leader
 ```
 
 #### Response
 
 ```json
-127.0.0.1:3002
+127.0.0.1:4000
 ```
 
 ## /heartbeat HTTP endpoint
@@ -80,7 +80,7 @@ You can also query the heartbeat data of the datanode for a specified `addr`, ho
 ### Definition
 
 ```bash
-curl -X GET http://localhost:3002/admin/heartbeat
+curl -X GET http://localhost:4000/admin/heartbeat
 ```
 
 | Query String Parameter | Type   | Optional/Required | Definition                |
@@ -92,7 +92,7 @@ curl -X GET http://localhost:3002/admin/heartbeat
 #### Request
 
 ```bash
-curl -X GET 'http://localhost:3002/admin/heartbeat?addr=127.0.0.1:4100'
+curl -X GET 'http://localhost:4000/admin/heartbeat?addr=127.0.0.1:4100'
 ```
 
 #### Response

--- a/docs/user-guide/deployments-administration/maintenance/maintenance-mode.md
+++ b/docs/user-guide/deployments-administration/maintenance/maintenance-mode.md
@@ -39,7 +39,7 @@ When maintenance mode is enabled:
 - Monitoring and metrics collection continue to function
 
 ## Managing Maintenance Mode
-The maintenance mode can be enabled and disabled through Metasrv's HTTP interface at: `http://{METASRV}:{RPC_PORT}/admin/maintenance/enable` and `http://{METASRV}:{RPC_PORT}/admin/maintenance/disable`. Note that this interface listens on Metasrv's `RPC_PORT`, which defaults to `3002`.
+The maintenance mode can be enabled and disabled through Metasrv's HTTP interface at: `http://{METASRV}:{HTTP_PORT}/admin/maintenance/enable` and `http://{METASRV}:{HTTP_PORT}/admin/maintenance/disable`. Note that this interface listens on Metasrv's `HTTP_PORT`, which defaults to `4000`.
 
 ### Enable Maintenance Mode
 
@@ -53,7 +53,7 @@ proceed with caution and avoid continuing with high-risk operations such as clus
 Enable maintenance mode by sending a POST request to the `/admin/maintenance/enable` endpoint. 
 
 ```bash
-curl -X POST 'http://localhost:3002/admin/maintenance/enable'
+curl -X POST 'http://localhost:4000/admin/maintenance/enable'
 ```
 
 The expected output is:
@@ -77,7 +77,7 @@ Before disabling maintenance mode:
 2. Verify that all nodes are properly joined to the cluster
 
 ```bash
-curl -X POST 'http://localhost:3002/admin/maintenance/disable'
+curl -X POST 'http://localhost:4000/admin/maintenance/disable'
 ```
 
 The expected output is:
@@ -90,7 +90,7 @@ The expected output is:
 Check maintenance mode status by sending a GET request to the `/admin/maintenance` endpoint.
 
 ```bash
-curl -X GET http://localhost:3002/admin/maintenance/status
+curl -X GET http://localhost:4000/admin/maintenance/status
 ```
 
 The expected output is:

--- a/docs/user-guide/deployments-administration/maintenance/prevent-metadata-changes.md
+++ b/docs/user-guide/deployments-administration/maintenance/prevent-metadata-changes.md
@@ -26,14 +26,14 @@ Once enabled, the Metasrv will reject the following procedures (including but no
 You may see error messages if you or Metasrv try to perform these procedures after metadata changes are paused. For region procedures, you can enable [Cluster Maintenance Mode](/user-guide/deployments-administration/maintenance/maintenance-mode.md) to temporarily disable them.
 
 ## Managing Procedure Manager
-The Procedure Manager can be paused and resumed through Metasrv's HTTP interface at: `http://{METASRV}:{RPC_PORT}/admin/procedure-manager/pause` and `http://{METASRV}:{RPC_PORT}/admin/procedure-manager/resume`. Note that this interface listens on Metasrv's `RPC_PORT`, which defaults to `3002`.
+The Procedure Manager can be paused and resumed through Metasrv's HTTP interface at: `http://{METASRV}:{HTTP_PORT}/admin/procedure-manager/pause` and `http://{METASRV}:{HTTP_PORT}/admin/procedure-manager/resume`. Note that this interface listens on Metasrv's `HTTP_PORT`, which defaults to `4000`.
 
 ### Pause Procedure Manager
 
 Pause Procedure Manager by sending a POST request to the `/admin/procedure-manager/pause` endpoint. 
 
 ```bash
-curl -X POST 'http://localhost:3002/admin/procedure-manager/pause'
+curl -X POST 'http://localhost:4000/admin/procedure-manager/pause'
 ```
 
 The expected output is:
@@ -46,7 +46,7 @@ The expected output is:
 Resume Procedure Manager by sending a POST request to the `/admin/procedure-manager/resume` endpoint. 
 
 ```bash
-curl -X POST 'http://localhost:3002/admin/procedure-manager/resume'
+curl -X POST 'http://localhost:4000/admin/procedure-manager/resume'
 ```
 
 The expected output is:
@@ -59,7 +59,7 @@ The expected output is:
 Check Procedure Manager status by sending a GET request to the `/admin/procedure-manager/status` endpoint.
 
 ```bash
-curl -X GET 'http://localhost:3002/admin/procedure-manager/status'
+curl -X GET 'http://localhost:4000/admin/procedure-manager/status'
 ```
 
 The expected output is:

--- a/i18n/zh/docusaurus-plugin-content-docs/current/contributor-guide/metasrv/admin-api.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/contributor-guide/metasrv/admin-api.md
@@ -17,7 +17,7 @@ Admin API 是一个 HTTP 服务，提供一组可以通过 HTTP 请求调用的 
 
 所有这些 API 都在父资源 `/admin` 下。
 
-在以下部分中，我们假设你的 metasrv 实例运行在本地主机的 3002 端口。
+在以下部分中，我们假设你的 metasrv 实例运行在本地主机的 4000 端口。
 
 ## /health HTTP 端点
 
@@ -26,7 +26,7 @@ Admin API 是一个 HTTP 服务，提供一组可以通过 HTTP 请求调用的 
 ### 定义
 
 ```bash
-curl -X GET http://localhost:3002/admin/health
+curl -X GET http://localhost:4000/admin/health
 ```
 
 ### 示例
@@ -34,7 +34,7 @@ curl -X GET http://localhost:3002/admin/health
 #### 请求
 
 ```bash
-curl -X GET http://localhost:3002/admin/health
+curl -X GET http://localhost:4000/admin/health
 ```
 
 #### 响应
@@ -50,7 +50,7 @@ OK
 ### 定义
 
 ```bash
-curl -X GET http://localhost:3002/admin/leader
+curl -X GET http://localhost:4000/admin/leader
 ```
 
 ### 示例
@@ -58,13 +58,13 @@ curl -X GET http://localhost:3002/admin/leader
 #### 请求
 
 ```bash
-curl -X GET http://localhost:3002/admin/leader
+curl -X GET http://localhost:4000/admin/leader
 ```
 
 #### 响应
 
 ```json
-127.0.0.1:3002
+127.0.0.1:4000
 ```
 
 ## /heartbeat HTTP 端点
@@ -76,7 +76,7 @@ curl -X GET http://localhost:3002/admin/leader
 ### 定义
 
 ```bash
-curl -X GET http://localhost:3002/admin/heartbeat
+curl -X GET http://localhost:4000/admin/heartbeat
 ```
 
 | 查询字符串参数 | 类型   | 可选/必选 | 定义                |
@@ -88,7 +88,7 @@ curl -X GET http://localhost:3002/admin/heartbeat
 #### 请求
 
 ```bash
-curl -X GET 'http://localhost:3002/admin/heartbeat?addr=127.0.0.1:4100'
+curl -X GET 'http://localhost:4000/admin/heartbeat?addr=127.0.0.1:4100'
 ```
 
 #### 响应

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/maintenance/maintenance-mode.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/maintenance/maintenance-mode.md
@@ -39,7 +39,7 @@ description: 介绍如何管理 GreptimeDB 集群维护模式，以便在防止�
 - 监控和指标收集继续运行
 
 ## 管理维护模式
-维护模式可以通过 Metasrv 的 HTTP 接口启用和禁用：`http://{METASRV}:{RPC_PORT}/admin/maintenance/enable` 和 `http://{METASRV}:{RPC_PORT}/admin/maintenance/disable`。请注意，此接口监听 Metasrv 的 `RPC_PORT`，默认为 `3002`。
+维护模式可以通过 Metasrv 的 HTTP 接口启用和禁用：`http://{METASRV}:{HTTP_PORT}/admin/maintenance/enable` 和 `http://{METASRV}:{HTTP_PORT}/admin/maintenance/disable`。请注意，此接口监听 Metasrv 的 `HTTP_PORT`，默认为 `4000`。
 
 ### 启用维护模式
 
@@ -50,7 +50,7 @@ description: 介绍如何管理 GreptimeDB 集群维护模式，以便在防止�
 通过发送 POST 请求到 `/admin/maintenance/enable` 端点启用维护模式。
 
 ```bash
-curl -X POST 'http://localhost:3002/admin/maintenance/enable'
+curl -X POST 'http://localhost:4000/admin/maintenance/enable'
 ```
 
 预期输出：
@@ -73,7 +73,7 @@ curl -X POST 'http://localhost:3002/admin/maintenance/enable'
 2. 验证所有节点是否正确加入集群
 
 ```bash
-curl -X POST 'http://localhost:3002/admin/maintenance/disable'
+curl -X POST 'http://localhost:4000/admin/maintenance/disable'
 ```
 
 预期输出：
@@ -86,7 +86,7 @@ curl -X POST 'http://localhost:3002/admin/maintenance/disable'
 通过发送 GET 请求到 `/admin/maintenance/status` 端点检查维护模式状态。
 
 ```bash
-curl -X GET http://localhost:3002/admin/maintenance/status
+curl -X GET http://localhost:4000/admin/maintenance/status
 ```
 
 预期输出：

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/maintenance/prevent-metadata-changes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/maintenance/prevent-metadata-changes.md
@@ -26,14 +26,14 @@ description: 管理 GreptimeDB 暂停元数据变更的指南，用于安全执�
 你在启用暂停元数据变更功能后尝试执行这些操作时，可能会看到错误消息。对于 Region 调度操作，你可以启用 [集群维护模式](/user-guide/deployments-administration/maintenance/maintenance-mode.md) 来临时暂时它们。
 
 ## 管理 Procedure Manager
-Procedure Manager 可以通过 Metasrv 的 HTTP 接口暂停和恢复：`http://{METASRV}:{RPC_PORT}/admin/procedure-manager/pause` 和 `http://{METASRV}:{RPC_PORT}/admin/procedure-manager/resume`。请注意，此接口监听 Metasrv 的 `RPC_PORT`，默认为 `3002`。
+Procedure Manager 可以通过 Metasrv 的 HTTP 接口暂停和恢复：`http://{METASRV}:{HTTP_PORT}/admin/procedure-manager/pause` 和 `http://{METASRV}:{HTTP_PORT}/admin/procedure-manager/resume`。请注意，此接口监听 Metasrv 的 `HTTP_PORT`，默认为 `4000`。
 
 ### 暂停 Procedure Manager
 
 通过向 `/admin/procedure-manager/pause` 端点发送 POST 请求来暂停 Procedure Manager。
 
 ```bash
-curl -X POST 'http://localhost:3002/admin/procedure-manager/pause'
+curl -X POST 'http://localhost:4000/admin/procedure-manager/pause'
 ```
 
 预期输出：
@@ -46,7 +46,7 @@ curl -X POST 'http://localhost:3002/admin/procedure-manager/pause'
 通过向 `/admin/procedure-manager/resume` 端点发送 POST 请求来恢复 Procedure Manager。
 
 ```bash
-curl -X POST 'http://localhost:3002/admin/procedure-manager/resume'
+curl -X POST 'http://localhost:4000/admin/procedure-manager/resume'
 ```
 
 预期输出：
@@ -59,7 +59,7 @@ curl -X POST 'http://localhost:3002/admin/procedure-manager/resume'
 通过向 `/admin/procedure-manager/status` 端点发送 GET 请求来检查 Procedure Manager 状态。
 
 ```bash
-curl -X GET 'http://localhost:3002/admin/procedure-manager/status'
+curl -X GET 'http://localhost:4000/admin/procedure-manager/status'
 ```
 
 预期输出：


### PR DESCRIPTION

## What's Changed in this PR

This PR updates the Metasrv Admin API documentation to reflect the port migration from 3002 to 4000 in the new version. The Admin API endpoints now listen on `HTTP_PORT` (default: 4000) instead of the previous `RPC_PORT` (default: 3002).

## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
