### PR TITLE
chore: add note for `meta_schema_name` field

### DIFF
--- a/docs/user-guide/deployments-administration/manage-metadata/configuration.md
+++ b/docs/user-guide/deployments-administration/manage-metadata/configuration.md
@@ -130,6 +130,7 @@ meta_table_name = "greptime_metakv"
 # In PostgreSQL 15 and later, the default public schema is restricted by default,
 # and non-superusers are no longer allowed to create tables in the public schema.
 # When encountering permission restrictions, use this parameter to specify a writable schema.
+# Note: This schema must be created manually before it can be used.
 meta_schema_name = "greptime_schema"
 
 # Optional: Advisory lock ID for election

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/manage-metadata/configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/manage-metadata/configuration.md
@@ -134,6 +134,7 @@ meta_election_lock_id = 1
 # 在 PostgreSQL 15 及更高版本中，默认的 public schema 通常被限制写入权限，
 # 非超级用户无法在 public schema 中创建表。
 # 当遇到权限限制时，可通过此参数指定一个具有写入权限的 schema。
+# 注意：该 schema 必须在使用前手动创建。
 meta_schema_name = "greptime_schema"
 
 [backend_tls]

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/deployments-administration/manage-metadata/configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/deployments-administration/manage-metadata/configuration.md
@@ -134,6 +134,7 @@ meta_election_lock_id = 1
 # 在 PostgreSQL 15 及更高版本中，默认的 public schema 通常被限制写入权限，
 # 非超级用户无法在 public schema 中创建表。
 # 当遇到权限限制时，可通过此参数指定一个具有写入权限的 schema。
+# 注意：该 schema 必须在使用前手动创建。
 meta_schema_name = "greptime_schema"
 
 [backend_tls]

--- a/versioned_docs/version-1.0/user-guide/deployments-administration/manage-metadata/configuration.md
+++ b/versioned_docs/version-1.0/user-guide/deployments-administration/manage-metadata/configuration.md
@@ -130,6 +130,7 @@ meta_table_name = "greptime_metakv"
 # In PostgreSQL 15 and later, the default public schema is restricted by default,
 # and non-superusers are no longer allowed to create tables in the public schema.
 # When encountering permission restrictions, use this parameter to specify a writable schema.
+# Note: This schema must be created manually before it can be used.
 meta_schema_name = "greptime_schema"
 
 # Optional: Advisory lock ID for election


### PR DESCRIPTION
## What's Changed in this PR

This PR adds a note for the meta_schema_name configuration field in the PostgreSQL backend documentation.

Added a note in both English and Chinese documentation clarifying that the schema specified by `meta_schema_name` must be created manually before it can be used.


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
