### PR TITLE
docs: flow tql cte

### DIFF
--- a/docs/reference/sql/create.md
+++ b/docs/reference/sql/create.md
@@ -485,6 +485,27 @@ AS
 <SQL>;
 ```
 
+For `CREATE FLOW`, the query after `AS` can be a regular flow query or a TQL query. GreptimeDB also supports a strict TQL CTE form for cleaner flow definitions:
+
+```sql
+CREATE FLOW calc_rate_cte
+SINK TO rate_reqs
+EVAL INTERVAL '1m' AS
+WITH rate_data (ts, req_rate, host, job, instance) AS (
+    TQL EVAL (now() - '1m'::interval, now(), '30s')
+    rate(http_requests_total{job="my_service"}[1m])
+    AS req_rate
+)
+SELECT * FROM rate_data;
+```
+
+When using `WITH` in `CREATE FLOW`, the accepted shape is intentionally strict:
+
+- Only one CTE is allowed, and it must contain `TQL EVAL`.
+- The outer query must be exactly `SELECT * FROM <cte-name>`.
+- Additional projection, filtering, joins, ordering, or extra SQL CTEs are not supported.
+- If the CTE name is quoted, reference it with the same quoted name in the outer `SELECT`.
+
 For the statement to create or update a flow, please read the [flow management documents](/user-guide/flow-computation/manage-flow.md#create-a-flow).
 
 ## CREATE VIEW

--- a/docs/user-guide/flow-computation/continuous-aggregation.md
+++ b/docs/user-guide/flow-computation/continuous-aggregation.md
@@ -459,6 +459,31 @@ This Flow definition includes several key components:
 - **rate()**: TQL function that calculates the rate of change
 - **[1m]**: Defines a 1-minute lookback window for the rate calculation
 
+### Wrapping TQL with a CTE
+
+If you want a cleaner flow definition or need stable output column names, you can wrap `TQL EVAL` in a simple CTE inside `CREATE FLOW`:
+
+```sql
+CREATE FLOW calc_rate_cte
+SINK TO rate_reqs_cte
+EVAL INTERVAL '1m' AS
+WITH rate_data (ts, req_rate, host, job, instance) AS (
+    TQL EVAL (now() - '1m'::interval, now(), '30s')
+    rate(http_requests_total{job="my_service"}[1m])
+    AS req_rate
+)
+SELECT * FROM rate_data;
+```
+
+This pattern is useful when you want to rename columns before GreptimeDB infers the sink table schema. It is especially handy for TQL expressions whose generated value column names are verbose.
+
+The supported shape is intentionally limited:
+
+- Use exactly one TQL CTE.
+- End the flow query with `SELECT * FROM <cte-name>`.
+- Do not add `WHERE`, joins, extra projections, or additional CTEs around it.
+- If you quote the CTE name, keep the same quoted form in the outer query.
+
 ### Examining the Generated Sink Table
 
 You can inspect the automatically created sink table structure:

--- a/docs/user-guide/query-data/cte.md
+++ b/docs/user-guide/query-data/cte.md
@@ -181,11 +181,13 @@ SELECT * FROM cte_name;
 1. **Column naming**:
    - The time index column name varies depending on your table schema (e.g., `ts` for custom tables, `greptime_timestamp` for Prometheus remote write)
    - The value column name depends on the PromQL expression and may be unpredictable, so it's better to use value aliasing with `AS` in TQL to ensure predictable column names: `TQL EVAL (...) expression AS my_value`
-   - **Important**: Avoid using column aliases in CTE definition (e.g., `WITH cte_name (ts, val) AS (...)`) because TQL EVAL results can have variable column count and order, especially in Prometheus scenarios where tags can be dynamically added or removed
+   - **Important**: In general, avoid using column aliases in CTE definitions (for example, `WITH cte_name (ts, val) AS (...)`) because TQL EVAL results can have variable column count and order, especially in Prometheus scenarios where tags can be dynamically added or removed. They are best reserved for cases where the result shape is stable, such as a simple `CREATE FLOW` TQL CTE.
 
 2. **Supported commands**: Only `TQL EVAL` is supported within CTEs. `TQL ANALYZE` and `TQL EXPLAIN` cannot be used in CTEs.
 
 3. **Lookback parameter**: The optional fourth parameter controls the lookback duration (default: 5 minutes).
+
+4. **Using TQL CTEs in `CREATE FLOW`**: GreptimeDB supports `WITH ... AS (TQL EVAL ...)` in `CREATE FLOW`, but only in the simplest form: a single TQL CTE followed by `SELECT * FROM <cte-name>`. Extra SQL CTEs, filters, joins, or custom projections are not supported in flow definitions.
 
 ### Examples
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/create.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/create.md
@@ -490,6 +490,27 @@ AS
 <SQL>;
 ```
 
