### PR TITLE
docs: add `flush_trigger_size` adn `checkpoint_trigger_size` for remo…

### DIFF
--- a/docs/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/docs/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -585,7 +585,7 @@ meta:
     [wal]
     provider = "kafka"
     replication_factor = 1
-    auto_prune_interval = "300s"
+    auto_prune_interval = "30m"
 datanode:
   configData: |
     [wal]

--- a/docs/user-guide/deployments-administration/deploy-on-kubernetes/configure-remote-wal.md
+++ b/docs/user-guide/deployments-administration/deploy-on-kubernetes/configure-remote-wal.md
@@ -43,7 +43,7 @@ meta:
     provider = "kafka"
     replication_factor = 1
     topic_name_prefix = "gtp_greptimedb_wal_topic"
-    auto_prune_interval = "300s"
+    auto_prune_interval = "30m"
 datanode:
   configData: |
     [wal]

--- a/docs/user-guide/deployments-administration/wal/remote-wal/configuration.md
+++ b/docs/user-guide/deployments-administration/wal/remote-wal/configuration.md
@@ -21,8 +21,10 @@ provider = "kafka"
 broker_endpoints = ["kafka.kafka-cluster.svc:9092"]
 
 # WAL data pruning options
-auto_prune_interval = "0s"
+auto_prune_interval = "30m"
 auto_prune_parallelism = 10
+flush_trigger_size = "512MB"
+checkpoint_trigger_size = "128MB"
 
 # Topic creation options
 auto_create_topics = true
@@ -33,16 +35,19 @@ topic_name_prefix = "greptimedb_wal_topic"
 
 ### Options
 
-| Configuration Option     | Description                                                                              |
-| ------------------------ | ---------------------------------------------------------------------------------------- |
-| `provider`               | Set to "kafka" to enable Remote WAL via Kafka.                                           |
-| `broker_endpoints`       | List of Kafka broker addresses.                                                          |
-| `auto_prune_interval`    | Interval to automatically prune stale WAL data. Set to "0s" to disable.                  |
-| `auto_prune_parallelism` | Maximum number of concurrent pruning tasks.                                              |
-| `auto_create_topics`     | Whether to automatically create Kafka topics. If false, topics must be created manually. |
-| `num_topics`             | Number of Kafka topics used for WAL.                                                     |
-| `replication_factor`     | Kafka replication factor for each topic.                                                 |
-| `topic_name_prefix`      | Prefix for Kafka topic names. Must match regex `[a-zA-Z_:-][a-zA-Z0-9_:\-\.@#]*`.        |
+| Configuration Option        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Configuration Option        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `provider`                 | The WAL provider to use. Set to `"kafka"` to enable Remote WAL with Kafka.                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `broker_endpoints`         | List of Kafka broker addresses to connect to. Example: `["kafka.kafka-cluster.svc:9092"]`.                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `auto_prune_interval`      | How often to automatically prune (delete) stale WAL data. Specify as a duration string (e.g., `"30m"`). Set to `"0s"` to disable automatic pruning.                                                                                                                                                                                                                                                                                                                                             |
+| `auto_prune_parallelism`   | Maximum number of concurrent pruning tasks. Increasing this value may speed up pruning but will use more resources.                                                                                                                                                                                                                                                                                                                                                                              |
+| `auto_create_topics`       | If `true`, Metasrv will automatically create required Kafka topics. If `false`, you must manually create all topics before starting Metasrv.                                                                                                                                                                                                                                                                                                                                                    |
+| `num_topics`               | Number of Kafka topics to use for WAL storage. More topics can improve scalability and performance.                                                                                                                                                                                                                                                                                                                                                                                              |
+| `replication_factor`       | Replication factor for Kafka topics. Determines how many Kafka brokers will store copies of each topic's data.                                                                                                                                                                                                                                                                                                                                            |
+| `topic_name_prefix`        | Prefix for Kafka topic names. WAL topics will be named as `{topic_name_prefix}_{index}` (e.g., `greptimedb_wal_topic_0`). The prefix must match the regex `[a-zA-Z_:-][a-zA-Z0-9_:\-\.@#]*`.                                                                                                                                                                                                                                                               |
+| `flush_trigger_size`       | Estimated size threshold (e.g., `"512MB"`) for triggering a flush operation in a region. Calculated as `(latest_entry_id - flushed_entry_id) * avg_record_size`. When this value exceeds `flush_trigger_size`, MetaSrv initiates a flush. Set to `"0"` to let the system automatically determine the flush trigger size. This also controls the maximum replay size from a topic during region replay; using a smaller value can help reduce region replay time during Datanode startup.                |
+| `checkpoint_trigger_size`  | Estimated size threshold (e.g., `"128MB"`) for triggering a checkpoint operation in a region. Calculated as `(latest_entry_id - last_checkpoint_entry_id) * avg_record_size`. When this value exceeds `checkpoint_trigger_size`, MetaSrv initiates a checkpoint. Set to `"0"` to let the system automatically determine the checkpoint trigger size. Using a smaller value can help reduce region replay time during Datanode startup.                                                        |
 
 #### Topic Setup and Kafka Permissions 
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -585,7 +585,7 @@ meta:
     [wal]
     provider = "kafka"
     replication_factor = 1
