### PR TITLE
docs: use pod identity to access S3

### DIFF
--- a/docs/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/docs/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -324,6 +324,37 @@ objectStorage:
     endpoint: ""
 ```
 
+#### Using AWS EKS Pod Identity for S3
+
+Instead of providing static access keys, you can use [AWS EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) (IAM Roles for Service Accounts) to grant S3 access to GreptimeDB. This approach is more secure as it eliminates the need to manage long-lived credentials.
+
+First, configure the datanode service account with the IAM role annotation. Only the datanode reads from and writes to S3:
+
+```yaml
+datanode:
+  podTemplate:
+    serviceAccount:
+      create: true
+      annotations:
+        eks.amazonaws.com/role-arn: ${YOUR_IAM_ROLE_ARN}
+```
+
+Make sure the IAM role has permissions to read and write to the target S3 bucket.
+
+Then, configure the object storage without credentials:
+
+```yaml
+objectStorage:
+  s3:
+    bucket: "${YOUR_S3_BUCKET}"
+    region: "${YOUR_S3_REGION}"
+    root: "greptimedb"
+```
+
+:::note
+When using EKS Pod Identity, omit the `objectStorage.credentials` section entirely. The datanode pods will automatically obtain temporary credentials through the IAM role associated with the service account.
+:::
+
 #### Google Cloud Storage
 
 ```yaml

--- a/docs/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/docs/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -339,7 +339,12 @@ datanode:
         eks.amazonaws.com/role-arn: ${YOUR_IAM_ROLE_ARN}
 ```
 
-Make sure the IAM role has permissions to read and write to the target S3 bucket.
+Make sure the IAM role has permissions to read and write to the target S3 bucket:
+- `s3:PutObject`
+- `s3:ListBucket`
+- `s3:GetObject`
+- `s3:DeleteObject`
+
 
 Then, configure the object storage without credentials:
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -339,7 +339,11 @@ datanode:
         eks.amazonaws.com/role-arn: ${YOUR_IAM_ROLE_ARN}
 ```
 
-请确保 IAM 角色具有对目标 S3 存储桶的读写权限。
+请确保 IAM 角色具有对目标 S3 存储桶的读写权限：
+- `s3:PutObject`
+- `s3:ListBucket`
+- `s3:GetObject`
+- `s3:DeleteObject`
 
 然后，配置对象存储时无需填写凭证：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -324,6 +324,37 @@ objectStorage:
     endpoint: ""
 ```
 
+#### 使用 AWS EKS Pod Identity 访问 S3
+
+除了提供静态访问密钥外，你还可以使用 [AWS EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)（IAM Roles for Service Accounts）来授予 GreptimeDB 访问 S3 的权限。这种方式更加安全，因为无需管理长期有效的凭证。
+
+首先，为 datanode 的 Service Account 配置 IAM 角色注解。只有 datanode 会读写 S3：
+
+```yaml
+datanode:
+  podTemplate:
+    serviceAccount:
+      create: true
+      annotations:
+        eks.amazonaws.com/role-arn: ${YOUR_IAM_ROLE_ARN}
+```
+
+请确保 IAM 角色具有对目标 S3 存储桶的读写权限。
+
+然后，配置对象存储时无需填写凭证：
+
+```yaml
+objectStorage:
+  s3:
+    bucket: "${YOUR_S3_BUCKET}"
+    region: "${YOUR_S3_REGION}"
+    root: "greptimedb"
+```
+
+:::note
+使用 EKS Pod Identity 时，请完全省略 `objectStorage.credentials` 部分。datanode Pod 将通过与 Service Account 关联的 IAM 角色自动获取临时凭证。
+:::
+
 #### Google Cloud Storage
 
 ```yaml

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -339,7 +339,11 @@ datanode:
         eks.amazonaws.com/role-arn: ${YOUR_IAM_ROLE_ARN}
 ```
 
-请确保 IAM 角色具有对目标 S3 存储桶的读写权限。
+请确保 IAM 角色具有对目标 S3 存储桶的读写权限：
+- `s3:PutObject`
+- `s3:ListBucket`
+- `s3:GetObject`
+- `s3:DeleteObject`
 
 然后，配置对象存储时无需填写凭证：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -324,6 +324,37 @@ objectStorage:
     endpoint: ""
 ```
 
