### PR TITLE
fix: locale versioning

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -7,6 +7,13 @@ import versions from './versions.json';
 const locale = process.env.DOC_LANG || 'en';
 const biel_project_id = process.env.BIEL_PROJECT_ID;
 
+// For versioning commands, we need all locales available
+// For building, we only need the current locale
+const isVersioningCommand = process.argv.some(arg => 
+  arg.includes('docs:version') || arg.includes('write-translations')
+);
+const availableLocales = isVersioningCommand ? ['en', 'zh'] : [locale];
+
 // Get the latest version (first item in versions array)
 const latestVersion = versions[0];
 const latestVersionNumber = parseFloat(latestVersion);
@@ -142,7 +149,7 @@ const config: Config = {
   // may want to replace "en" with "zh-Hans".
   i18n: {
     defaultLocale: locale,
-    locales: [locale], // Only build the current locale
+    locales: availableLocales, // All locales for versioning, current locale for building
   },
 
   presets: [


### PR DESCRIPTION
## What's Changed in this PR
* version command need two  locales to generate all locale content
<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

*Describe the change in this PR*


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
