### PR TITLE
fix: use new path instead of the deprecated path in docs

### DIFF
--- a/docs/greptimecloud/integrations/fluent-bit.md
+++ b/docs/greptimecloud/integrations/fluent-bit.md
@@ -18,7 +18,7 @@ Fluent Bit can be configured to send logs to GreptimeCloud using the HTTP protoc
     Match            *
     Host             <host>
     Port             443
-    Uri              /v1/events/logs?db=<dbname>&table=<table_name>&pipeline_name=<pipeline_name>
+    Uri              /v1/ingest?db=<dbname>&table=<table_name>&pipeline_name=<pipeline_name>
     Format           json
     Json_date_key    scrape_timestamp
     Json_date_format iso8601

--- a/docs/reference/http-endpoints.md
+++ b/docs/reference/http-endpoints.md
@@ -222,9 +222,9 @@ Refer to the original Prometheus documentation for more information on the [Prom
 ## Log Ingestion Endpoints
 
 - **Paths**:
-  - `/v1/events/logs`
-  - `/v1/events/pipelines/{pipeline_name}`
-  - `/v1/events/pipelines/dryrun`
+  - `/v1/ingest`
+  - `/v1/pipelines/{pipeline_name}`
+  - `/v1/pipelines/dryrun`
 - **Methods**:
   - `POST` for ingesting logs and adding pipelines.
   - `DELETE` for deleting pipelines.

--- a/docs/user-guide/ingest-data/for-observability/fluent-bit.md
+++ b/docs/user-guide/ingest-data/for-observability/fluent-bit.md
@@ -19,7 +19,7 @@ Using Fluent Bit's [HTTP Output Plugin](https://docs.fluentbit.io/manual/pipelin
     Match            *
     Host             greptimedb
     Port             4000
-    Uri              /v1/events/logs?db=public&table=your_table&pipeline_name=pipeline_if_any
+    Uri              /v1/ingest?db=public&table=your_table&pipeline_name=pipeline_if_any
     Format           json
     Json_date_key    scrape_timestamp
     Json_date_format iso8601

--- a/docs/user-guide/ingest-data/for-observability/loki.md
+++ b/docs/user-guide/ingest-data/for-observability/loki.md
@@ -222,7 +222,7 @@ In the `greptime_loki`, the `x-greptime-pipeline-name` header is added to indica
 2. [Upload](/user-guide/logs/manage-pipelines.md#create-a-pipeline) the pipeline configuration to the database using `curl`:
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/pp" -F "file=@pipeline.yaml"
+curl -X "POST" "http://localhost:4000/v1/pipelines/pp" -F "file=@pipeline.yaml"
 ```
 
 3. Start the Alloy Docker container to process the logs:

--- a/docs/user-guide/logs/manage-pipelines.md
+++ b/docs/user-guide/logs/manage-pipelines.md
@@ -21,7 +21,7 @@ Assuming you have prepared a pipeline configuration file `pipeline.yaml`, use th
 
 ```shell
 ## Upload the pipeline file. 'test' is the name of the pipeline
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/test" \
   -H "Authorization: Basic {{authentication}}" \
   -F "file=@pipeline.yaml"
 ```
@@ -34,7 +34,7 @@ You can use the following HTTP interface to delete a pipeline:
 
 ```shell
 ## 'test' is the name of the pipeline
-curl -X "DELETE" "http://localhost:4000/v1/events/pipelines/test?version=2024-06-27%2012%3A02%3A34.257312110Z" \
+curl -X "DELETE" "http://localhost:4000/v1/pipelines/test?version=2024-06-27%2012%3A02%3A34.257312110Z" \
   -H "Authorization: Basic {{authentication}}"
 ```
 
@@ -46,13 +46,13 @@ Querying a pipeline with a name through HTTP interface as follow:
 
 ```shell
 ## 'test' is the name of the pipeline, it will return a pipeline with latest version if the pipeline named `test` exists.
-curl "http://localhost:4000/v1/events/pipelines/test" \
+curl "http://localhost:4000/v1/pipelines/test" \
   -H "Authorization: Basic {{authentication}}"
 ```
 
 ```shell
 ## with the version parameter, it will return the specify version pipeline.
-curl "http://localhost:4000/v1/events/pipelines/test?version=2025-04-01%2006%3A58%3A31.335251882%2B0000" \
+curl "http://localhost:4000/v1/pipelines/test?version=2025-04-01%2006%3A58%3A31.335251882%2B0000" \
   -H "Authorization: Basic {{authentication}}"
 ```
 
@@ -192,7 +192,7 @@ You may encounter errors when creating a Pipeline. For example, when creating a 
 
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/test" \
      -H "Content-Type: application/x-yaml" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'processors:
@@ -228,7 +228,7 @@ The pipeline configuration contains an error. The `gsub` Processor expects the `
 Therefore, We need to modify the configuration of the `gsub` Processor and change the value of the `replacement` field to a string type.
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/test" \
      -H "Content-Type: application/x-yaml" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'processors:
@@ -263,7 +263,7 @@ We can test the Pipeline using the `dryrun` interface. We will test it with erro
 
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/dryrun?pipeline_name=test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/dryrun?pipeline_name=test" \
      -H "Content-Type: application/json" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'{"message": 1998.08,"time":"2024-05-25 20:16:37.217"}'
@@ -275,7 +275,7 @@ The output indicates that the pipeline processing failed because the `gsub` Proc
 Let's change the value of the message field to a string type and test the pipeline again.
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/dryrun?pipeline_name=test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/dryrun?pipeline_name=test" \
      -H "Content-Type: application/json" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'{"message": "1998.08","time":"2024-05-25 20:16:37.217"}'

--- a/docs/user-guide/logs/quick-start.md
+++ b/docs/user-guide/logs/quick-start.md
@@ -22,7 +22,7 @@ GreptimeDB offers a built-in pipeline, `greptime_identity`, for handling JSON lo
 
 ```shell
 curl -X POST \
-  "http://localhost:4000/v1/events/logs?db=public&table=pipeline_logs&pipeline_name=greptime_identity" \
+  "http://localhost:4000/v1/ingest?db=public&table=pipeline_logs&pipeline_name=greptime_identity" \
   -H "Content-Type: application/json" \
   -H "Authorization: Basic {{authentication}}" \
   -d '[
@@ -133,7 +133,7 @@ Execute the following command to upload the configuration file:
 
 ```shell
 curl -X "POST" \
-  "http://localhost:4000/v1/events/pipelines/nginx_pipeline" \
+  "http://localhost:4000/v1/pipelines/nginx_pipeline" \
      -H 'Authorization: Basic {{authentication}}' \
      -F "file=@pipeline.yaml"
 ```
@@ -154,7 +154,7 @@ The following example writes logs to the `custom_pipeline_logs` table and uses t
 
 ```shell
 curl -X POST \
-  "http://localhost:4000/v1/events/logs?db=public&table=custom_pipeline_logs&pipeline_name=nginx_pipeline" \
+  "http://localhost:4000/v1/ingest?db=public&table=custom_pipeline_logs&pipeline_name=nginx_pipeline" \
   -H "Content-Type: application/json" \
   -H "Authorization: Basic {{authentication}}" \
   -d '[

--- a/docs/user-guide/logs/write-logs.md
+++ b/docs/user-guide/logs/write-logs.md
@@ -14,7 +14,7 @@ Before writing logs, please read the [Pipeline Configuration](pipeline-config.md
 You can use the following command to write logs via the HTTP interface:
 
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>" \
      -H "Content-Type: application/x-ndjson" \
      -H "Authorization: Basic {{authentication}}" \
      -d "$<log-items>"
@@ -190,7 +190,7 @@ Example of Incoming Log Data:
 
 To instruct the server to use ts as the time index, set the following query parameter in the HTTP header:
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=public&table=pipeline_logs&pipeline_name=greptime_identity&custom_time_index=ts;epoch;s" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=public&table=pipeline_logs&pipeline_name=greptime_identity&custom_time_index=ts;epoch;s" \
      -H "Content-Type: application/json" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'[{"action": "login", "ts": 1742814853}]'
@@ -231,7 +231,7 @@ If flattening a JSON object into a single-level structure is needed, add the `x-
 Here is a sample request:
 
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=<db-name>&table=<table-name>&pipeline_name=greptime_identity&version=<pipeline-version>" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=<db-name>&table=<table-name>&pipeline_name=greptime_identity&version=<pipeline-version>" \
      -H "Content-Type: application/x-ndjson" \
      -H "Authorization: Basic {{authentication}}" \
      -H "x-greptime-pipeline-params: flatten_json_object=true" \
@@ -338,7 +338,7 @@ mode](/user-guide/deployments-administration/performance-tuning/design-table.md#
 If you want to skip errors when writing logs, you can add the `skip_error` parameter to the HTTP request's query params. For example:
 
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>&skip_error=true" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>&skip_error=true" \
      -H "Content-Type: application/x-ndjson" \
      -H "Authorization: Basic {{authentication}}" \
      -d "$<log-items>"

--- a/i18n/zh/docusaurus-plugin-content-docs/current/greptimecloud/integrations/fluent-bit.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/greptimecloud/integrations/fluent-bit.md
@@ -17,7 +17,7 @@ Fluent Bit 可以配置为使用 HTTP 协议将日志发送到 GreptimeCloud。�
     Match            *
     Host             <host>
     Port             443
-    Uri              /v1/events/logs?db=<dbname>&table=<table_name>&pipeline_name=<pipeline_name>
+    Uri              /v1/ingest?db=<dbname>&table=<table_name>&pipeline_name=<pipeline_name>
     Format           json
     Json_date_key    scrape_timestamp
     Json_date_format iso8601

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/http-endpoints.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/http-endpoints.md
@@ -222,9 +222,9 @@ is_strict_mode = false
 ## 日志写入端点
 
 - **路径**:
-  - `/v1/events/logs`
-  - `/v1/events/pipelines/{pipeline_name}`
-  - `/v1/events/pipelines/dryrun`
+  - `/v1/ingest`
+  - `/v1/pipelines/{pipeline_name}`
+  - `/v1/pipelines/dryrun`
 - **方法**:
   - `POST` 写入日志和添加 Pipeline。
   - `DELETE` 用于删除 Pipeline。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/fluent-bit.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/fluent-bit.md
@@ -19,7 +19,7 @@ description: 将 GreptimeDB 与 Fluent bit 集成以实现 Prometheus Remote Wri
     Match            *
     Host             greptimedb
     Port             4000
-    Uri              /v1/events/logs?db=public&table=your_table&pipeline_name=pipeline_if_any
+    Uri              /v1/ingest?db=public&table=your_table&pipeline_name=pipeline_if_any
     Format           json
     Json_date_key    scrape_timestamp
     Json_date_format iso8601

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/loki.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/loki.md
@@ -222,7 +222,7 @@ loki.write "greptime_loki" {
 2. [上传](/user-guide/logs/manage-pipelines.md#create-a-pipeline) pipeline 配置到数据库：
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/pp" -F "file=@pipeline.yaml"
+curl -X "POST" "http://localhost:4000/v1/pipelines/pp" -F "file=@pipeline.yaml"
 ```
 
 3. 启动 Alloy Docker 容器来处理日志：

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/manage-pipelines.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/manage-pipelines.md
@@ -22,7 +22,7 @@ GreptimeDB 提供了专用的 HTTP 接口用于创建 Pipeline。
 
 ```shell
 ## 上传 pipeline 文件。test 为 Pipeline 的名称
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/test" \
   -H "Authorization: Basic {{authentication}}" \
   -F "file=@pipeline.yaml"
 ```
@@ -35,7 +35,7 @@ curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
 
 ```shell
 ## test 为 Pipeline 的名称
-curl -X "DELETE" "http://localhost:4000/v1/events/pipelines/test?version=2024-06-27%2012%3A02%3A34.257312110Z" \
+curl -X "DELETE" "http://localhost:4000/v1/pipelines/test?version=2024-06-27%2012%3A02%3A34.257312110Z" \
   -H "Authorization: Basic {{authentication}}"
 ```
 
@@ -47,13 +47,13 @@ curl -X "DELETE" "http://localhost:4000/v1/events/pipelines/test?version=2024-06
 
 ```shell
 ## test 是 Pipeline 的名称，该查询将返回最新版本的 Pipeline。
-curl "http://localhost:4000/v1/events/pipelines/test" \
+curl "http://localhost:4000/v1/pipelines/test" \
   -H "Authorization: Basic {{authentication}}"
 ```
 
 ```shell
 ## 如果你想查询某个 Pipeline 的历史版本，可以在 URL 中添加 `version` 参数
-curl "http://localhost:4000/v1/events/pipelines/test?version=2025-04-01%2006%3A58%3A31.335251882%2B0000" \
+curl "http://localhost:4000/v1/pipelines/test?version=2025-04-01%2006%3A58%3A31.335251882%2B0000" \
   -H "Authorization: Basic {{authentication}}"
 ```
 
@@ -193,7 +193,7 @@ Readable timestamp (UTC): 2024-06-27 12:02:34.257312110Z
 在创建 Pipeline 的时候你可能会遇到错误，例如使用如下配置创建 Pipeline：
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/test" \
      -H "Content-Type: application/x-yaml" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'processors:
@@ -229,7 +229,7 @@ Pipeline 配置存在错误。`gsub` processor 期望 `replacement` 字段为字
 因此，你需要修改 `gsub` processor 的配置，将 `replacement` 字段的值更改为字符串类型。
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/test" \
      -H "Content-Type: application/x-yaml" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'processors:
@@ -263,7 +263,7 @@ transform:
 **此接口仅仅用于测试 Pipeline 的处理结果，不会将日志写入到 GreptimeDB 中。**
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/dryrun?pipeline_name=test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/dryrun?pipeline_name=test" \
      -H "Content-Type: application/json" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'{"message": 1998.08,"time":"2024-05-25 20:16:37.217"}'
@@ -275,7 +275,7 @@ curl -X "POST" "http://localhost:4000/v1/events/pipelines/dryrun?pipeline_name=t
 我们再将 message 字段的值修改为字符串类型，然后再次测试该 Pipeline。
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/dryrun?pipeline_name=test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/dryrun?pipeline_name=test" \
      -H "Content-Type: application/json" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'{"message": "1998.08","time":"2024-05-25 20:16:37.217"}'

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/quick-start.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/quick-start.md
@@ -22,7 +22,7 @@ GreptimeDB 提供了一个内置 pipeline `greptime_identity` 用于处理 JSON 
 
 ```shell
 curl -X POST \
-  "http://localhost:4000/v1/events/logs?db=public&table=pipeline_logs&pipeline_name=greptime_identity" \
+  "http://localhost:4000/v1/ingest?db=public&table=pipeline_logs&pipeline_name=greptime_identity" \
   -H "Content-Type: application/json" \
   -H "Authorization: Basic {{authentication}}" \
   -d '[
@@ -128,7 +128,7 @@ transform:
 
 ```shell
 curl -X "POST" \
-  "http://localhost:4000/v1/events/pipelines/nginx_pipeline" \
+  "http://localhost:4000/v1/pipelines/nginx_pipeline" \
      -H 'Authorization: Basic {{authentication}}' \
      -F "file=@pipeline.yaml"
 ```
@@ -149,7 +149,7 @@ curl -X "POST" \
 
 ```shell
 curl -X POST \
-  "http://localhost:4000/v1/events/logs?db=public&table=custom_pipeline_logs&pipeline_name=nginx_pipeline" \
+  "http://localhost:4000/v1/ingest?db=public&table=custom_pipeline_logs&pipeline_name=nginx_pipeline" \
   -H "Content-Type: application/json" \
   -H "Authorization: Basic {{authentication}}" \
   -d '[

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/write-logs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/write-logs.md
@@ -14,7 +14,7 @@ description: 介绍如何通过 HTTP 接口使用指定的 Pipeline 将日志写
 您可以使用以下命令通过 HTTP 接口写入日志：
 
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>" \
      -H "Content-Type: application/x-ndjson" \
      -H "Authorization: Basic {{authentication}}" \
      -d "$<log-items>"
@@ -190,7 +190,7 @@ mysql> select * from pipeline_logs;
 
 设置如下的 URL 参数来指定自定义时间索引列：
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=public&table=pipeline_logs&pipeline_name=greptime_identity&custom_time_index=ts;epoch;s" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=public&table=pipeline_logs&pipeline_name=greptime_identity&custom_time_index=ts;epoch;s" \
      -H "Content-Type: application/json" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'[{"action": "login", "ts": 1742814853}]'
@@ -231,7 +231,7 @@ DESC pipeline_logs;
 以下是一个示例请求：
 
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=<db-name>&table=<table-name>&pipeline_name=greptime_identity&version=<pipeline-version>" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=<db-name>&table=<table-name>&pipeline_name=greptime_identity&version=<pipeline-version>" \
      -H "Content-Type: application/x-ndjson" \
      -H "Authorization: Basic {{authentication}}" \
      -H "x-greptime-pipeline-params: flatten_json_object=true" \
@@ -335,7 +335,7 @@ processors:
 如果你希望在写入日志时跳过错误，可以在 HTTP 请求的 query params 中添加 `skip_error` 参数。比如：
 
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>&skip_error=true" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>&skip_error=true" \
      -H "Content-Type: application/x-ndjson" \
      -H "Authorization: Basic {{authentication}}" \
      -d "$<log-items>"

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.16/reference/http-endpoints.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.16/reference/http-endpoints.md
@@ -222,9 +222,9 @@ is_strict_mode = false
 ## 日志写入端点
 
 - **路径**:
-  - `/v1/events/logs`
-  - `/v1/events/pipelines/{pipeline_name}`
-  - `/v1/events/pipelines/dryrun`
+  - `/v1/ingest`
+  - `/v1/pipelines/{pipeline_name}`
+  - `/v1/pipelines/dryrun`
 - **方法**:
   - `POST` 写入日志和添加 Pipeline。
   - `DELETE` 用于删除 Pipeline。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.16/user-guide/ingest-data/for-observability/fluent-bit.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.16/user-guide/ingest-data/for-observability/fluent-bit.md
@@ -19,7 +19,7 @@ description: 将 GreptimeDB 与 Fluent bit 集成以实现 Prometheus Remote Wri
     Match            *
     Host             greptimedb
     Port             4000
-    Uri              /v1/events/logs?db=public&table=your_table&pipeline_name=pipeline_if_any
+    Uri              /v1/ingest?db=public&table=your_table&pipeline_name=pipeline_if_any
     Format           json
     Json_date_key    scrape_timestamp
     Json_date_format iso8601

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.16/user-guide/ingest-data/for-observability/loki.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.16/user-guide/ingest-data/for-observability/loki.md
@@ -222,7 +222,7 @@ loki.write "greptime_loki" {
 2. [上传](/user-guide/logs/manage-pipelines.md#create-a-pipeline) pipeline 配置到数据库：
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/pp" -F "file=@pipeline.yaml"
+curl -X "POST" "http://localhost:4000/v1/pipelines/pp" -F "file=@pipeline.yaml"
 ```
 
 3. 启动 Alloy Docker 容器来处理日志：

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.16/user-guide/logs/manage-pipelines.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.16/user-guide/logs/manage-pipelines.md
@@ -22,7 +22,7 @@ GreptimeDB 提供了专用的 HTTP 接口用于创建 Pipeline。
 
 ```shell
 ## 上传 pipeline 文件。test 为 Pipeline 的名称
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/test" \
   -H "Authorization: Basic {{authentication}}" \
   -F "file=@pipeline.yaml"
 ```
@@ -35,7 +35,7 @@ curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
 
 ```shell
 ## test 为 Pipeline 的名称
-curl -X "DELETE" "http://localhost:4000/v1/events/pipelines/test?version=2024-06-27%2012%3A02%3A34.257312110Z" \
+curl -X "DELETE" "http://localhost:4000/v1/pipelines/test?version=2024-06-27%2012%3A02%3A34.257312110Z" \
   -H "Authorization: Basic {{authentication}}"
 ```
 
@@ -47,13 +47,13 @@ curl -X "DELETE" "http://localhost:4000/v1/events/pipelines/test?version=2024-06
 
 ```shell
 ## test 是 Pipeline 的名称，该查询将返回最新版本的 Pipeline。
-curl "http://localhost:4000/v1/events/pipelines/test" \
+curl "http://localhost:4000/v1/pipelines/test" \
   -H "Authorization: Basic {{authentication}}"
 ```
 
 ```shell
 ## 如果你想查询某个 Pipeline 的历史版本，可以在 URL 中添加 `version` 参数
-curl "http://localhost:4000/v1/events/pipelines/test?version=2025-04-01%2006%3A58%3A31.335251882%2B0000" \
+curl "http://localhost:4000/v1/pipelines/test?version=2025-04-01%2006%3A58%3A31.335251882%2B0000" \
   -H "Authorization: Basic {{authentication}}"
 ```
 
@@ -193,7 +193,7 @@ Readable timestamp (UTC): 2024-06-27 12:02:34.257312110Z
 在创建 Pipeline 的时候你可能会遇到错误，例如使用如下配置创建 Pipeline：
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/test" \
      -H "Content-Type: application/x-yaml" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'processors:
@@ -229,7 +229,7 @@ Pipeline 配置存在错误。`gsub` processor 期望 `replacement` 字段为字
 因此，你需要修改 `gsub` processor 的配置，将 `replacement` 字段的值更改为字符串类型。
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/test" \
      -H "Content-Type: application/x-yaml" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'processors:
@@ -263,7 +263,7 @@ transform:
 **此接口仅仅用于测试 Pipeline 的处理结果，不会将日志写入到 GreptimeDB 中。**
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/dryrun?pipeline_name=test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/dryrun?pipeline_name=test" \
      -H "Content-Type: application/json" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'{"message": 1998.08,"time":"2024-05-25 20:16:37.217"}'
@@ -275,7 +275,7 @@ curl -X "POST" "http://localhost:4000/v1/events/pipelines/dryrun?pipeline_name=t
 我们再将 message 字段的值修改为字符串类型，然后再次测试该 Pipeline。
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/dryrun?pipeline_name=test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/dryrun?pipeline_name=test" \
      -H "Content-Type: application/json" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'{"message": "1998.08","time":"2024-05-25 20:16:37.217"}'

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.16/user-guide/logs/quick-start.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.16/user-guide/logs/quick-start.md
@@ -22,7 +22,7 @@ GreptimeDB 提供了一个内置 pipeline `greptime_identity` 用于处理 JSON 
 
 ```shell
 curl -X POST \
-  "http://localhost:4000/v1/events/logs?db=public&table=pipeline_logs&pipeline_name=greptime_identity" \
+  "http://localhost:4000/v1/ingest?db=public&table=pipeline_logs&pipeline_name=greptime_identity" \
   -H "Content-Type: application/json" \
   -H "Authorization: Basic {{authentication}}" \
   -d '[
@@ -128,7 +128,7 @@ transform:
 
 ```shell
 curl -X "POST" \
-  "http://localhost:4000/v1/events/pipelines/nginx_pipeline" \
+  "http://localhost:4000/v1/pipelines/nginx_pipeline" \
      -H 'Authorization: Basic {{authentication}}' \
      -F "file=@pipeline.yaml"
 ```
@@ -149,7 +149,7 @@ curl -X "POST" \
 
 ```shell
 curl -X POST \
-  "http://localhost:4000/v1/events/logs?db=public&table=custom_pipeline_logs&pipeline_name=nginx_pipeline" \
+  "http://localhost:4000/v1/ingest?db=public&table=custom_pipeline_logs&pipeline_name=nginx_pipeline" \
   -H "Content-Type: application/json" \
   -H "Authorization: Basic {{authentication}}" \
   -d '[

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.16/user-guide/logs/write-logs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.16/user-guide/logs/write-logs.md
@@ -14,7 +14,7 @@ description: 介绍如何通过 HTTP 接口使用指定的 Pipeline 将日志写
 您可以使用以下命令通过 HTTP 接口写入日志：
 
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>" \
      -H "Content-Type: application/x-ndjson" \
      -H "Authorization: Basic {{authentication}}" \
      -d "$<log-items>"
@@ -190,7 +190,7 @@ mysql> select * from pipeline_logs;
 
 设置如下的 URL 参数来指定自定义时间索引列：
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=public&table=pipeline_logs&pipeline_name=greptime_identity&custom_time_index=ts;epoch;s" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=public&table=pipeline_logs&pipeline_name=greptime_identity&custom_time_index=ts;epoch;s" \
      -H "Content-Type: application/json" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'[{"action": "login", "ts": 1742814853}]'
@@ -231,7 +231,7 @@ DESC pipeline_logs;
 以下是一个示例请求：
 
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=<db-name>&table=<table-name>&pipeline_name=greptime_identity&version=<pipeline-version>" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=<db-name>&table=<table-name>&pipeline_name=greptime_identity&version=<pipeline-version>" \
      -H "Content-Type: application/x-ndjson" \
      -H "Authorization: Basic {{authentication}}" \
      -H "x-greptime-pipeline-params: flatten_json_object=true" \
@@ -335,7 +335,7 @@ processors:
 如果你希望在写入日志时跳过错误，可以在 HTTP 请求的 query params 中添加 `skip_error` 参数。比如：
 
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>&skip_error=true" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>&skip_error=true" \
      -H "Content-Type: application/x-ndjson" \
      -H "Authorization: Basic {{authentication}}" \
      -d "$<log-items>"

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.17/greptimecloud/integrations/fluent-bit.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.17/greptimecloud/integrations/fluent-bit.md
@@ -17,7 +17,7 @@ Fluent Bit 可以配置为使用 HTTP 协议将日志发送到 GreptimeCloud。�
     Match            *
     Host             <host>
     Port             443
-    Uri              /v1/events/logs?db=<dbname>&table=<table_name>&pipeline_name=<pipeline_name>
+    Uri              /v1/ingest?db=<dbname>&table=<table_name>&pipeline_name=<pipeline_name>
     Format           json
     Json_date_key    scrape_timestamp
     Json_date_format iso8601

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.17/reference/http-endpoints.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.17/reference/http-endpoints.md
@@ -222,9 +222,9 @@ is_strict_mode = false
 ## 日志写入端点
 
 - **路径**:
-  - `/v1/events/logs`
-  - `/v1/events/pipelines/{pipeline_name}`
-  - `/v1/events/pipelines/dryrun`
+  - `/v1/ingest`
+  - `/v1/pipelines/{pipeline_name}`
+  - `/v1/pipelines/dryrun`
 - **方法**:
   - `POST` 写入日志和添加 Pipeline。
   - `DELETE` 用于删除 Pipeline。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.17/user-guide/ingest-data/for-observability/fluent-bit.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.17/user-guide/ingest-data/for-observability/fluent-bit.md
@@ -19,7 +19,7 @@ description: 将 GreptimeDB 与 Fluent bit 集成以实现 Prometheus Remote Wri
     Match            *
     Host             greptimedb
     Port             4000
-    Uri              /v1/events/logs?db=public&table=your_table&pipeline_name=pipeline_if_any
+    Uri              /v1/ingest?db=public&table=your_table&pipeline_name=pipeline_if_any
     Format           json
     Json_date_key    scrape_timestamp
     Json_date_format iso8601

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.17/user-guide/ingest-data/for-observability/loki.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.17/user-guide/ingest-data/for-observability/loki.md
@@ -222,7 +222,7 @@ loki.write "greptime_loki" {
 2. [上传](/user-guide/logs/manage-pipelines.md#create-a-pipeline) pipeline 配置到数据库：
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/pp" -F "file=@pipeline.yaml"
+curl -X "POST" "http://localhost:4000/v1/pipelines/pp" -F "file=@pipeline.yaml"
 ```
 
 3. 启动 Alloy Docker 容器来处理日志：

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.17/user-guide/logs/manage-pipelines.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.17/user-guide/logs/manage-pipelines.md
@@ -22,7 +22,7 @@ GreptimeDB 提供了专用的 HTTP 接口用于创建 Pipeline。
 
 ```shell
 ## 上传 pipeline 文件。test 为 Pipeline 的名称
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/test" \
   -H "Authorization: Basic {{authentication}}" \
   -F "file=@pipeline.yaml"
 ```
@@ -35,7 +35,7 @@ curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
 
 ```shell
 ## test 为 Pipeline 的名称
-curl -X "DELETE" "http://localhost:4000/v1/events/pipelines/test?version=2024-06-27%2012%3A02%3A34.257312110Z" \
+curl -X "DELETE" "http://localhost:4000/v1/pipelines/test?version=2024-06-27%2012%3A02%3A34.257312110Z" \
   -H "Authorization: Basic {{authentication}}"
 ```
 
@@ -47,13 +47,13 @@ curl -X "DELETE" "http://localhost:4000/v1/events/pipelines/test?version=2024-06
 
 ```shell
 ## test 是 Pipeline 的名称，该查询将返回最新版本的 Pipeline。
-curl "http://localhost:4000/v1/events/pipelines/test" \
+curl "http://localhost:4000/v1/pipelines/test" \
   -H "Authorization: Basic {{authentication}}"
 ```
 
 ```shell
 ## 如果你想查询某个 Pipeline 的历史版本，可以在 URL 中添加 `version` 参数
-curl "http://localhost:4000/v1/events/pipelines/test?version=2025-04-01%2006%3A58%3A31.335251882%2B0000" \
+curl "http://localhost:4000/v1/pipelines/test?version=2025-04-01%2006%3A58%3A31.335251882%2B0000" \
   -H "Authorization: Basic {{authentication}}"
 ```
 
@@ -193,7 +193,7 @@ Readable timestamp (UTC): 2024-06-27 12:02:34.257312110Z
 在创建 Pipeline 的时候你可能会遇到错误，例如使用如下配置创建 Pipeline：
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/test" \
      -H "Content-Type: application/x-yaml" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'processors:
@@ -229,7 +229,7 @@ Pipeline 配置存在错误。`gsub` processor 期望 `replacement` 字段为字
 因此，你需要修改 `gsub` processor 的配置，将 `replacement` 字段的值更改为字符串类型。
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/test" \
      -H "Content-Type: application/x-yaml" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'processors:
@@ -263,7 +263,7 @@ transform:
 **此接口仅仅用于测试 Pipeline 的处理结果，不会将日志写入到 GreptimeDB 中。**
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/dryrun?pipeline_name=test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/dryrun?pipeline_name=test" \
      -H "Content-Type: application/json" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'{"message": 1998.08,"time":"2024-05-25 20:16:37.217"}'
@@ -275,7 +275,7 @@ curl -X "POST" "http://localhost:4000/v1/events/pipelines/dryrun?pipeline_name=t
 我们再将 message 字段的值修改为字符串类型，然后再次测试该 Pipeline。
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/dryrun?pipeline_name=test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/dryrun?pipeline_name=test" \
      -H "Content-Type: application/json" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'{"message": "1998.08","time":"2024-05-25 20:16:37.217"}'

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.17/user-guide/logs/quick-start.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.17/user-guide/logs/quick-start.md
@@ -22,7 +22,7 @@ GreptimeDB 提供了一个内置 pipeline `greptime_identity` 用于处理 JSON 
 
 ```shell
 curl -X POST \
-  "http://localhost:4000/v1/events/logs?db=public&table=pipeline_logs&pipeline_name=greptime_identity" \
+  "http://localhost:4000/v1/ingest?db=public&table=pipeline_logs&pipeline_name=greptime_identity" \
   -H "Content-Type: application/json" \
   -H "Authorization: Basic {{authentication}}" \
   -d '[
@@ -128,7 +128,7 @@ transform:
 
 ```shell
 curl -X "POST" \
-  "http://localhost:4000/v1/events/pipelines/nginx_pipeline" \
+  "http://localhost:4000/v1/pipelines/nginx_pipeline" \
      -H 'Authorization: Basic {{authentication}}' \
      -F "file=@pipeline.yaml"
 ```
@@ -149,7 +149,7 @@ curl -X "POST" \
 
 ```shell
 curl -X POST \
-  "http://localhost:4000/v1/events/logs?db=public&table=custom_pipeline_logs&pipeline_name=nginx_pipeline" \
+  "http://localhost:4000/v1/ingest?db=public&table=custom_pipeline_logs&pipeline_name=nginx_pipeline" \
   -H "Content-Type: application/json" \
   -H "Authorization: Basic {{authentication}}" \
   -d '[

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.17/user-guide/logs/write-logs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.17/user-guide/logs/write-logs.md
@@ -14,7 +14,7 @@ description: 介绍如何通过 HTTP 接口使用指定的 Pipeline 将日志写
 您可以使用以下命令通过 HTTP 接口写入日志：
 
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>" \
      -H "Content-Type: application/x-ndjson" \
      -H "Authorization: Basic {{authentication}}" \
      -d "$<log-items>"
@@ -190,7 +190,7 @@ mysql> select * from pipeline_logs;
 
 设置如下的 URL 参数来指定自定义时间索引列：
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=public&table=pipeline_logs&pipeline_name=greptime_identity&custom_time_index=ts;epoch;s" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=public&table=pipeline_logs&pipeline_name=greptime_identity&custom_time_index=ts;epoch;s" \
      -H "Content-Type: application/json" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'[{"action": "login", "ts": 1742814853}]'
@@ -231,7 +231,7 @@ DESC pipeline_logs;
 以下是一个示例请求：
 
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=<db-name>&table=<table-name>&pipeline_name=greptime_identity&version=<pipeline-version>" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=<db-name>&table=<table-name>&pipeline_name=greptime_identity&version=<pipeline-version>" \
      -H "Content-Type: application/x-ndjson" \
      -H "Authorization: Basic {{authentication}}" \
      -H "x-greptime-pipeline-params: flatten_json_object=true" \
@@ -335,7 +335,7 @@ processors:
 如果你希望在写入日志时跳过错误，可以在 HTTP 请求的 query params 中添加 `skip_error` 参数。比如：
 
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>&skip_error=true" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>&skip_error=true" \
      -H "Content-Type: application/x-ndjson" \
      -H "Authorization: Basic {{authentication}}" \
      -d "$<log-items>"

--- a/versioned_docs/version-0.16/reference/http-endpoints.md
+++ b/versioned_docs/version-0.16/reference/http-endpoints.md
@@ -222,9 +222,9 @@ Refer to the original Prometheus documentation for more information on the [Prom
 ## Log Ingestion Endpoints
 
 - **Paths**:
-  - `/v1/events/logs`
-  - `/v1/events/pipelines/{pipeline_name}`
-  - `/v1/events/pipelines/dryrun`
+  - `/v1/ingest`
+  - `/v1/pipelines/{pipeline_name}`
+  - `/v1/pipelines/dryrun`
 - **Methods**:
   - `POST` for ingesting logs and adding pipelines.
   - `DELETE` for deleting pipelines.

--- a/versioned_docs/version-0.16/user-guide/ingest-data/for-observability/fluent-bit.md
+++ b/versioned_docs/version-0.16/user-guide/ingest-data/for-observability/fluent-bit.md
@@ -19,7 +19,7 @@ Using Fluent Bit's [HTTP Output Plugin](https://docs.fluentbit.io/manual/pipelin
     Match            *
     Host             greptimedb
     Port             4000
-    Uri              /v1/events/logs?db=public&table=your_table&pipeline_name=pipeline_if_any
+    Uri              /v1/ingest?db=public&table=your_table&pipeline_name=pipeline_if_any
     Format           json
     Json_date_key    scrape_timestamp
     Json_date_format iso8601

--- a/versioned_docs/version-0.16/user-guide/ingest-data/for-observability/loki.md
+++ b/versioned_docs/version-0.16/user-guide/ingest-data/for-observability/loki.md
@@ -222,7 +222,7 @@ In the `greptime_loki`, the `x-greptime-pipeline-name` header is added to indica
 2. [Upload](/user-guide/logs/manage-pipelines.md#create-a-pipeline) the pipeline configuration to the database using `curl`:
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/pp" -F "file=@pipeline.yaml"
+curl -X "POST" "http://localhost:4000/v1/pipelines/pp" -F "file=@pipeline.yaml"
 ```
 
 3. Start the Alloy Docker container to process the logs:

--- a/versioned_docs/version-0.16/user-guide/logs/manage-pipelines.md
+++ b/versioned_docs/version-0.16/user-guide/logs/manage-pipelines.md
@@ -21,7 +21,7 @@ Assuming you have prepared a pipeline configuration file `pipeline.yaml`, use th
 
 ```shell
 ## Upload the pipeline file. 'test' is the name of the pipeline
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/test" \
   -H "Authorization: Basic {{authentication}}" \
   -F "file=@pipeline.yaml"
 ```
@@ -34,7 +34,7 @@ You can use the following HTTP interface to delete a pipeline:
 
 ```shell
 ## 'test' is the name of the pipeline
-curl -X "DELETE" "http://localhost:4000/v1/events/pipelines/test?version=2024-06-27%2012%3A02%3A34.257312110Z" \
+curl -X "DELETE" "http://localhost:4000/v1/pipelines/test?version=2024-06-27%2012%3A02%3A34.257312110Z" \
   -H "Authorization: Basic {{authentication}}"
 ```
 
@@ -46,13 +46,13 @@ Querying a pipeline with a name through HTTP interface as follow:
 
 ```shell
 ## 'test' is the name of the pipeline, it will return a pipeline with latest version if the pipeline named `test` exists.
-curl "http://localhost:4000/v1/events/pipelines/test" \
+curl "http://localhost:4000/v1/pipelines/test" \
   -H "Authorization: Basic {{authentication}}"
 ```
 
 ```shell
 ## with the version parameter, it will return the specify version pipeline.
-curl "http://localhost:4000/v1/events/pipelines/test?version=2025-04-01%2006%3A58%3A31.335251882%2B0000" \
+curl "http://localhost:4000/v1/pipelines/test?version=2025-04-01%2006%3A58%3A31.335251882%2B0000" \
   -H "Authorization: Basic {{authentication}}"
 ```
 
@@ -192,7 +192,7 @@ You may encounter errors when creating a Pipeline. For example, when creating a 
 
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/test" \
      -H "Content-Type: application/x-yaml" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'processors:
@@ -228,7 +228,7 @@ The pipeline configuration contains an error. The `gsub` Processor expects the `
 Therefore, We need to modify the configuration of the `gsub` Processor and change the value of the `replacement` field to a string type.
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/test" \
      -H "Content-Type: application/x-yaml" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'processors:
@@ -263,7 +263,7 @@ We can test the Pipeline using the `dryrun` interface. We will test it with erro
 
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/dryrun?pipeline_name=test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/dryrun?pipeline_name=test" \
      -H "Content-Type: application/json" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'{"message": 1998.08,"time":"2024-05-25 20:16:37.217"}'
@@ -275,7 +275,7 @@ The output indicates that the pipeline processing failed because the `gsub` Proc
 Let's change the value of the message field to a string type and test the pipeline again.
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/dryrun?pipeline_name=test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/dryrun?pipeline_name=test" \
      -H "Content-Type: application/json" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'{"message": "1998.08","time":"2024-05-25 20:16:37.217"}'

--- a/versioned_docs/version-0.16/user-guide/logs/quick-start.md
+++ b/versioned_docs/version-0.16/user-guide/logs/quick-start.md
@@ -22,7 +22,7 @@ GreptimeDB offers a built-in pipeline, `greptime_identity`, for handling JSON lo
 
 ```shell
 curl -X POST \
-  "http://localhost:4000/v1/events/logs?db=public&table=pipeline_logs&pipeline_name=greptime_identity" \
+  "http://localhost:4000/v1/ingest?db=public&table=pipeline_logs&pipeline_name=greptime_identity" \
   -H "Content-Type: application/json" \
   -H "Authorization: Basic {{authentication}}" \
   -d '[
@@ -133,7 +133,7 @@ Execute the following command to upload the configuration file:
 
 ```shell
 curl -X "POST" \
-  "http://localhost:4000/v1/events/pipelines/nginx_pipeline" \
+  "http://localhost:4000/v1/pipelines/nginx_pipeline" \
      -H 'Authorization: Basic {{authentication}}' \
      -F "file=@pipeline.yaml"
 ```
@@ -154,7 +154,7 @@ The following example writes logs to the `custom_pipeline_logs` table and uses t
 
 ```shell
 curl -X POST \
-  "http://localhost:4000/v1/events/logs?db=public&table=custom_pipeline_logs&pipeline_name=nginx_pipeline" \
+  "http://localhost:4000/v1/ingest?db=public&table=custom_pipeline_logs&pipeline_name=nginx_pipeline" \
   -H "Content-Type: application/json" \
   -H "Authorization: Basic {{authentication}}" \
   -d '[

--- a/versioned_docs/version-0.16/user-guide/logs/write-logs.md
+++ b/versioned_docs/version-0.16/user-guide/logs/write-logs.md
@@ -14,7 +14,7 @@ Before writing logs, please read the [Pipeline Configuration](pipeline-config.md
 You can use the following command to write logs via the HTTP interface:
 
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>" \
      -H "Content-Type: application/x-ndjson" \
      -H "Authorization: Basic {{authentication}}" \
      -d "$<log-items>"
@@ -190,7 +190,7 @@ Example of Incoming Log Data:
 
 To instruct the server to use ts as the time index, set the following query parameter in the HTTP header:
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=public&table=pipeline_logs&pipeline_name=greptime_identity&custom_time_index=ts;epoch;s" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=public&table=pipeline_logs&pipeline_name=greptime_identity&custom_time_index=ts;epoch;s" \
      -H "Content-Type: application/json" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'[{"action": "login", "ts": 1742814853}]'
@@ -231,7 +231,7 @@ If flattening a JSON object into a single-level structure is needed, add the `x-
 Here is a sample request:
 
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=<db-name>&table=<table-name>&pipeline_name=greptime_identity&version=<pipeline-version>" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=<db-name>&table=<table-name>&pipeline_name=greptime_identity&version=<pipeline-version>" \
      -H "Content-Type: application/x-ndjson" \
      -H "Authorization: Basic {{authentication}}" \
      -H "x-greptime-pipeline-params: flatten_json_object=true" \
@@ -338,7 +338,7 @@ mode](/user-guide/deployments-administration/performance-tuning/design-table.md#
 If you want to skip errors when writing logs, you can add the `skip_error` parameter to the HTTP request's query params. For example:
 
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>&skip_error=true" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>&skip_error=true" \
      -H "Content-Type: application/x-ndjson" \
      -H "Authorization: Basic {{authentication}}" \
      -d "$<log-items>"

--- a/versioned_docs/version-0.17/greptimecloud/integrations/fluent-bit.md
+++ b/versioned_docs/version-0.17/greptimecloud/integrations/fluent-bit.md
@@ -18,7 +18,7 @@ Fluent Bit can be configured to send logs to GreptimeCloud using the HTTP protoc
     Match            *
     Host             <host>
     Port             443
-    Uri              /v1/events/logs?db=<dbname>&table=<table_name>&pipeline_name=<pipeline_name>
+    Uri              /v1/ingest?db=<dbname>&table=<table_name>&pipeline_name=<pipeline_name>
     Format           json
     Json_date_key    scrape_timestamp
     Json_date_format iso8601

--- a/versioned_docs/version-0.17/reference/http-endpoints.md
+++ b/versioned_docs/version-0.17/reference/http-endpoints.md
@@ -222,9 +222,9 @@ Refer to the original Prometheus documentation for more information on the [Prom
 ## Log Ingestion Endpoints
 
 - **Paths**:
-  - `/v1/events/logs`
-  - `/v1/events/pipelines/{pipeline_name}`
-  - `/v1/events/pipelines/dryrun`
+  - `/v1/ingest`
+  - `/v1/pipelines/{pipeline_name}`
+  - `/v1/pipelines/dryrun`
 - **Methods**:
   - `POST` for ingesting logs and adding pipelines.
   - `DELETE` for deleting pipelines.

--- a/versioned_docs/version-0.17/user-guide/ingest-data/for-observability/fluent-bit.md
+++ b/versioned_docs/version-0.17/user-guide/ingest-data/for-observability/fluent-bit.md
@@ -19,7 +19,7 @@ Using Fluent Bit's [HTTP Output Plugin](https://docs.fluentbit.io/manual/pipelin
     Match            *
     Host             greptimedb
     Port             4000
-    Uri              /v1/events/logs?db=public&table=your_table&pipeline_name=pipeline_if_any
+    Uri              /v1/ingest?db=public&table=your_table&pipeline_name=pipeline_if_any
     Format           json
     Json_date_key    scrape_timestamp
     Json_date_format iso8601

--- a/versioned_docs/version-0.17/user-guide/ingest-data/for-observability/loki.md
+++ b/versioned_docs/version-0.17/user-guide/ingest-data/for-observability/loki.md
@@ -222,7 +222,7 @@ In the `greptime_loki`, the `x-greptime-pipeline-name` header is added to indica
 2. [Upload](/user-guide/logs/manage-pipelines.md#create-a-pipeline) the pipeline configuration to the database using `curl`:
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/pp" -F "file=@pipeline.yaml"
+curl -X "POST" "http://localhost:4000/v1/pipelines/pp" -F "file=@pipeline.yaml"
 ```
 
 3. Start the Alloy Docker container to process the logs:

--- a/versioned_docs/version-0.17/user-guide/logs/manage-pipelines.md
+++ b/versioned_docs/version-0.17/user-guide/logs/manage-pipelines.md
@@ -21,7 +21,7 @@ Assuming you have prepared a pipeline configuration file `pipeline.yaml`, use th
 
 ```shell
 ## Upload the pipeline file. 'test' is the name of the pipeline
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/test" \
   -H "Authorization: Basic {{authentication}}" \
   -F "file=@pipeline.yaml"
 ```
@@ -34,7 +34,7 @@ You can use the following HTTP interface to delete a pipeline:
 
 ```shell
 ## 'test' is the name of the pipeline
-curl -X "DELETE" "http://localhost:4000/v1/events/pipelines/test?version=2024-06-27%2012%3A02%3A34.257312110Z" \
+curl -X "DELETE" "http://localhost:4000/v1/pipelines/test?version=2024-06-27%2012%3A02%3A34.257312110Z" \
   -H "Authorization: Basic {{authentication}}"
 ```
 
@@ -46,13 +46,13 @@ Querying a pipeline with a name through HTTP interface as follow:
 
 ```shell
 ## 'test' is the name of the pipeline, it will return a pipeline with latest version if the pipeline named `test` exists.
-curl "http://localhost:4000/v1/events/pipelines/test" \
+curl "http://localhost:4000/v1/pipelines/test" \
   -H "Authorization: Basic {{authentication}}"
 ```
 
 ```shell
 ## with the version parameter, it will return the specify version pipeline.
-curl "http://localhost:4000/v1/events/pipelines/test?version=2025-04-01%2006%3A58%3A31.335251882%2B0000" \
+curl "http://localhost:4000/v1/pipelines/test?version=2025-04-01%2006%3A58%3A31.335251882%2B0000" \
   -H "Authorization: Basic {{authentication}}"
 ```
 
@@ -192,7 +192,7 @@ You may encounter errors when creating a Pipeline. For example, when creating a 
 
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/test" \
      -H "Content-Type: application/x-yaml" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'processors:
@@ -228,7 +228,7 @@ The pipeline configuration contains an error. The `gsub` Processor expects the `
 Therefore, We need to modify the configuration of the `gsub` Processor and change the value of the `replacement` field to a string type.
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/test" \
      -H "Content-Type: application/x-yaml" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'processors:
@@ -263,7 +263,7 @@ We can test the Pipeline using the `dryrun` interface. We will test it with erro
 
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/dryrun?pipeline_name=test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/dryrun?pipeline_name=test" \
      -H "Content-Type: application/json" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'{"message": 1998.08,"time":"2024-05-25 20:16:37.217"}'
@@ -275,7 +275,7 @@ The output indicates that the pipeline processing failed because the `gsub` Proc
 Let's change the value of the message field to a string type and test the pipeline again.
 
 ```bash
-curl -X "POST" "http://localhost:4000/v1/events/pipelines/dryrun?pipeline_name=test" \
+curl -X "POST" "http://localhost:4000/v1/pipelines/dryrun?pipeline_name=test" \
      -H "Content-Type: application/json" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'{"message": "1998.08","time":"2024-05-25 20:16:37.217"}'

--- a/versioned_docs/version-0.17/user-guide/logs/quick-start.md
+++ b/versioned_docs/version-0.17/user-guide/logs/quick-start.md
@@ -22,7 +22,7 @@ GreptimeDB offers a built-in pipeline, `greptime_identity`, for handling JSON lo
 
 ```shell
 curl -X POST \
-  "http://localhost:4000/v1/events/logs?db=public&table=pipeline_logs&pipeline_name=greptime_identity" \
+  "http://localhost:4000/v1/ingest?db=public&table=pipeline_logs&pipeline_name=greptime_identity" \
   -H "Content-Type: application/json" \
   -H "Authorization: Basic {{authentication}}" \
   -d '[
@@ -133,7 +133,7 @@ Execute the following command to upload the configuration file:
 
 ```shell
 curl -X "POST" \
-  "http://localhost:4000/v1/events/pipelines/nginx_pipeline" \
+  "http://localhost:4000/v1/pipelines/nginx_pipeline" \
      -H 'Authorization: Basic {{authentication}}' \
      -F "file=@pipeline.yaml"
 ```
@@ -154,7 +154,7 @@ The following example writes logs to the `custom_pipeline_logs` table and uses t
 
 ```shell
 curl -X POST \
-  "http://localhost:4000/v1/events/logs?db=public&table=custom_pipeline_logs&pipeline_name=nginx_pipeline" \
+  "http://localhost:4000/v1/ingest?db=public&table=custom_pipeline_logs&pipeline_name=nginx_pipeline" \
   -H "Content-Type: application/json" \
   -H "Authorization: Basic {{authentication}}" \
   -d '[

--- a/versioned_docs/version-0.17/user-guide/logs/write-logs.md
+++ b/versioned_docs/version-0.17/user-guide/logs/write-logs.md
@@ -14,7 +14,7 @@ Before writing logs, please read the [Pipeline Configuration](pipeline-config.md
 You can use the following command to write logs via the HTTP interface:
 
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>" \
      -H "Content-Type: application/x-ndjson" \
      -H "Authorization: Basic {{authentication}}" \
      -d "$<log-items>"
@@ -190,7 +190,7 @@ Example of Incoming Log Data:
 
 To instruct the server to use ts as the time index, set the following query parameter in the HTTP header:
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=public&table=pipeline_logs&pipeline_name=greptime_identity&custom_time_index=ts;epoch;s" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=public&table=pipeline_logs&pipeline_name=greptime_identity&custom_time_index=ts;epoch;s" \
      -H "Content-Type: application/json" \
      -H "Authorization: Basic {{authentication}}" \
      -d $'[{"action": "login", "ts": 1742814853}]'
@@ -231,7 +231,7 @@ If flattening a JSON object into a single-level structure is needed, add the `x-
 Here is a sample request:
 
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=<db-name>&table=<table-name>&pipeline_name=greptime_identity&version=<pipeline-version>" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=<db-name>&table=<table-name>&pipeline_name=greptime_identity&version=<pipeline-version>" \
      -H "Content-Type: application/x-ndjson" \
      -H "Authorization: Basic {{authentication}}" \
      -H "x-greptime-pipeline-params: flatten_json_object=true" \
@@ -338,7 +338,7 @@ mode](/user-guide/deployments-administration/performance-tuning/design-table.md#
 If you want to skip errors when writing logs, you can add the `skip_error` parameter to the HTTP request's query params. For example:
 
 ```shell
-curl -X "POST" "http://localhost:4000/v1/events/logs?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>&skip_error=true" \
+curl -X "POST" "http://localhost:4000/v1/ingest?db=<db-name>&table=<table-name>&pipeline_name=<pipeline-name>&version=<pipeline-version>&skip_error=true" \
      -H "Content-Type: application/x-ndjson" \
      -H "Authorization: Basic {{authentication}}" \
      -d "$<log-items>"


### PR DESCRIPTION
## What's Changed in this PR

The `/events` path is annotated deprecated after v0.11, but the docs are still using the old path.
This PR updates the path to the new one, and backports the change to v0.17 and v0.16


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