+对于 `CREATE FLOW`，`AS` 后面的查询既可以是常规 Flow 查询，也可以是 TQL 查询。GreptimeDB 现在还支持一种严格受限的 TQL CTE 写法，用来让 Flow 定义更清晰：
+
+```sql
+CREATE FLOW calc_rate_cte
+SINK TO rate_reqs
+EVAL INTERVAL '1m' AS
+WITH rate_data (ts, req_rate, host, job, instance) AS (
+    TQL EVAL (now() - '1m'::interval, now(), '30s')
+    rate(http_requests_total{job="my_service"}[1m])
+    AS req_rate
+)
+SELECT * FROM rate_data;
+```
+
+在 `CREATE FLOW` 中使用 `WITH` 时，当前仅支持一种刻意保持简单的形式：
+
+- 只能有一个 CTE，并且该 CTE 必须包含 `TQL EVAL`。
+- 外层查询必须严格是 `SELECT * FROM <cte-name>`。
+- 不支持额外的列投影、过滤、JOIN、排序，也不支持再混入其他 SQL CTE。
+- 如果 CTE 名称使用了引号，那么外层 `SELECT` 里也要用相同的带引号名称引用它。
+
 用于创建或更新 Flow 任务，请阅读[Flow 管理文档](/user-guide/flow-computation/manage-flow.md#创建-flow)。
 
 ## 创建 View

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/flow-computation/continuous-aggregation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/flow-computation/continuous-aggregation.md
@@ -450,6 +450,31 @@ TQL EVAL (now() - '1m'::interval, now(), '30s') rate(http_requests_total{job="my
 - **rate()**：计算变化率的 TQL 函数。
 - **[1m]**：定义速率计算的 1 分钟回溯窗口。
 
+### 用 CTE 包装 TQL
+
+如果你想让 Flow 定义更清晰，或者希望提前固定输出列名，可以在 `CREATE FLOW` 中用一个简单的 CTE 包装 `TQL EVAL`：
+
+```sql
+CREATE FLOW calc_rate_cte
+SINK TO rate_reqs_cte
+EVAL INTERVAL '1m' AS
+WITH rate_data (ts, req_rate, host, job, instance) AS (
+    TQL EVAL (now() - '1m'::interval, now(), '30s')
+    rate(http_requests_total{job="my_service"}[1m])
+    AS req_rate
+)
+SELECT * FROM rate_data;
+```
+
+当你希望在 GreptimeDB 推断 sink 表 schema 之前先重命名列时，这种写法会很有用，尤其适合值列名较长的 TQL 表达式。
+
+这个能力目前是刻意限制范围的：
+
+- 只能使用一个 TQL CTE。
+- Flow 查询必须以 `SELECT * FROM <cte-name>` 结束。
+- 不能再增加 `WHERE`、JOIN、额外投影或其他 CTE。
+- 如果 CTE 名称使用了引号，外层查询也要保持同样的带引号写法。
+
 ### 检查生成的 Sink 表
 
 你可以检查自动创建的 Sink 表结构：

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/query-data/cte.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/query-data/cte.md
@@ -180,11 +180,13 @@ SELECT * FROM cte_name;
 1. **列名**：
    - 时间索引列名取决于表结构（例如，自定义表使用 `ts`，Prometheus 远程写入的默认使用 `greptime_timestamp`）
    - 值的列名取决于 PromQL 表达式，可能无法预测，因此更推荐使用 TQL 中的 `AS` 进行值别名以确保可预测的值列名：`TQL EVAL (...) expression AS my_value`
-   - **重要**：避免在 CTE 定义中使用列别名（如 `WITH cte_name (ts, val) AS (...)`），因为 TQL EVAL 结果的列数量和顺序可能变化，特别是在 Prometheus 场景中标签可能动态添加或删除
+   - **重要**：一般情况下不建议在 CTE 定义中使用列别名（如 `WITH cte_name (ts, val) AS (...)`），因为 TQL EVAL 结果的列数量和顺序可能变化，特别是在 Prometheus 场景中标签可能动态添加或删除。更适合在结果列稳定的场景使用，例如简单的 `CREATE FLOW` TQL CTE。
 
 2. **支持的命令**：CTE 中仅支持 `TQL EVAL`。不能在 CTE 中使用 `TQL ANALYZE` 和 `TQL EXPLAIN`。
 
 3. **回溯参数**：可选的第四个参数控制回溯持续时间（默认：5 分钟）。
+
+4. **在 `CREATE FLOW` 中使用 TQL CTE**：GreptimeDB 支持在 `CREATE FLOW` 中写 `WITH ... AS (TQL EVAL ...)`，但只支持最简单的形式：单个 TQL CTE，后面紧跟 `SELECT * FROM <cte-name>`。Flow 定义里不支持额外 SQL CTE、过滤、JOIN 或自定义列投影。
 
 ### 示例
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.0/reference/sql/create.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.0/reference/sql/create.md
@@ -490,6 +490,27 @@ AS
 <SQL>;
 ```
 
+对于 `CREATE FLOW`，`AS` 后面的查询既可以是常规 Flow 查询，也可以是 TQL 查询。GreptimeDB 现在还支持一种严格受限的 TQL CTE 写法，用来让 Flow 定义更清晰：
+
+```sql
+CREATE FLOW calc_rate_cte
+SINK TO rate_reqs
+EVAL INTERVAL '1m' AS
+WITH rate_data (ts, req_rate, host, job, instance) AS (
+    TQL EVAL (now() - '1m'::interval, now(), '30s')
+    rate(http_requests_total{job="my_service"}[1m])
+    AS req_rate
+)
+SELECT * FROM rate_data;
+```
+
+在 `CREATE FLOW` 中使用 `WITH` 时，当前仅支持一种刻意保持简单的形式：
+
+- 只能有一个 CTE，并且该 CTE 必须包含 `TQL EVAL`。
+- 外层查询必须严格是 `SELECT * FROM <cte-name>`。
+- 不支持额外的列投影、过滤、JOIN、排序，也不支持再混入其他 SQL CTE。
+- 如果 CTE 名称使用了引号，那么外层 `SELECT` 里也要用相同的带引号名称引用它。
+
 用于创建或更新 Flow 任务，请阅读[Flow 管理文档](/user-guide/flow-computation/manage-flow.md#创建-flow)。
 
 ## 创建 View

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/flow-computation/continuous-aggregation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/flow-computation/continuous-aggregation.md
@@ -450,6 +450,31 @@ TQL EVAL (now() - '1m'::interval, now(), '30s') rate(http_requests_total{job="my
 - **rate()**：计算变化率的 TQL 函数。
 - **[1m]**：定义速率计算的 1 分钟回溯窗口。
 
+### 用 CTE 包装 TQL
+
+如果你想让 Flow 定义更清晰，或者希望提前固定输出列名，可以在 `CREATE FLOW` 中用一个简单的 CTE 包装 `TQL EVAL`：
+
+```sql
+CREATE FLOW calc_rate_cte
+SINK TO rate_reqs_cte
+EVAL INTERVAL '1m' AS
+WITH rate_data (ts, req_rate, host, job, instance) AS (
+    TQL EVAL (now() - '1m'::interval, now(), '30s')
+    rate(http_requests_total{job="my_service"}[1m])
+    AS req_rate
+)
+SELECT * FROM rate_data;
+```
+
+当你希望在 GreptimeDB 推断 sink 表 schema 之前先重命名列时，这种写法会很有用，尤其适合值列名较长的 TQL 表达式。
+
+这个能力目前是刻意限制范围的：
+
+- 只能使用一个 TQL CTE。
+- Flow 查询必须以 `SELECT * FROM <cte-name>` 结束。
+- 不能再增加 `WHERE`、JOIN、额外投影或其他 CTE。
+- 如果 CTE 名称使用了引号，外层查询也要保持同样的带引号写法。
+
 ### 检查生成的 Sink 表
 
 你可以检查自动创建的 Sink 表结构：

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/query-data/cte.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/query-data/cte.md
@@ -180,11 +180,13 @@ SELECT * FROM cte_name;
 1. **列名**：
    - 时间索引列名取决于表结构（例如，自定义表使用 `ts`，Prometheus 远程写入的默认使用 `greptime_timestamp`）
    - 值的列名取决于 PromQL 表达式，可能无法预测，因此更推荐使用 TQL 中的 `AS` 进行值别名以确保可预测的值列名：`TQL EVAL (...) expression AS my_value`
-   - **重要**：避免在 CTE 定义中使用列别名（如 `WITH cte_name (ts, val) AS (...)`），因为 TQL EVAL 结果的列数量和顺序可能变化，特别是在 Prometheus 场景中标签可能动态添加或删除
+   - **重要**：一般情况下不建议在 CTE 定义中使用列别名（如 `WITH cte_name (ts, val) AS (...)`），因为 TQL EVAL 结果的列数量和顺序可能变化，特别是在 Prometheus 场景中标签可能动态添加或删除。更适合在结果列稳定的场景使用，例如简单的 `CREATE FLOW` TQL CTE。
 
 2. **支持的命令**：CTE 中仅支持 `TQL EVAL`。不能在 CTE 中使用 `TQL ANALYZE` 和 `TQL EXPLAIN`。
 
 3. **回溯参数**：可选的第四个参数控制回溯持续时间（默认：5 分钟）。
+
+4. **在 `CREATE FLOW` 中使用 TQL CTE**：GreptimeDB 支持在 `CREATE FLOW` 中写 `WITH ... AS (TQL EVAL ...)`，但只支持最简单的形式：单个 TQL CTE，后面紧跟 `SELECT * FROM <cte-name>`。Flow 定义里不支持额外 SQL CTE、过滤、JOIN 或自定义列投影。
 
 ### 示例
 

--- a/versioned_docs/version-1.0/reference/sql/create.md
+++ b/versioned_docs/version-1.0/reference/sql/create.md
@@ -485,6 +485,27 @@ AS
 <SQL>;
 ```
 
+For `CREATE FLOW`, the query after `AS` can be a regular flow query or a TQL query. GreptimeDB also supports a strict TQL CTE form for cleaner flow definitions:
+
+```sql
+CREATE FLOW calc_rate_cte
+SINK TO rate_reqs
+EVAL INTERVAL '1m' AS
+WITH rate_data (ts, req_rate, host, job, instance) AS (
+    TQL EVAL (now() - '1m'::interval, now(), '30s')
+    rate(http_requests_total{job="my_service"}[1m])
+    AS req_rate
+)
+SELECT * FROM rate_data;
+```
+
+When using `WITH` in `CREATE FLOW`, the accepted shape is intentionally strict:
+
+- Only one CTE is allowed, and it must contain `TQL EVAL`.
+- The outer query must be exactly `SELECT * FROM <cte-name>`.
+- Additional projection, filtering, joins, ordering, or extra SQL CTEs are not supported.
+- If the CTE name is quoted, reference it with the same quoted name in the outer `SELECT`.
+
 For the statement to create or update a flow, please read the [flow management documents](/user-guide/flow-computation/manage-flow.md#create-a-flow).
 
 ## CREATE VIEW

--- a/versioned_docs/version-1.0/user-guide/flow-computation/continuous-aggregation.md
+++ b/versioned_docs/version-1.0/user-guide/flow-computation/continuous-aggregation.md
@@ -459,6 +459,31 @@ This Flow definition includes several key components:
 - **rate()**: TQL function that calculates the rate of change
 - **[1m]**: Defines a 1-minute lookback window for the rate calculation
 
+### Wrapping TQL with a CTE
+
+If you want a cleaner flow definition or need stable output column names, you can wrap `TQL EVAL` in a simple CTE inside `CREATE FLOW`:
+
+```sql
+CREATE FLOW calc_rate_cte
+SINK TO rate_reqs_cte
+EVAL INTERVAL '1m' AS
+WITH rate_data (ts, req_rate, host, job, instance) AS (
+    TQL EVAL (now() - '1m'::interval, now(), '30s')
+    rate(http_requests_total{job="my_service"}[1m])
+    AS req_rate
+)
+SELECT * FROM rate_data;
+```
+
+This pattern is useful when you want to rename columns before GreptimeDB infers the sink table schema. It is especially handy for TQL expressions whose generated value column names are verbose.
+
+The supported shape is intentionally limited:
+
+- Use exactly one TQL CTE.
+- End the flow query with `SELECT * FROM <cte-name>`.
+- Do not add `WHERE`, joins, extra projections, or additional CTEs around it.
+- If you quote the CTE name, keep the same quoted form in the outer query.
+
 ### Examining the Generated Sink Table
 
 You can inspect the automatically created sink table structure:

--- a/versioned_docs/version-1.0/user-guide/query-data/cte.md
+++ b/versioned_docs/version-1.0/user-guide/query-data/cte.md
@@ -181,11 +181,13 @@ SELECT * FROM cte_name;
 1. **Column naming**:
    - The time index column name varies depending on your table schema (e.g., `ts` for custom tables, `greptime_timestamp` for Prometheus remote write)
    - The value column name depends on the PromQL expression and may be unpredictable, so it's better to use value aliasing with `AS` in TQL to ensure predictable column names: `TQL EVAL (...) expression AS my_value`
-   - **Important**: Avoid using column aliases in CTE definition (e.g., `WITH cte_name (ts, val) AS (...)`) because TQL EVAL results can have variable column count and order, especially in Prometheus scenarios where tags can be dynamically added or removed
+   - **Important**: In general, avoid using column aliases in CTE definitions (for example, `WITH cte_name (ts, val) AS (...)`) because TQL EVAL results can have variable column count and order, especially in Prometheus scenarios where tags can be dynamically added or removed. They are best reserved for cases where the result shape is stable, such as a simple `CREATE FLOW` TQL CTE.
 
 2. **Supported commands**: Only `TQL EVAL` is supported within CTEs. `TQL ANALYZE` and `TQL EXPLAIN` cannot be used in CTEs.
 
 3. **Lookback parameter**: The optional fourth parameter controls the lookback duration (default: 5 minutes).
+
+4. **Using TQL CTEs in `CREATE FLOW`**: GreptimeDB supports `WITH ... AS (TQL EVAL ...)` in `CREATE FLOW`, but only in the simplest form: a single TQL CTE followed by `SELECT * FROM <cte-name>`. Extra SQL CTEs, filters, joins, or custom projections are not supported in flow definitions.
 
 ### Examples
 


### PR DESCRIPTION
## What's Changed in this PR

This PR documents the new `CREATE FLOW` capability introduced in GreptimeDB PR `greptimedb#7702`: using a simple TQL CTE in flow definitions, for example `WITH ... AS (TQL EVAL ...) SELECT * FROM ...`.

The English docs in this PR now cover:
- the new `CREATE FLOW` syntax shape for TQL CTEs;
- a practical flow example showing how to wrap `TQL EVAL` in a CTE;
- the intended restrictions of this feature, including that only the simplest single-TQL-CTE form is supported in flows.

Updated pages:
- `docs/reference/sql/create.md`
- `docs/user-guide/flow-computation/continuous-aggregation.md`
- `docs/user-guide/query-data/cte.md`

Notes:
- This PR currently updates the English docs only.
- Localized docs will be updated in a follow-up change after the English wording is finalized.

## Checklist

- [x] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [x] This change requires follow-up update in localized docs.
