### PR TITLE
fix: authentication helm chart value example

### DIFF
--- a/docs/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/docs/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -201,7 +201,7 @@ The Helm Chart does not enable User Provider mode authentication by default. You
 auth:
   enabled: true
   users:
-    - name: "admin"
+    - username: "admin"
       password: "admin"
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -201,7 +201,7 @@ Helm Chart 默认不启用 User Provider 模式的鉴权，你可以通过 `auth
 auth:
   enabled: true
   users:
-    - name: "admin"
+    - username: "admin"
       password: "admin"
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.12/user-guide/deployments/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.12/user-guide/deployments/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -201,7 +201,7 @@ Helm Chart 默认不启用 User Provider 模式的鉴权，你可以通过 `auth
 auth:
   enabled: true
   users:
-    - name: "admin"
+    - username: "admin"
       password: "admin"
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.13/user-guide/deployments/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.13/user-guide/deployments/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -201,7 +201,7 @@ Helm Chart 默认不启用 User Provider 模式的鉴权，你可以通过 `auth
 auth:
   enabled: true
   users:
-    - name: "admin"
+    - username: "admin"
       password: "admin"
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/deployments/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/deployments/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -201,7 +201,7 @@ Helm Chart 默认不启用 User Provider 模式的鉴权，你可以通过 `auth
 auth:
   enabled: true
   users:
-    - name: "admin"
+    - username: "admin"
       password: "admin"
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.15/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.15/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -201,7 +201,7 @@ Helm Chart 默认不启用 User Provider 模式的鉴权，你可以通过 `auth
 auth:
   enabled: true
   users:
-    - name: "admin"
+    - username: "admin"
       password: "admin"
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.16/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.16/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -201,7 +201,7 @@ Helm Chart 默认不启用 User Provider 模式的鉴权，你可以通过 `auth
 auth:
   enabled: true
   users:
-    - name: "admin"
+    - username: "admin"
       password: "admin"
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.17/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.17/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -201,7 +201,7 @@ Helm Chart 默认不启用 User Provider 模式的鉴权，你可以通过 `auth
 auth:
   enabled: true
   users:
-    - name: "admin"
+    - username: "admin"
       password: "admin"
 ```
 

--- a/versioned_docs/version-0.12/user-guide/deployments/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/versioned_docs/version-0.12/user-guide/deployments/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -201,7 +201,7 @@ The Helm Chart does not enable User Provider mode authentication by default. You
 auth:
   enabled: true
   users:
-    - name: "admin"
+    - username: "admin"
       password: "admin"
 ```
 

--- a/versioned_docs/version-0.13/user-guide/deployments/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/versioned_docs/version-0.13/user-guide/deployments/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -201,7 +201,7 @@ The Helm Chart does not enable User Provider mode authentication by default. You
 auth:
   enabled: true
   users:
-    - name: "admin"
+    - username: "admin"
       password: "admin"
 ```
 

--- a/versioned_docs/version-0.14/user-guide/deployments/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/versioned_docs/version-0.14/user-guide/deployments/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -201,7 +201,7 @@ The Helm Chart does not enable User Provider mode authentication by default. You
 auth:
   enabled: true
   users:
-    - name: "admin"
+    - username: "admin"
       password: "admin"
 ```
 

--- a/versioned_docs/version-0.15/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/versioned_docs/version-0.15/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -201,7 +201,7 @@ The Helm Chart does not enable User Provider mode authentication by default. You
 auth:
   enabled: true
   users:
-    - name: "admin"
+    - username: "admin"
       password: "admin"
 ```
 

--- a/versioned_docs/version-0.16/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/versioned_docs/version-0.16/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -201,7 +201,7 @@ The Helm Chart does not enable User Provider mode authentication by default. You
 auth:
   enabled: true
   users:
-    - name: "admin"
+    - username: "admin"
       password: "admin"
 ```
 

--- a/versioned_docs/version-0.17/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/versioned_docs/version-0.17/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -201,7 +201,7 @@ The Helm Chart does not enable User Provider mode authentication by default. You
 auth:
   enabled: true
   users:
-    - name: "admin"
+    - username: "admin"
       password: "admin"
 ```
 


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

According to the greptimedb-cluster Helm chart code, name of the user in auth block should be `username`, not `name`.

https://github.com/GreptimeTeam/helm-charts/blob/1843f2a53f02c0a4ffbf65b470996bf9a2bce404/charts/greptimedb-cluster/templates/users-auth-secret.yaml#L13


## Checklist

- [x] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