+#### 使用 AWS EKS Pod Identity 访问 S3
+
+除了提供静态访问密钥外，你还可以使用 [AWS EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)（IAM Roles for Service Accounts）来授予 GreptimeDB 访问 S3 的权限。这种方式更加安全，因为无需管理长期有效的凭证。
+
+首先，为 datanode 的 Service Account 配置 IAM 角色注解。只有 datanode 会读写 S3：
+
+```yaml
+datanode:
+  podTemplate:
+    serviceAccount:
+      create: true
+      annotations:
+        eks.amazonaws.com/role-arn: ${YOUR_IAM_ROLE_ARN}
+```
+
+请确保 IAM 角色具有对目标 S3 存储桶的读写权限。
+
+然后，配置对象存储时无需填写凭证：
+
+```yaml
+objectStorage:
+  s3:
+    bucket: "${YOUR_S3_BUCKET}"
+    region: "${YOUR_S3_REGION}"
+    root: "greptimedb"
+```
+
+:::note
+使用 EKS Pod Identity 时，请完全省略 `objectStorage.credentials` 部分。datanode Pod 将通过与 Service Account 关联的 IAM 角色自动获取临时凭证。
+:::
+
 #### Google Cloud Storage
 
 ```yaml

--- a/versioned_docs/version-1.0/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/versioned_docs/version-1.0/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -324,6 +324,37 @@ objectStorage:
     endpoint: ""
 ```
 
+#### Using AWS EKS Pod Identity for S3
+
+Instead of providing static access keys, you can use [AWS EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) (IAM Roles for Service Accounts) to grant S3 access to GreptimeDB. This approach is more secure as it eliminates the need to manage long-lived credentials.
+
+First, configure the datanode service account with the IAM role annotation. Only the datanode reads from and writes to S3:
+
+```yaml
+datanode:
+  podTemplate:
+    serviceAccount:
+      create: true
+      annotations:
+        eks.amazonaws.com/role-arn: ${YOUR_IAM_ROLE_ARN}
+```
+
+Make sure the IAM role has permissions to read and write to the target S3 bucket.
+
+Then, configure the object storage without credentials:
+
+```yaml
+objectStorage:
+  s3:
+    bucket: "${YOUR_S3_BUCKET}"
+    region: "${YOUR_S3_REGION}"
+    root: "greptimedb"
+```
+
+:::note
+When using EKS Pod Identity, omit the `objectStorage.credentials` section entirely. The datanode pods will automatically obtain temporary credentials through the IAM role associated with the service account.
+:::
+
 #### Google Cloud Storage
 
 ```yaml

--- a/versioned_docs/version-1.0/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/versioned_docs/version-1.0/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -339,7 +339,11 @@ datanode:
         eks.amazonaws.com/role-arn: ${YOUR_IAM_ROLE_ARN}
 ```
 
-Make sure the IAM role has permissions to read and write to the target S3 bucket.
+Make sure the IAM role has permissions to read and write to the target S3 bucket:
+- `s3:PutObject`
+- `s3:ListBucket`
+- `s3:GetObject`
+- `s3:DeleteObject`
 
 Then, configure the object storage without credentials:
 


### PR DESCRIPTION


## What's Changed in this PR
 Add AWS EKS Pod Identity configuration for S3 access

 - Updated `common-helm-chart-configurations.md` in multiple language and version directories to include instructions for using AWS EKS Pod Identity (IAM Roles for Service Accounts) for secure S3 access in GreptimeDB deployments.
 - Added YAML configuration examples for setting up IAM role annotations on datanode service accounts and configuring object storage without static credentials.

## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
