### PR TITLE
feat: i18n link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,7 +214,7 @@ For an example, please refer to the [gRPC-SDK dictionary](docs/user-guide/ingest
 ## Build and preview the docs locally
 
 We highly encourage you to preview your changes locally before submitting a pull request.
-This project requires Node.js version 18.0.0 or higher.
+This project requires Node.js version 20.x or higher.
 Use `npm install -g pnpm` to install package manager, and start a local server with the following commands:
 
 ```shell

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,7 +230,7 @@ To preview the documentation in a specific language, use command `pnpm run start
 For example:
 
 ```cmd
-pnpm run start --locale zh
+DOC_LANG=zh pnpm start
 ```
 
 ## PR title check

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -160,7 +160,15 @@ const config: Config = {
           sidebarPath: './sidebars.ts',
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl: 'https://github.com/GreptimeTeam/docs/blob/main',
+          editUrl: ({ locale, version, versionDocsDirPath, docPath }) => {
+            if (locale === 'zh') {
+              // For Chinese locale, files are directly under version-{version} folder
+              const versionDir = version === 'current' ? 'current' : `version-${version}`;
+              return `https://github.com/GreptimeTeam/docs/edit/main/i18n/zh/docusaurus-plugin-content-docs/${versionDir}/${docPath}`;
+            }
+            // For English locale, use the default Docusaurus behavior
+            return `https://github.com/GreptimeTeam/docs/blob/main`;
+          },
           routeBasePath: '/',
           exclude: [
             'db-cloud-shared/**',

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -162,12 +162,12 @@ const config: Config = {
           // Remove this to remove the "edit this page" links.
           editUrl: ({ locale, version, versionDocsDirPath, docPath }) => {
             if (locale === 'zh') {
-              // For Chinese locale, files are directly under version-{version} folder
+              // Chinese locale: i18n folder, versioned by current|version-<x>
               const versionDir = version === 'current' ? 'current' : `version-${version}`;
               return `https://github.com/GreptimeTeam/docs/edit/main/i18n/zh/docusaurus-plugin-content-docs/${versionDir}/${docPath}`;
             }
-            // For English locale, use the default Docusaurus behavior
-            return `https://github.com/GreptimeTeam/docs/blob/main`;
+            // English locale: use Docusaurus-provided versionDocsDirPath
+            return `https://github.com/GreptimeTeam/docs/edit/main/${versionDocsDirPath}/${docPath}`;
           },
           routeBasePath: '/',
           exclude: [

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -160,8 +160,7 @@ const config: Config = {
           sidebarPath: './sidebars.ts',
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl:
-            'https://github.com/GreptimeTeam/docs/blob/main',
+          editUrl: 'https://github.com/GreptimeTeam/docs/blob/main',
           routeBasePath: '/',
           exclude: [
             'db-cloud-shared/**',
@@ -231,6 +230,21 @@ const config: Config = {
   trailingSlash: true,
   plugins: [
     ['docusaurus-biel', bielMetaMap[locale]],
+    function injectLocaleSwitchScript() {
+      return {
+        name: 'inject-locale-switch-script',
+        injectHtmlTags() {
+          return {
+            headTags: [
+              {
+                tagName: 'script',
+                attributes: { src: '/js/locale-switch.js' }
+              }
+            ]
+          };
+        }
+      };
+    }
   ],
 
   themeConfig: {
@@ -266,7 +280,7 @@ const config: Config = {
             {
               label: locale === 'en' ? '中文' : 'English',
               to: locale === 'en' ? 'https://docs.greptime.cn' : 'https://docs.greptime.com',
-              className: 'dropdown__link',
+              className: 'dropdown__link locale-switch-link',
             },
           ],
         },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
+    "start:zh": "DOC_LANG=zh pnpm start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/static/js/locale-switch.js
+++ b/static/js/locale-switch.js
@@ -1,0 +1,37 @@
+(function() {
+  if (typeof window === 'undefined') return;
+
+  function rewriteLocaleSwitchHref() {
+    var link = document.querySelector('.locale-switch-link');
+    if (!link) return;
+    try {
+      var current = new URL(window.location.href);
+      var target = new URL(link.href);
+      link.href = current.protocol + '//' + target.host + current.pathname + current.search + current.hash;
+    } catch (e) {
+      // ignore
+    }
+  }
+
+  // Intercept clicks on the locale switch link to rewrite URL immediately
+  function handleLocaleSwitchClick(event) {
+    var link = event.target.closest('.locale-switch-link');
+    if (!link) return;
+    
+    try {
+      var current = new URL(window.location.href);
+      var target = new URL(link.href);
+      var newUrl = current.protocol + '//' + target.host + current.pathname + current.search + current.hash;
+      
+      // Update the href immediately before navigation
+      link.href = newUrl;
+      console.log('Rewritten locale switch URL:', newUrl);
+    } catch (e) {
+      console.error('Error rewriting locale switch URL:', e);
+    }
+  }
+
+  // Set up click listener on document to catch all clicks
+  document.addEventListener('click', handleLocaleSwitchClick, true);
+  
+})();

--- a/static/js/locale-switch.js
+++ b/static/js/locale-switch.js
@@ -1,7 +1,7 @@
 (function() {
   if (typeof window === 'undefined') return;
 
-  function rewriteLocaleSwitchHref() {
+  function updateLocaleSwitchHref() {
     var link = document.querySelector('.locale-switch-link');
     if (!link) return;
     try {
@@ -13,25 +13,30 @@
     }
   }
 
+
   // Intercept clicks on the locale switch link to rewrite URL immediately
   function handleLocaleSwitchClick(event) {
     var link = event.target.closest('.locale-switch-link');
     if (!link) return;
     
     try {
-      var current = new URL(window.location.href);
-      var target = new URL(link.href);
-      var newUrl = current.protocol + '//' + target.host + current.pathname + current.search + current.hash;
-      
-      // Update the href immediately before navigation
-      link.href = newUrl;
-      console.log('Rewritten locale switch URL:', newUrl);
-    } catch (e) {
-      console.error('Error rewriting locale switch URL:', e);
-    }
+      updateLocaleSwitchHref();
+    } catch (e) {}
   }
 
   // Set up click listener on document to catch all clicks
   document.addEventListener('click', handleLocaleSwitchClick, true);
+  
+  // Initial update on load
+  setTimeout(updateLocaleSwitchHref, 1000);
+
+  if ('navigation' in window && window.navigation) {
+    // Update when URL changes due to SPA navigation
+    window.navigation.addEventListener('navigate', function () {
+      // run after route has settled
+      setTimeout(updateLocaleSwitchHref, 0);
+    });
+  }
+  
   
 })();


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->


*Describe the change in this PR*
#2131 #2132
* keep url when nav to other locale site.
because docusaurus swizzle  mark LocaleDropdown as unsafe, so not use React Component for implementation.
## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