-    auto_prune_interval = "300s"
+    auto_prune_interval = "30m"
 datanode:
   configData: |
     [wal]

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/configure-remote-wal.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/configure-remote-wal.md
@@ -44,7 +44,7 @@ meta:
     provider = "kafka"
     replication_factor = 1
     topic_name_prefix = "gtp_greptimedb_wal_topic"
-    auto_prune_interval = "300s"
+    auto_prune_interval = "30m"
 datanode:
   configData: |
     [wal]

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/wal/remote-wal/configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/wal/remote-wal/configuration.md
@@ -18,8 +18,10 @@ provider = "kafka"
 broker_endpoints = ["kafka.kafka-cluster.svc:9092"]
 
 # WAL 数据清理策略
-auto_prune_interval = "0s"
+auto_prune_interval = "30m"
 auto_prune_parallelism = 10
+flush_trigger_size = "512MB"
+checkpoint_trigger_size = "128MB"
 
 # Topic 自动创建配置
 auto_create_topics = true
@@ -30,16 +32,18 @@ topic_name_prefix = "greptimedb_wal_topic"
 
 ### 配置
 
-| 配置项                   | 说明                                                                   |
-| ------------------------ | ---------------------------------------------------------------------- |
-| `provider`               | 设置为 `"kafka"` 以启用 Remote WAL。                                   |
-| `broker_endpoints`       | Kafka broker 的地址列表。                                              |
-| `auto_prune_interval`    | 自动清理过期 WAL 的间隔时间，设为 `"0s"` 表示禁用。                    |
-| `auto_prune_parallelism` | 并发清理任务的最大数量。                                               |
-| `auto_create_topics`     | 是否自动创建 Kafka topic，设为 `false` 时需手动预创建。                |
-| `num_topics`             | 用于存储 WAL 的 Kafka topic 数量。                                     |
-| `replication_factor`     | 每个 topic 的副本数量。                                                |
-| `topic_name_prefix`      | Kafka topic 名称前缀，必须匹配正则 `[a-zA-Z_:-][a-zA-Z0-9_:\-\.@#]*`。 |
+| 配置项                     | 说明                                                                                                                                                                                                                                                                                                                                                      |
+|----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `provider`                 | 设置为 `"kafka"` 以启用 Remote WAL。                                                                                                                                                                                                                                                                                                                     |
+| `broker_endpoints`         | Kafka broker 的地址列表。                                                                                                                                                                                                                                                                                                                               |
+| `auto_prune_interval`      | 自动清理过期 WAL 的间隔时间，设为 `"0s"` 表示禁用。                                                                                                                                                                                                                                                               |
+| `auto_prune_parallelism`   | 并发清理任务的最大数量。                                                                                                                                                                                                                                                                                         |
+| `auto_create_topics`       | 是否自动创建 Kafka topic，设为 `false` 时需手动预创建。                                                                                                                                                                                                                                                           |
+| `num_topics`               | 用于存储 WAL 的 Kafka topic 数量。                                                                                                                                                                                                                                                                                |
+| `replication_factor`       | 每个 topic 的副本数量。                                                                                                                                                                                                                                                                                           |
+| `topic_name_prefix`        | Kafka topic 名称前缀，必须匹配正则 `[a-zA-Z_:-][a-zA-Z0-9_:\-\.@#]*`。                                                                                                                                                                                                                                            |
+| `flush_trigger_size`       | 触发 region flush 操作的预估大小阈值（如 `"512MB"`）。计算公式为 `(latest_entry_id - flushed_entry_id) * avg_record_size`。当此值超过 `flush_trigger_size` 时，MetaSrv 会触发 region flush 操作。设为 `"0"` 时由系统自动控制。该配置还可控制 region 重放期间从 topic 重放的最大数据量，较小的值有助于缩短 Datanode 启动时的重放时间。 |
+| `checkpoint_trigger_size`  | 触发 region checkpoint 操作的预估大小阈值（如 `"128MB"`）。计算公式为 `(latest_entry_id - last_checkpoint_entry_id) * avg_record_size`。当此值超过 `checkpoint_trigger_size` 时，MetaSrv 会启动检查点操作。设为 `"0"` 时由系统自动控制。较小的值有助于缩短 Datanode 启动时的重放时间。                                 |
 
 #### Kafka Topic 与权限要求
 


### PR DESCRIPTION
…te wal

## What's Changed in this PR

This PR updates the Remote WAL configuration documentation to improve the default settings.

1. Changed `auto_prune_interval` from "300s" to "30m" across all configuration examples
2. Added new configuration options:
- `flush_trigger_size`: Controls the size threshold for triggering region flush operations.
- `checkpoint_trigger_size`: Controls the size threshold for triggering checkpoint operations.


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
