### PR TITLE
docs: remove obsolete Metasrv command line option

### DIFF
--- a/docs/reference/command-lines/metasrv.md
+++ b/docs/reference/command-lines/metasrv.md
@@ -24,7 +24,6 @@ greptime metasrv start --help
 | `--http-timeout <HTTP_TIMEOUT>`       | HTTP request timeout in seconds                                                                                                                                                                                                                                              |
 | `--selector <SELECTOR>`               | You can refer [selector-type](/contributor-guide/metasrv/selector.md#selector-type)                                                                                                                                                                                          |
 | `--store-addrs <STORE_ADDR>`          | Comma or space separated key-value storage server (default is etcd) address, used for storing metadata                                                                                                                                                                       |
-| `--use-memory-store`                  | Use memory store instead of etcd, for test purpose only                                                                                                                                                                                                                      |
 
 ## Examples
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/command-lines/metasrv.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/command-lines/metasrv.md
@@ -24,7 +24,6 @@ greptime metasrv start --help
 | `--http-timeout <HTTP_TIMEOUT>`       | HTTP 请求超时时间（秒）                                                                                                                            |
 | `--selector <SELECTOR>`               | 您可以参考 [selector-type](/contributor-guide/metasrv/selector.md#selector-type)                                                                   |
 | `--store-addrs <STORE_ADDR>`          | 逗号或空格分隔的键值存储服务器（默认是 etcd）地址，用于存储元数据                                                                                  |
-| `--use-memory-store`                  | 用内存存储而不是其他持久化的存储后端，仅用于测试目的                                                                                             |
 
 所有的 `addr` 类选项都是 `ip:port` 形式的字符串。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.0/reference/command-lines/metasrv.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.0/reference/command-lines/metasrv.md
@@ -24,7 +24,6 @@ greptime metasrv start --help
 | `--http-timeout <HTTP_TIMEOUT>`       | HTTP 请求超时时间（秒）                                                                                                                            |
 | `--selector <SELECTOR>`               | 您可以参考 [selector-type](/contributor-guide/metasrv/selector.md#selector-type)                                                                   |
 | `--store-addrs <STORE_ADDR>`          | 逗号或空格分隔的键值存储服务器（默认是 etcd）地址，用于存储元数据                                                                                  |
-| `--use-memory-store`                  | 用内存存储而不是其他持久化的存储后端，仅用于测试目的                                                                                             |
 
 所有的 `addr` 类选项都是 `ip:port` 形式的字符串。
 

--- a/versioned_docs/version-1.0/reference/command-lines/metasrv.md
+++ b/versioned_docs/version-1.0/reference/command-lines/metasrv.md
@@ -24,7 +24,6 @@ greptime metasrv start --help
 | `--http-timeout <HTTP_TIMEOUT>`       | HTTP request timeout in seconds                                                                                                                                                                                                                                              |
 | `--selector <SELECTOR>`               | You can refer [selector-type](/contributor-guide/metasrv/selector.md#selector-type)                                                                                                                                                                                          |
 | `--store-addrs <STORE_ADDR>`          | Comma or space separated key-value storage server (default is etcd) address, used for storing metadata                                                                                                                                                                       |
-| `--use-memory-store`                  | Use memory store instead of etcd, for test purpose only                                                                                                                                                                                                                      |
 
 ## Examples
 


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

close https://github.com/GreptimeTeam/docs/issues/2270


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
