### PR TITLE
fix: otel trace endpoint config

### DIFF
--- a/docs/user-guide/traces/read-write.md
+++ b/docs/user-guide/traces/read-write.md
@@ -86,7 +86,7 @@ OpenTelemetry Collector. For example, you can use the environment variable
 `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` to configure the endpoint of the exporter:
 
 ```shell
-export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://localhost:4318/v1/otlp"
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://localhost:4318/v1/otlp/v1/traces"
 ```
 
 For convenience, you can use the tool

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/traces/read-write.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/traces/read-write.md
@@ -82,7 +82,7 @@ service:
 endpoint：
 
 ```shell
-export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://localhost:4318/v1/otlp"
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://localhost:4318/v1/otlp/v1/traces"
 ```
 
 此处为了方便，我们可使用工具


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

*Describe the change in this PR*

According to OTEL docs, the trace endpoint should include `/v1/traces` in the endpoint: https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/#otel_exporter_otlp_traces_endpoint

## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
