### PR TITLE
fix: protocols, integrations and ingestions

### DIFF
--- a/docs/user-guide/ingest-data/for-iot/grpc-sdks/go.md
+++ b/docs/user-guide/ingest-data/for-iot/grpc-sdks/go.md
@@ -252,7 +252,7 @@ affected, err := cli.CloseStream(ctx)
 
 ## Insert data in JSON type
 
-GreptimeDB supports storing complex data structures using [JSON type data](/reference/sql/data-types.md#json-type).
+GreptimeDB supports storing complex data structures using [JSON type data](/reference/sql/data-types.md#json-type-experimental).
 With this ingester library, you can insert JSON data using string values.
 For instance, if you have a table named `sensor_readings` and wish to add a JSON column named `attributes`,
 refer to the following code snippet.

--- a/docs/user-guide/ingest-data/for-iot/grpc-sdks/java.md
+++ b/docs/user-guide/ingest-data/for-iot/grpc-sdks/java.md
@@ -83,7 +83,7 @@ This client offers multiple ingestion methods optimized for various performance 
 Make sure that your system has JDK 8 or later installed. For more information on how to
 check your version of Java and install the JDK, see the [Oracle Overview of JDK Installation documentation](https://www.oracle.com/java/technologies/javase-downloads.html)
 
-2. Add GreptiemDB Java SDK as a Dependency
+2. Add GreptimeDB Java SDK as a Dependency
 
 If you are using [Maven](https://maven.apache.org/), add the following to your pom.xml
 dependencies list:
@@ -168,7 +168,7 @@ table.complete();
 CompletableFuture<Result<WriteOk, Err>> future = client.write(table);
 ```
 
-GreptimeDB supports storing complex data structures using [JSON type data](/reference/sql/data-types.md#json-type). You can define JSON columns in your table schema and insert data using Map objects:
+GreptimeDB supports storing complex data structures using [JSON type data](/reference/sql/data-types.md#json-type-experimental). You can define JSON columns in your table schema and insert data using Map objects:
 
 ```java
 // Construct the table schema for sensor_readings
@@ -183,7 +183,8 @@ TableSchema sensorReadings = TableSchema.newBuilder("sensor_readings")
 // Use map to insert JSON data
 Map<String, Object> attr = new HashMap<>();
 attr.put("location", "factory-1");
-sensorReadings.addRow(<other-column-values>... , attr);
+Table table = Table.from(sensorReadings);
+table.addRow(<other-column-values>... , attr);
 ```
 
 ##### TableSchema
@@ -341,7 +342,7 @@ BulkWrite.Config cfg = BulkWrite.Config.newBuilder()
         .allocatorInitReservation(64 * 1024 * 1024L) // Customize memory allocation: 64MB initial reservation
         .allocatorMaxAllocation(4 * 1024 * 1024 * 1024L) // Customize memory allocation: 4GB max allocation
         .timeoutMsPerMessage(60 * 1000) // 60 seconds timeout per request
-        .maxRequestsInFlight(8) // Concurrency Control: Configure with 10 maximum in-flight requests
+        .maxRequestsInFlight(8) // Concurrency Control: Configure with 8 maximum in-flight requests
         .build();
 // Enable Zstd compression
 Context ctx = Context.newDefault().withCompression(Compression.Zstd);

--- a/docs/user-guide/ingest-data/for-observability/loki.md
+++ b/docs/user-guide/ingest-data/for-observability/loki.md
@@ -72,13 +72,14 @@ The Loki logs data model is mapped to the GreptimeDB data model according to the
 
 ```sql
 DESC loki_demo_logs;
-+--------------------+---------------------+------+------+---------+---------------+
-| Column             | Type                | Key  | Null | Default | Semantic Type |
-+--------------------+---------------------+------+------+---------+---------------+
-| greptime_timestamp | TimestampNanosecond | PRI  | NO   |         | TIMESTAMP     |
-| line               | String              |      | YES  |         | FIELD         |
-+--------------------+---------------------+------+------+---------+---------------+
-5 rows in set (0.00 sec)
++---------------------+---------------------+------+------+---------+---------------+
+| Column              | Type                | Key  | Null | Default | Semantic Type |
++---------------------+---------------------+------+------+---------+---------------+
+| greptime_timestamp  | TimestampNanosecond | PRI  | NO   |         | TIMESTAMP     |
+| line                | String              |      | YES  |         | FIELD         |
+| structured_metadata | Json                |      | YES  |         | FIELD         |
++---------------------+---------------------+------+------+---------+---------------+
+3 rows in set (0.00 sec)
 ```
 
 - `greptime_timestamp`: The timestamp of the log entry
@@ -96,16 +97,17 @@ The following is an example of the table schema with external labels:
 
 ```sql
 DESC loki_demo_logs;
-+--------------------+---------------------+------+------+---------+---------------+
-| Column             | Type                | Key  | Null | Default | Semantic Type |
-+--------------------+---------------------+------+------+---------+---------------+
-| greptime_timestamp | TimestampNanosecond | PRI  | NO   |         | TIMESTAMP     |
-| line               | String              |      | YES  |         | FIELD         |
-| filename           | String              | PRI  | YES  |         | TAG           |
-| from               | String              | PRI  | YES  |         | TAG           |
-| job                | String              | PRI  | YES  |         | TAG           |
-+--------------------+---------------------+------+------+---------+---------------+
-5 rows in set (0.00 sec)
++---------------------+---------------------+------+------+---------+---------------+
+| Column              | Type                | Key  | Null | Default | Semantic Type |
++---------------------+---------------------+------+------+---------+---------------+
+| greptime_timestamp  | TimestampNanosecond | PRI  | NO   |         | TIMESTAMP     |
+| line                | String              |      | YES  |         | FIELD         |
+| structured_metadata | Json                |      | YES  |         | FIELD         |
+| filename            | String              | PRI  | YES  |         | TAG           |
+| from                | String              | PRI  | YES  |         | TAG           |
+| job                 | String              | PRI  | YES  |         | TAG           |
++---------------------+---------------------+------+------+---------+---------------+
+6 rows in set (0.00 sec)
 ```
 
 ```sql

--- a/docs/user-guide/ingest-data/for-observability/loki.md
+++ b/docs/user-guide/ingest-data/for-observability/loki.md
@@ -84,6 +84,7 @@ DESC loki_demo_logs;
 
 - `greptime_timestamp`: The timestamp of the log entry
 - `line`: The log message content
+- `structured_metadata`: The structured metadata of the log entry in JSON format
 
 If the Loki Push request contains labels, they will be added as tags to the table schema (like `job` and `from` in the above example).
 

--- a/docs/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/docs/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -197,7 +197,7 @@ For more information about the OpenTelemetry SDK, please refer to the official d
 
 ### Example Code
 
-Please refer to the sample code in [opentelemetry-collector](#opentelemetry-collector), which includes how to send OpenTelemetry logs to GreptimeDB.  
+Please refer to the sample code in the [OpenTelemetry Collector documentation](otel-collector.md), which includes how to send OpenTelemetry logs to GreptimeDB.  
 You can also refer to the sample code in the [Alloy documentation](alloy.md#logs) to learn how to send OpenTelemetry logs to GreptimeDB.
 
 ### Data Model
@@ -225,7 +225,7 @@ Default table schema:
 | resource_attributes   | Json                |      | YES  |         | FIELD         |
 | resource_schema_url   | String              |      | YES  |         | FIELD         |
 +-----------------------+---------------------+------+------+---------+---------------+
-17 rows in set (0.00 sec)
+14 rows in set (0.00 sec)
 ```
 
 - You can use `X-Greptime-Log-Table-Name` to specify the table name for storing the logs. If not provided, the default table name is `opentelemetry_logs`.

--- a/docs/user-guide/integrations/grafana.md
+++ b/docs/user-guide/integrations/grafana.md
@@ -10,7 +10,7 @@ You have the option to connect GreptimeDB with Grafana using one of three data s
 
 ## GreptimeDB data source plugin
 
-The [GreptimeDB data source plugin (v2.0)](https://github.com/GreptimeTeam/greptimedb-grafana-datasource) is based on the ClickHouse data source and adds GreptimeDB-specific features.
+The [GreptimeDB data source plugin](https://github.com/GreptimeTeam/greptimedb-grafana-datasource) is based on the ClickHouse data source and adds GreptimeDB-specific features.
 The plugin adapts perfectly to the GreptimeDB data model,
 thus providing a better user experience.
 In addition, it also solves some compatibility issues compared to using the Prometheus data source directly.

--- a/docs/user-guide/protocols/http.md
+++ b/docs/user-guide/protocols/http.md
@@ -116,7 +116,7 @@ To submit a SQL query to the GreptimeDB server via HTTP API, use the following f
 ```shell
 curl -X POST \
   -H 'Authorization: Basic {{authentication}}' \
-  -H 'X-Greptime-Timeout: {{time precision}}' \
+  -H 'X-Greptime-Timeout: {{timeout}}' \
   -H 'Content-Type: application/x-www-form-urlencoded' \
   -d 'sql={{SQL-statement}}' \
 http://{{API-host}}/v1/sql
@@ -160,7 +160,7 @@ http://{{API-host}}/v1/sql
 
 The response is a JSON object containing the following fields:
 
-- `output`: The SQL executed result. Please refer to the examples blow to see the details.
+- `output`: The SQL executed result. Please refer to the examples below to see the details.
 - `execution_time_ms`: The execution time of the statement in milliseconds.
 
 ### Examples
@@ -373,16 +373,14 @@ curl -X POST \
           "name": "",
           "columns": [
             "host",
+            "ts",
             "cpu",
-            "memory",
-            "ts"
+            "memory"
           ],
           "values": [
-            [
-              ["127.0.0.1", 0.1, 0.4, 1667446797450],
-              ["127.0.0.1", 0.5, 0.2, 1667446798450],
-              ["127.0.0.2", 0.2, 0.3, 1667446798450]
-            ]
+            ["127.0.0.1", 1667446797450, 0.1, 0.4],
+            ["127.0.0.1", 1667446798450, 0.5, 0.2],
+            ["127.0.0.2", 1667446798450, 0.2, 0.3]
           ]
         }
       ]
@@ -412,12 +410,46 @@ curl -X POST \
         "with": null,
         "body": {
           "Select": {
+            "select_token": {
+              "token": {
+                "Word": {
+                  "value": "SELECT",
+                  "quote_style": null,
+                  "keyword": "SELECT"
+                }
+              },
+              "span": {
+                "start": {
+                  "line": 1,
+                  "column": 1
+                },
+                "end": {
+                  "line": 1,
+                  "column": 7
+                }
+              }
+            },
+            "optimizer_hint": null,
             "distinct": null,
+            "select_modifiers": null,
             "top": null,
             "top_before_distinct": false,
             "projection": [
               {
                 "Wildcard": {
+                  "wildcard_token": {
+                    "token": "Mul",
+                    "span": {
+                      "start": {
+                        "line": 1,
+                        "column": 8
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 9
+                      }
+                    }
+                  },
                   "opt_ilike": null,
                   "opt_exclude": null,
                   "opt_except": null,
@@ -426,6 +458,7 @@ curl -X POST \
                 }
               }
             ],
+            "exclude": null,
             "into": null,
             "from": [
               {
@@ -433,8 +466,20 @@ curl -X POST \
                   "Table": {
                     "name": [
                       {
-                        "value": "monitor",
-                        "quote_style": null
+                        "Identifier": {
+                          "value": "monitor",
+                          "quote_style": null,
+                          "span": {
+                            "start": {
+                              "line": 1,
+                              "column": 15
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 22
+                            }
+                          }
+                        }
                       }
                     ],
                     "alias": null,
@@ -442,7 +487,10 @@ curl -X POST \
                     "with_hints": [],
                     "version": null,
                     "with_ordinality": false,
-                    "partitions": []
+                    "partitions": [],
+                    "json_path": null,
+                    "sample": null,
+                    "index_hints": []
                   }
                 },
                 "joins": []
@@ -451,6 +499,7 @@ curl -X POST \
             "lateral_views": [],
             "prewhere": null,
             "selection": null,
+            "connect_by": [],
             "group_by": {
               "Expressions": [
                 [],
@@ -465,19 +514,19 @@ curl -X POST \
             "qualify": null,
             "window_before_qualify": false,
             "value_table_mode": null,
-            "connect_by": null
+            "flavor": "Standard"
           }
         },
         "order_by": null,
-        "limit": null,
-        "limit_by": [],
-        "offset": null,
+        "limit_clause": null,
         "fetch": null,
         "locks": [],
         "for_clause": null,
         "settings": null,
-        "format_clause": null
-      }
+        "format_clause": null,
+        "pipe_operators": []
+      },
+      "hybrid_cte": null
     }
   }
 ]
@@ -511,7 +560,7 @@ curl -X GET \
 
 The input parameters are similar to the [`range_query`](https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries) in Prometheus' HTTP API:
 
-- `db=<database name>`: Required when using GreptimeDB with authorization, otherwise can be omitted if you are using the default `public` database. Note this parameter should bet set in the query param, or using a HTTP header `--header 'x-greptime-db-name: <database name>'`.
+- `db=<database name>`: Required when using GreptimeDB with authorization, otherwise can be omitted if you are using the default `public` database. Note this parameter should be set in the query param, or using a HTTP header `--header 'x-greptime-db-name: <database name>'`.
 - `query=<string>`: Required. Prometheus expression query string.
 - `start=<rfc3339 | unix_timestamp>`: Required. The start timestamp, which is inclusive. It is used to set the range of time in `TIME INDEX` column.
 - `end=<rfc3339 | unix_timestamp>`: Required. The end timestamp, which is inclusive. It is used to set the range of time in `TIME INDEX` column.
@@ -555,7 +604,6 @@ The result format is the same as `/sql` interface described in [Post SQL stateme
 
 ```json
 {
-  "code": 0,
   "output": [
     {
       "records": {
@@ -620,7 +668,7 @@ curl -X POST \
 ```shell
 curl -X POST \
   -d '{{Influxdb-line-protocol-data}}' \
-  http://{{API-host}}/v1/influxdb/api/v1/write?u={{username}}&p={{password}}&precision={{time-precision}}
+  http://{{API-host}}/v1/influxdb/write?u={{username}}&p={{password}}&precision={{time-precision}}
 ```
 
 </TabItem>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-iot/grpc-sdks/java.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-iot/grpc-sdks/java.md
@@ -179,7 +179,8 @@ TableSchema sensorReadings = TableSchema.newBuilder("sensor_readings")
 // 使用 map 插入 JSON 数据
 Map<String, Object> attr = new HashMap<>();
 attr.put("location", "factory-1");
-sensorReadings.addRow(<other-column-values>... , attr);
+Table table = Table.from(sensorReadings);
+table.addRow(<other-column-values>... , attr);
 ```
 
 ##### TableSchema

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/loki.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/loki.md
@@ -72,13 +72,14 @@ Loki 日志数据模型根据以下规则映射到 GreptimeDB 数据模型：
 
 ```sql
 DESC loki_demo_logs;
-+--------------------+---------------------+------+------+---------+---------------+
-| Column             | Type                | Key  | Null | Default | Semantic Type |
-+--------------------+---------------------+------+------+---------+---------------+
-| greptime_timestamp | TimestampNanosecond | PRI  | NO   |         | TIMESTAMP     |
-| line               | String              |      | YES  |         | FIELD         |
-+--------------------+---------------------+------+------+---------+---------------+
-5 rows in set (0.00 sec)
++---------------------+---------------------+------+------+---------+---------------+
+| Column              | Type                | Key  | Null | Default | Semantic Type |
++---------------------+---------------------+------+------+---------+---------------+
+| greptime_timestamp  | TimestampNanosecond | PRI  | NO   |         | TIMESTAMP     |
+| line                | String              |      | YES  |         | FIELD         |
+| structured_metadata | Json                |      | YES  |         | FIELD         |
++---------------------+---------------------+------+------+---------+---------------+
+3 rows in set (0.00 sec)
 ```
 
 - `greptime_timestamp`: 日志条目的时间戳
@@ -96,16 +97,17 @@ DESC loki_demo_logs;
 
 ```sql
 DESC loki_demo_logs;
-+--------------------+---------------------+------+------+---------+---------------+
-| Column             | Type                | Key  | Null | Default | Semantic Type |
-+--------------------+---------------------+------+------+---------+---------------+
-| greptime_timestamp | TimestampNanosecond | PRI  | NO   |         | TIMESTAMP     |
-| line               | String              |      | YES  |         | FIELD         |
-| filename           | String              | PRI  | YES  |         | TAG           |
-| from               | String              | PRI  | YES  |         | TAG           |
-| job                | String              | PRI  | YES  |         | TAG           |
-+--------------------+---------------------+------+------+---------+---------------+
-5 rows in set (0.00 sec)
++---------------------+---------------------+------+------+---------+---------------+
+| Column              | Type                | Key  | Null | Default | Semantic Type |
++---------------------+---------------------+------+------+---------+---------------+
+| greptime_timestamp  | TimestampNanosecond | PRI  | NO   |         | TIMESTAMP     |
+| line                | String              |      | YES  |         | FIELD         |
+| structured_metadata | Json                |      | YES  |         | FIELD         |
+| filename            | String              | PRI  | YES  |         | TAG           |
+| from                | String              | PRI  | YES  |         | TAG           |
+| job                 | String              | PRI  | YES  |         | TAG           |
++---------------------+---------------------+------+------+---------+---------------+
+6 rows in set (0.00 sec)
 ```
 
 ```sql

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/loki.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/loki.md
@@ -84,6 +84,7 @@ DESC loki_demo_logs;
 
 - `greptime_timestamp`: 日志条目的时间戳
 - `line`: 日志消息内容
+- `structured_metadata`: 日志条目的结构化元数据，JSON 格式
 
 如果 Loki 请求数据中含有 label，它们将作为 tag 添加到表结构中（如上例中的 `job` 和 `from`）。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -198,7 +198,7 @@ GreptimeDB 是能够通过 [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/
 
 ### 示例代码
 
-请参考 [opentelemetry-collector](#opentelemetry-collector) 中的示例代码，里面包含了如何将 OpenTelemetry 日志发送到 GreptimeDB。
+请参考 [OpenTelemetry Collector 文档](otel-collector.md)中的示例代码，里面包含了如何将 OpenTelemetry 日志发送到 GreptimeDB。
 也可参考 [Alloy 文档](alloy.md#日志)中的示例代码，了解如何将 OpenTelemetry 日志发送到 GreptimeDB。
 
 ### 数据模型
@@ -226,7 +226,7 @@ OTLP 日志数据模型根据以下规则映射到 GreptimeDB 数据模型：
 | resource_attributes   | Json                |      | YES  |         | FIELD         |
 | resource_schema_url   | String              |      | YES  |         | FIELD         |
 +-----------------------+---------------------+------+------+---------+---------------+
-17 rows in set (0.00 sec)
+14 rows in set (0.00 sec)
 ```
 
 - 您可以使用 `X-Greptime-Log-Table-Name` 指定存储日志的表名。如果未提供，默认表名为 `opentelemetry_logs`。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/protocols/http.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/protocols/http.md
@@ -109,7 +109,7 @@ http://localhost:4000/v1/sql
 ```shell
 curl -X POST \
   -H 'Authorization: Basic {{authentication}}' \
-  -H 'X-Greptime-Timeout: {{time precision}}' \
+  -H 'X-Greptime-Timeout: {{timeout}}' \
   -H 'Content-Type: application/x-www-form-urlencoded' \
   -d 'sql={{SQL-statement}}' \
 http://{{API-host}}/v1/sql
@@ -360,16 +360,14 @@ curl -X POST \
           "name": "",
           "columns": [
             "host",
+            "ts",
             "cpu",
-            "memory",
-            "ts"
+            "memory"
           ],
           "values": [
-            [
-              ["127.0.0.1", 0.1, 0.4, 1667446797450],
-              ["127.0.0.1", 0.5, 0.2, 1667446798450],
-              ["127.0.0.2", 0.2, 0.3, 1667446798450]
-            ]
+            ["127.0.0.1", 1667446797450, 0.1, 0.4],
+            ["127.0.0.1", 1667446798450, 0.5, 0.2],
+            ["127.0.0.2", 1667446798450, 0.2, 0.3]
           ]
         }
       ]
@@ -400,12 +398,46 @@ curl -X POST \
         "with": null,
         "body": {
           "Select": {
+            "select_token": {
+              "token": {
+                "Word": {
+                  "value": "SELECT",
+                  "quote_style": null,
+                  "keyword": "SELECT"
+                }
+              },
+              "span": {
+                "start": {
+                  "line": 1,
+                  "column": 1
+                },
+                "end": {
+                  "line": 1,
+                  "column": 7
+                }
+              }
+            },
+            "optimizer_hint": null,
             "distinct": null,
+            "select_modifiers": null,
             "top": null,
             "top_before_distinct": false,
             "projection": [
               {
                 "Wildcard": {
+                  "wildcard_token": {
+                    "token": "Mul",
+                    "span": {
+                      "start": {
+                        "line": 1,
+                        "column": 8
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 9
+                      }
+                    }
+                  },
                   "opt_ilike": null,
                   "opt_exclude": null,
                   "opt_except": null,
@@ -414,6 +446,7 @@ curl -X POST \
                 }
               }
             ],
+            "exclude": null,
             "into": null,
             "from": [
               {
@@ -421,8 +454,20 @@ curl -X POST \
                   "Table": {
                     "name": [
                       {
-                        "value": "monitor",
-                        "quote_style": null
+                        "Identifier": {
+                          "value": "monitor",
+                          "quote_style": null,
+                          "span": {
+                            "start": {
+                              "line": 1,
+                              "column": 15
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 22
+                            }
+                          }
+                        }
                       }
                     ],
                     "alias": null,
@@ -430,7 +475,10 @@ curl -X POST \
                     "with_hints": [],
                     "version": null,
                     "with_ordinality": false,
-                    "partitions": []
+                    "partitions": [],
+                    "json_path": null,
+                    "sample": null,
+                    "index_hints": []
                   }
                 },
                 "joins": []
@@ -439,6 +487,7 @@ curl -X POST \
             "lateral_views": [],
             "prewhere": null,
             "selection": null,
+            "connect_by": [],
             "group_by": {
               "Expressions": [
                 [],
@@ -453,19 +502,19 @@ curl -X POST \
             "qualify": null,
             "window_before_qualify": false,
             "value_table_mode": null,
-            "connect_by": null
+            "flavor": "Standard"
           }
         },
         "order_by": null,
-        "limit": null,
-        "limit_by": [],
-        "offset": null,
+        "limit_clause": null,
         "fetch": null,
         "locks": [],
         "for_clause": null,
         "settings": null,
-        "format_clause": null
-      }
+        "format_clause": null,
+        "pipe_operators": []
+      },
+      "hybrid_cte": null
     }
   }
 ]
@@ -537,7 +586,6 @@ curl -X GET \
 
 ```json
 {
-  "code": 0,
   "output": [
     {
       "records": {
@@ -602,7 +650,7 @@ curl -X POST \
 ```shell
 curl -X POST \
   -d '{{Influxdb-line-protocol-data}}' \
-  http://{{API-host}}/v1/influxdb/api/v1/write?u={{username}}&p={{password}}&precision={{time-precision}}
+  http://{{API-host}}/v1/influxdb/write?u={{username}}&p={{password}}&precision={{time-precision}}
 ```
 
 </TabItem>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/ingest-data/for-iot/grpc-sdks/java.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/ingest-data/for-iot/grpc-sdks/java.md
@@ -179,7 +179,8 @@ TableSchema sensorReadings = TableSchema.newBuilder("sensor_readings")
 // 使用 map 插入 JSON 数据
 Map<String, Object> attr = new HashMap<>();
 attr.put("location", "factory-1");
-sensorReadings.addRow(<other-column-values>... , attr);
+Table table = Table.from(sensorReadings);
+table.addRow(<other-column-values>... , attr);
 ```
 
 ##### TableSchema

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/ingest-data/for-observability/loki.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/ingest-data/for-observability/loki.md
@@ -72,13 +72,14 @@ Loki 日志数据模型根据以下规则映射到 GreptimeDB 数据模型：
 
 ```sql
 DESC loki_demo_logs;
-+--------------------+---------------------+------+------+---------+---------------+
-| Column             | Type                | Key  | Null | Default | Semantic Type |
-+--------------------+---------------------+------+------+---------+---------------+
-| greptime_timestamp | TimestampNanosecond | PRI  | NO   |         | TIMESTAMP     |
-| line               | String              |      | YES  |         | FIELD         |
-+--------------------+---------------------+------+------+---------+---------------+
-5 rows in set (0.00 sec)
++---------------------+---------------------+------+------+---------+---------------+
+| Column              | Type                | Key  | Null | Default | Semantic Type |
++---------------------+---------------------+------+------+---------+---------------+
+| greptime_timestamp  | TimestampNanosecond | PRI  | NO   |         | TIMESTAMP     |
+| line                | String              |      | YES  |         | FIELD         |
+| structured_metadata | Json                |      | YES  |         | FIELD         |
++---------------------+---------------------+------+------+---------+---------------+
+3 rows in set (0.00 sec)
 ```
 
 - `greptime_timestamp`: 日志条目的时间戳
@@ -96,16 +97,17 @@ DESC loki_demo_logs;
 
 ```sql
 DESC loki_demo_logs;
-+--------------------+---------------------+------+------+---------+---------------+
-| Column             | Type                | Key  | Null | Default | Semantic Type |
-+--------------------+---------------------+------+------+---------+---------------+
-| greptime_timestamp | TimestampNanosecond | PRI  | NO   |         | TIMESTAMP     |
-| line               | String              |      | YES  |         | FIELD         |
-| filename           | String              | PRI  | YES  |         | TAG           |
-| from               | String              | PRI  | YES  |         | TAG           |
-| job                | String              | PRI  | YES  |         | TAG           |
-+--------------------+---------------------+------+------+---------+---------------+
-5 rows in set (0.00 sec)
++---------------------+---------------------+------+------+---------+---------------+
+| Column              | Type                | Key  | Null | Default | Semantic Type |
++---------------------+---------------------+------+------+---------+---------------+
+| greptime_timestamp  | TimestampNanosecond | PRI  | NO   |         | TIMESTAMP     |
+| line                | String              |      | YES  |         | FIELD         |
+| structured_metadata | Json                |      | YES  |         | FIELD         |
+| filename            | String              | PRI  | YES  |         | TAG           |
+| from                | String              | PRI  | YES  |         | TAG           |
+| job                 | String              | PRI  | YES  |         | TAG           |
++---------------------+---------------------+------+------+---------+---------------+
+6 rows in set (0.00 sec)
 ```
 
 ```sql

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/ingest-data/for-observability/loki.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/ingest-data/for-observability/loki.md
@@ -84,6 +84,7 @@ DESC loki_demo_logs;
 
 - `greptime_timestamp`: 日志条目的时间戳
 - `line`: 日志消息内容
+- `structured_metadata`: 日志条目的结构化元数据，JSON 格式
 
 如果 Loki 请求数据中含有 label，它们将作为 tag 添加到表结构中（如上例中的 `job` 和 `from`）。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -198,7 +198,7 @@ GreptimeDB 是能够通过 [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/
 
 ### 示例代码
 
-请参考 [opentelemetry-collector](#opentelemetry-collector) 中的示例代码，里面包含了如何将 OpenTelemetry 日志发送到 GreptimeDB。
+请参考 [OpenTelemetry Collector 文档](otel-collector.md)中的示例代码，里面包含了如何将 OpenTelemetry 日志发送到 GreptimeDB。
 也可参考 [Alloy 文档](alloy.md#日志)中的示例代码，了解如何将 OpenTelemetry 日志发送到 GreptimeDB。
 
 ### 数据模型
@@ -226,7 +226,7 @@ OTLP 日志数据模型根据以下规则映射到 GreptimeDB 数据模型：
 | resource_attributes   | Json                |      | YES  |         | FIELD         |
 | resource_schema_url   | String              |      | YES  |         | FIELD         |
 +-----------------------+---------------------+------+------+---------+---------------+
-17 rows in set (0.00 sec)
+14 rows in set (0.00 sec)
 ```
 
 - 您可以使用 `X-Greptime-Log-Table-Name` 指定存储日志的表名。如果未提供，默认表名为 `opentelemetry_logs`。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/protocols/http.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/protocols/http.md
@@ -109,7 +109,7 @@ http://localhost:4000/v1/sql
 ```shell
 curl -X POST \
   -H 'Authorization: Basic {{authentication}}' \
-  -H 'X-Greptime-Timeout: {{time precision}}' \
+  -H 'X-Greptime-Timeout: {{timeout}}' \
   -H 'Content-Type: application/x-www-form-urlencoded' \
   -d 'sql={{SQL-statement}}' \
 http://{{API-host}}/v1/sql
@@ -360,16 +360,14 @@ curl -X POST \
           "name": "",
           "columns": [
             "host",
+            "ts",
             "cpu",
-            "memory",
-            "ts"
+            "memory"
           ],
           "values": [
-            [
-              ["127.0.0.1", 0.1, 0.4, 1667446797450],
-              ["127.0.0.1", 0.5, 0.2, 1667446798450],
-              ["127.0.0.2", 0.2, 0.3, 1667446798450]
-            ]
+            ["127.0.0.1", 1667446797450, 0.1, 0.4],
+            ["127.0.0.1", 1667446798450, 0.5, 0.2],
+            ["127.0.0.2", 1667446798450, 0.2, 0.3]
           ]
         }
       ]
@@ -400,12 +398,46 @@ curl -X POST \
         "with": null,
         "body": {
           "Select": {
+            "select_token": {
+              "token": {
+                "Word": {
+                  "value": "SELECT",
+                  "quote_style": null,
+                  "keyword": "SELECT"
+                }
+              },
+              "span": {
+                "start": {
+                  "line": 1,
+                  "column": 1
+                },
+                "end": {
+                  "line": 1,
+                  "column": 7
+                }
+              }
+            },
+            "optimizer_hint": null,
             "distinct": null,
+            "select_modifiers": null,
             "top": null,
             "top_before_distinct": false,
             "projection": [
               {
                 "Wildcard": {
+                  "wildcard_token": {
+                    "token": "Mul",
+                    "span": {
+                      "start": {
+                        "line": 1,
+                        "column": 8
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 9
+                      }
+                    }
+                  },
                   "opt_ilike": null,
                   "opt_exclude": null,
                   "opt_except": null,
@@ -414,6 +446,7 @@ curl -X POST \
                 }
               }
             ],
+            "exclude": null,
             "into": null,
             "from": [
               {
@@ -421,8 +454,20 @@ curl -X POST \
                   "Table": {
                     "name": [
                       {
-                        "value": "monitor",
-                        "quote_style": null
+                        "Identifier": {
+                          "value": "monitor",
+                          "quote_style": null,
+                          "span": {
+                            "start": {
+                              "line": 1,
+                              "column": 15
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 22
+                            }
+                          }
+                        }
                       }
                     ],
                     "alias": null,
@@ -430,7 +475,10 @@ curl -X POST \
                     "with_hints": [],
                     "version": null,
                     "with_ordinality": false,
-                    "partitions": []
+                    "partitions": [],
+                    "json_path": null,
+                    "sample": null,
+                    "index_hints": []
                   }
                 },
                 "joins": []
@@ -439,6 +487,7 @@ curl -X POST \
             "lateral_views": [],
             "prewhere": null,
             "selection": null,
+            "connect_by": [],
             "group_by": {
               "Expressions": [
                 [],
@@ -453,19 +502,19 @@ curl -X POST \
             "qualify": null,
             "window_before_qualify": false,
             "value_table_mode": null,
-            "connect_by": null
+            "flavor": "Standard"
           }
         },
         "order_by": null,
-        "limit": null,
-        "limit_by": [],
-        "offset": null,
+        "limit_clause": null,
         "fetch": null,
         "locks": [],
         "for_clause": null,
         "settings": null,
-        "format_clause": null
-      }
+        "format_clause": null,
+        "pipe_operators": []
+      },
+      "hybrid_cte": null
     }
   }
 ]
@@ -537,7 +586,6 @@ curl -X GET \
 
 ```json
 {
-  "code": 0,
   "output": [
     {
       "records": {
@@ -602,7 +650,7 @@ curl -X POST \
 ```shell
 curl -X POST \
   -d '{{Influxdb-line-protocol-data}}' \
-  http://{{API-host}}/v1/influxdb/api/v1/write?u={{username}}&p={{password}}&precision={{time-precision}}
+  http://{{API-host}}/v1/influxdb/write?u={{username}}&p={{password}}&precision={{time-precision}}
 ```
 
 </TabItem>

--- a/versioned_docs/version-1.0/user-guide/ingest-data/for-iot/grpc-sdks/go.md
+++ b/versioned_docs/version-1.0/user-guide/ingest-data/for-iot/grpc-sdks/go.md
@@ -252,7 +252,7 @@ affected, err := cli.CloseStream(ctx)
 
 ## Insert data in JSON type
 
-GreptimeDB supports storing complex data structures using [JSON type data](/reference/sql/data-types.md#json-type).
+GreptimeDB supports storing complex data structures using [JSON type data](/reference/sql/data-types.md#json-type-experimental).
 With this ingester library, you can insert JSON data using string values.
 For instance, if you have a table named `sensor_readings` and wish to add a JSON column named `attributes`,
 refer to the following code snippet.

--- a/versioned_docs/version-1.0/user-guide/ingest-data/for-iot/grpc-sdks/java.md
+++ b/versioned_docs/version-1.0/user-guide/ingest-data/for-iot/grpc-sdks/java.md
@@ -83,7 +83,7 @@ This client offers multiple ingestion methods optimized for various performance 
 Make sure that your system has JDK 8 or later installed. For more information on how to
 check your version of Java and install the JDK, see the [Oracle Overview of JDK Installation documentation](https://www.oracle.com/java/technologies/javase-downloads.html)
 
-2. Add GreptiemDB Java SDK as a Dependency
+2. Add GreptimeDB Java SDK as a Dependency
 
 If you are using [Maven](https://maven.apache.org/), add the following to your pom.xml
 dependencies list:
@@ -168,7 +168,7 @@ table.complete();
 CompletableFuture<Result<WriteOk, Err>> future = client.write(table);
 ```
 
-GreptimeDB supports storing complex data structures using [JSON type data](/reference/sql/data-types.md#json-type). You can define JSON columns in your table schema and insert data using Map objects:
+GreptimeDB supports storing complex data structures using [JSON type data](/reference/sql/data-types.md#json-type-experimental). You can define JSON columns in your table schema and insert data using Map objects:
 
 ```java
 // Construct the table schema for sensor_readings
@@ -183,7 +183,8 @@ TableSchema sensorReadings = TableSchema.newBuilder("sensor_readings")
 // Use map to insert JSON data
 Map<String, Object> attr = new HashMap<>();
 attr.put("location", "factory-1");
-sensorReadings.addRow(<other-column-values>... , attr);
+Table table = Table.from(sensorReadings);
+table.addRow(<other-column-values>... , attr);
 ```
 
 ##### TableSchema
@@ -341,7 +342,7 @@ BulkWrite.Config cfg = BulkWrite.Config.newBuilder()
         .allocatorInitReservation(64 * 1024 * 1024L) // Customize memory allocation: 64MB initial reservation
         .allocatorMaxAllocation(4 * 1024 * 1024 * 1024L) // Customize memory allocation: 4GB max allocation
         .timeoutMsPerMessage(60 * 1000) // 60 seconds timeout per request
-        .maxRequestsInFlight(8) // Concurrency Control: Configure with 10 maximum in-flight requests
+        .maxRequestsInFlight(8) // Concurrency Control: Configure with 8 maximum in-flight requests
         .build();
 // Enable Zstd compression
 Context ctx = Context.newDefault().withCompression(Compression.Zstd);

--- a/versioned_docs/version-1.0/user-guide/ingest-data/for-observability/loki.md
+++ b/versioned_docs/version-1.0/user-guide/ingest-data/for-observability/loki.md
@@ -72,13 +72,14 @@ The Loki logs data model is mapped to the GreptimeDB data model according to the
 
 ```sql
 DESC loki_demo_logs;
-+--------------------+---------------------+------+------+---------+---------------+
-| Column             | Type                | Key  | Null | Default | Semantic Type |
-+--------------------+---------------------+------+------+---------+---------------+
-| greptime_timestamp | TimestampNanosecond | PRI  | NO   |         | TIMESTAMP     |
-| line               | String              |      | YES  |         | FIELD         |
-+--------------------+---------------------+------+------+---------+---------------+
-5 rows in set (0.00 sec)
++---------------------+---------------------+------+------+---------+---------------+
+| Column              | Type                | Key  | Null | Default | Semantic Type |
++---------------------+---------------------+------+------+---------+---------------+
+| greptime_timestamp  | TimestampNanosecond | PRI  | NO   |         | TIMESTAMP     |
+| line                | String              |      | YES  |         | FIELD         |
+| structured_metadata | Json                |      | YES  |         | FIELD         |
++---------------------+---------------------+------+------+---------+---------------+
+3 rows in set (0.00 sec)
 ```
 
 - `greptime_timestamp`: The timestamp of the log entry
@@ -96,16 +97,17 @@ The following is an example of the table schema with external labels:
 
 ```sql
 DESC loki_demo_logs;
-+--------------------+---------------------+------+------+---------+---------------+
-| Column             | Type                | Key  | Null | Default | Semantic Type |
-+--------------------+---------------------+------+------+---------+---------------+
-| greptime_timestamp | TimestampNanosecond | PRI  | NO   |         | TIMESTAMP     |
-| line               | String              |      | YES  |         | FIELD         |
-| filename           | String              | PRI  | YES  |         | TAG           |
-| from               | String              | PRI  | YES  |         | TAG           |
-| job                | String              | PRI  | YES  |         | TAG           |
-+--------------------+---------------------+------+------+---------+---------------+
-5 rows in set (0.00 sec)
++---------------------+---------------------+------+------+---------+---------------+
+| Column              | Type                | Key  | Null | Default | Semantic Type |
++---------------------+---------------------+------+------+---------+---------------+
+| greptime_timestamp  | TimestampNanosecond | PRI  | NO   |         | TIMESTAMP     |
+| line                | String              |      | YES  |         | FIELD         |
+| structured_metadata | Json                |      | YES  |         | FIELD         |
+| filename            | String              | PRI  | YES  |         | TAG           |
+| from                | String              | PRI  | YES  |         | TAG           |
+| job                 | String              | PRI  | YES  |         | TAG           |
++---------------------+---------------------+------+------+---------+---------------+
+6 rows in set (0.00 sec)
 ```
 
 ```sql

--- a/versioned_docs/version-1.0/user-guide/ingest-data/for-observability/loki.md
+++ b/versioned_docs/version-1.0/user-guide/ingest-data/for-observability/loki.md
@@ -84,6 +84,7 @@ DESC loki_demo_logs;
 
 - `greptime_timestamp`: The timestamp of the log entry
 - `line`: The log message content
+- `structured_metadata`: The structured metadata of the log entry in JSON format
 
 If the Loki Push request contains labels, they will be added as tags to the table schema (like `job` and `from` in the above example).
 

--- a/versioned_docs/version-1.0/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/versioned_docs/version-1.0/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -197,7 +197,7 @@ For more information about the OpenTelemetry SDK, please refer to the official d
 
 ### Example Code
 
-Please refer to the sample code in [opentelemetry-collector](#opentelemetry-collector), which includes how to send OpenTelemetry logs to GreptimeDB.  
+Please refer to the sample code in the [OpenTelemetry Collector documentation](otel-collector.md), which includes how to send OpenTelemetry logs to GreptimeDB.  
 You can also refer to the sample code in the [Alloy documentation](alloy.md#logs) to learn how to send OpenTelemetry logs to GreptimeDB.
 
 ### Data Model
@@ -225,7 +225,7 @@ Default table schema:
 | resource_attributes   | Json                |      | YES  |         | FIELD         |
 | resource_schema_url   | String              |      | YES  |         | FIELD         |
 +-----------------------+---------------------+------+------+---------+---------------+
-17 rows in set (0.00 sec)
+14 rows in set (0.00 sec)
 ```
 
 - You can use `X-Greptime-Log-Table-Name` to specify the table name for storing the logs. If not provided, the default table name is `opentelemetry_logs`.

--- a/versioned_docs/version-1.0/user-guide/integrations/grafana.md
+++ b/versioned_docs/version-1.0/user-guide/integrations/grafana.md
@@ -10,7 +10,7 @@ You have the option to connect GreptimeDB with Grafana using one of three data s
 
 ## GreptimeDB data source plugin
 
-The [GreptimeDB data source plugin (v2.0)](https://github.com/GreptimeTeam/greptimedb-grafana-datasource) is based on the ClickHouse data source and adds GreptimeDB-specific features.
+The [GreptimeDB data source plugin](https://github.com/GreptimeTeam/greptimedb-grafana-datasource) is based on the ClickHouse data source and adds GreptimeDB-specific features.
 The plugin adapts perfectly to the GreptimeDB data model,
 thus providing a better user experience.
 In addition, it also solves some compatibility issues compared to using the Prometheus data source directly.

--- a/versioned_docs/version-1.0/user-guide/protocols/http.md
+++ b/versioned_docs/version-1.0/user-guide/protocols/http.md
@@ -116,7 +116,7 @@ To submit a SQL query to the GreptimeDB server via HTTP API, use the following f
 ```shell
 curl -X POST \
   -H 'Authorization: Basic {{authentication}}' \
-  -H 'X-Greptime-Timeout: {{time precision}}' \
+  -H 'X-Greptime-Timeout: {{timeout}}' \
   -H 'Content-Type: application/x-www-form-urlencoded' \
   -d 'sql={{SQL-statement}}' \
 http://{{API-host}}/v1/sql
@@ -160,7 +160,7 @@ http://{{API-host}}/v1/sql
 
 The response is a JSON object containing the following fields:
 
-- `output`: The SQL executed result. Please refer to the examples blow to see the details.
+- `output`: The SQL executed result. Please refer to the examples below to see the details.
 - `execution_time_ms`: The execution time of the statement in milliseconds.
 
 ### Examples
@@ -373,16 +373,14 @@ curl -X POST \
           "name": "",
           "columns": [
             "host",
+            "ts",
             "cpu",
-            "memory",
-            "ts"
+            "memory"
           ],
           "values": [
-            [
-              ["127.0.0.1", 0.1, 0.4, 1667446797450],
-              ["127.0.0.1", 0.5, 0.2, 1667446798450],
-              ["127.0.0.2", 0.2, 0.3, 1667446798450]
-            ]
+            ["127.0.0.1", 1667446797450, 0.1, 0.4],
+            ["127.0.0.1", 1667446798450, 0.5, 0.2],
+            ["127.0.0.2", 1667446798450, 0.2, 0.3]
           ]
         }
       ]
@@ -412,12 +410,46 @@ curl -X POST \
         "with": null,
         "body": {
           "Select": {
+            "select_token": {
+              "token": {
+                "Word": {
+                  "value": "SELECT",
+                  "quote_style": null,
+                  "keyword": "SELECT"
+                }
+              },
+              "span": {
+                "start": {
+                  "line": 1,
+                  "column": 1
+                },
+                "end": {
+                  "line": 1,
+                  "column": 7
+                }
+              }
+            },
+            "optimizer_hint": null,
             "distinct": null,
+            "select_modifiers": null,
             "top": null,
             "top_before_distinct": false,
             "projection": [
               {
                 "Wildcard": {
+                  "wildcard_token": {
+                    "token": "Mul",
+                    "span": {
+                      "start": {
+                        "line": 1,
+                        "column": 8
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 9
+                      }
+                    }
+                  },
                   "opt_ilike": null,
                   "opt_exclude": null,
                   "opt_except": null,
@@ -426,6 +458,7 @@ curl -X POST \
                 }
               }
             ],
+            "exclude": null,
             "into": null,
             "from": [
               {
@@ -433,8 +466,20 @@ curl -X POST \
                   "Table": {
                     "name": [
                       {
-                        "value": "monitor",
-                        "quote_style": null
+                        "Identifier": {
+                          "value": "monitor",
+                          "quote_style": null,
+                          "span": {
+                            "start": {
+                              "line": 1,
+                              "column": 15
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 22
+                            }
+                          }
+                        }
                       }
                     ],
                     "alias": null,
@@ -442,7 +487,10 @@ curl -X POST \
                     "with_hints": [],
                     "version": null,
                     "with_ordinality": false,
-                    "partitions": []
+                    "partitions": [],
+                    "json_path": null,
+                    "sample": null,
+                    "index_hints": []
                   }
                 },
                 "joins": []
@@ -451,6 +499,7 @@ curl -X POST \
             "lateral_views": [],
             "prewhere": null,
             "selection": null,
+            "connect_by": [],
             "group_by": {
               "Expressions": [
                 [],
@@ -465,19 +514,19 @@ curl -X POST \
             "qualify": null,
             "window_before_qualify": false,
             "value_table_mode": null,
-            "connect_by": null
+            "flavor": "Standard"
           }
         },
         "order_by": null,
-        "limit": null,
-        "limit_by": [],
-        "offset": null,
+        "limit_clause": null,
         "fetch": null,
         "locks": [],
         "for_clause": null,
         "settings": null,
-        "format_clause": null
-      }
+        "format_clause": null,
+        "pipe_operators": []
+      },
+      "hybrid_cte": null
     }
   }
 ]
@@ -511,7 +560,7 @@ curl -X GET \
 
 The input parameters are similar to the [`range_query`](https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries) in Prometheus' HTTP API:
 
-- `db=<database name>`: Required when using GreptimeDB with authorization, otherwise can be omitted if you are using the default `public` database. Note this parameter should bet set in the query param, or using a HTTP header `--header 'x-greptime-db-name: <database name>'`.
+- `db=<database name>`: Required when using GreptimeDB with authorization, otherwise can be omitted if you are using the default `public` database. Note this parameter should be set in the query param, or using a HTTP header `--header 'x-greptime-db-name: <database name>'`.
 - `query=<string>`: Required. Prometheus expression query string.
 - `start=<rfc3339 | unix_timestamp>`: Required. The start timestamp, which is inclusive. It is used to set the range of time in `TIME INDEX` column.
 - `end=<rfc3339 | unix_timestamp>`: Required. The end timestamp, which is inclusive. It is used to set the range of time in `TIME INDEX` column.
@@ -555,7 +604,6 @@ The result format is the same as `/sql` interface described in [Post SQL stateme
 
 ```json
 {
-  "code": 0,
   "output": [
     {
       "records": {
@@ -620,7 +668,7 @@ curl -X POST \
 ```shell
 curl -X POST \
   -d '{{Influxdb-line-protocol-data}}' \
-  http://{{API-host}}/v1/influxdb/api/v1/write?u={{username}}&p={{password}}&precision={{time-precision}}
+  http://{{API-host}}/v1/influxdb/write?u={{username}}&p={{password}}&precision={{time-precision}}
 ```
 
 </TabItem>


### PR DESCRIPTION
## What's Changed in this PR

part of #2417 

  Audit and fix documentation issues in `user-guide/protocols`, `user-guide/ingest-data`, and `user-guide/integrations`. All issues were verified against GreptimeDB source code and tested against a running v1.0.0
  instance. Fixes applied across EN nightly, EN v1.0, ZH nightly, and ZH v1.0 where applicable.

  | # | Severity | Issue | File | EN nightly | EN v1.0 | ZH nightly | ZH v1.0 |
  |---|----------|-------|------|:---:|:---:|:---:|:---:|
  | H1 | High | InfluxDB V1 endpoint URL wrong: `/v1/influxdb/api/v1/write` → `/v1/influxdb/write` | `protocols/http.md` | ✅ | ✅ | ✅ | ✅ |
  | H2 | High | `influxdb_v1` response example: fix triple-nested values to double-nested, correct column order | `protocols/http.md` | ✅ | ✅ | ✅ | ✅ |
  | H3 | High | Remove non-existent `"code": 0` field from PromQL response example | `protocols/http.md` | ✅ | ✅ | ✅ | ✅ |
  | M1 | Medium | `X-Greptime-Timeout` placeholder `{{time precision}}` → `{{timeout}}` (it's a duration, not precision) | `protocols/http.md` | ✅ | ✅ | ✅ | ✅ |
  | M2 | Medium | Replace outdated `/v1/sql/parse` response JSON with current AST output | `protocols/http.md` | ✅ | ✅ | ✅ | ✅ |
  | M3 | Medium | Fix broken anchor `#json-type` → `#json-type-experimental` | `grpc-sdks/go.md` | ✅ | ✅ | — | — |
  | M4 | Medium | Fix broken anchor `#json-type` → `#json-type-experimental` | `grpc-sdks/java.md` | ✅ | ✅ | — | — |
  | M5 | Medium | Fix `addRow()` called on `TableSchema` instead of `Table` — add missing `Table.from(schema)` step | `grpc-sdks/java.md` | ✅ | ✅ | ✅ | ✅ |
  | M6 | Medium | Fix broken in-page anchor `#opentelemetry-collector` → link to `otel-collector.md` | `observability/opentelemetry.md` | ✅ | ✅ | ✅ | ✅ |
  | M7 | Medium | OTLP logs schema row count `17 rows` → `14 rows` (table shows 14 columns) | `observability/opentelemetry.md` | ✅ | ✅ | ✅ | ✅ |
  | M8 | Medium | Loki schema: add missing `structured_metadata` column, fix row count `5 rows` → `3 rows` | `observability/loki.md` | ✅ | ✅ | ✅ | ✅ |
  | L1 | Low | Typo: "examples blow" → "examples below" | `protocols/http.md` | ✅ | ✅ | — | — |
  | L2 | Low | Typo: "should bet set" → "should be set" | `protocols/http.md` | ✅ | ✅ | — | — |
  | L3 | Low | Typo: "GreptiemDB" → "GreptimeDB" | `grpc-sdks/java.md` | ✅ | ✅ | — | — |
  | L4 | Low | Comment says "10 maximum in-flight requests" but code sets 8 → fix to "8 maximum" | `grpc-sdks/java.md` | ✅ | ✅ | — | — |
  | L5 | Low | Remove stale Grafana plugin version "(v2.0)" from link text | `integrations/grafana.md` | ✅ | ✅ | — | — |


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
