### PR TITLE
docs: refresh ingestion protocol ratios in FAQ

### DIFF
--- a/docs/faq-and-others/faq.md
+++ b/docs/faq-and-others/faq.md
@@ -157,13 +157,12 @@ GreptimeDB supports multiple ingestion protocols with very different throughput 
 
 | Protocol | Relative throughput |
 | --- | --- |
-| gRPC Bulk (Arrow Flight) | Highest (~55x SQL) |
-| gRPC Stream | ~40x SQL |
-| gRPC SDK (Unary) | ~33x SQL |
-| OTLP Logs | ~29x SQL |
-| InfluxDB Line Protocol | ~27x SQL |
-| MySQL INSERT | ~2x PostgreSQL |
-| PostgreSQL INSERT | Baseline |
+| gRPC Bulk (Arrow Flight) | Highest (~37x SQL) |
+| gRPC Stream | ~21x SQL |
+| gRPC SDK (Unary) | ~16x SQL |
+| InfluxDB Line Protocol | ~12x SQL |
+| OTLP Logs | ~8.5x SQL |
+| MySQL / PostgreSQL INSERT | Baseline |
 
 **How to choose:**
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/faq-and-others/faq.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/faq-and-others/faq.md
@@ -157,13 +157,12 @@ GreptimeDB 支持多种写入协议，吞吐性能差异很大。以下数据来
 
 | 协议 | 相对吞吐 |
 | --- | --- |
-| gRPC Bulk (Arrow Flight) | 最高（约 55 倍 SQL） |
-| gRPC Stream | 约 40 倍 SQL |
-| gRPC SDK (Unary) | 约 33 倍 SQL |
-| OTLP Logs | 约 29 倍 SQL |
-| InfluxDB Line Protocol | 约 27 倍 SQL |
-| MySQL INSERT | 约 2 倍 PostgreSQL |
-| PostgreSQL INSERT | 基线 |
+| gRPC Bulk (Arrow Flight) | 最高（约 37 倍 SQL） |
+| gRPC Stream | 约 21 倍 SQL |
+| gRPC SDK (Unary) | 约 16 倍 SQL |
+| InfluxDB Line Protocol | 约 12 倍 SQL |
+| OTLP Logs | 约 8.5 倍 SQL |
+| MySQL / PostgreSQL INSERT | 基线 |
 
 **选择建议：**
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.0/faq-and-others/faq.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.0/faq-and-others/faq.md
@@ -157,13 +157,12 @@ GreptimeDB 支持多种写入协议，吞吐性能差异很大。以下数据来
 
 | 协议 | 相对吞吐 |
 | --- | --- |
-| gRPC Bulk (Arrow Flight) | 最高（约 55 倍 SQL） |
-| gRPC Stream | 约 40 倍 SQL |
-| gRPC SDK (Unary) | 约 33 倍 SQL |
-| OTLP Logs | 约 29 倍 SQL |
-| InfluxDB Line Protocol | 约 27 倍 SQL |
-| MySQL INSERT | 约 2 倍 PostgreSQL |
-| PostgreSQL INSERT | 基线 |
+| gRPC Bulk (Arrow Flight) | 最高（约 37 倍 SQL） |
+| gRPC Stream | 约 21 倍 SQL |
+| gRPC SDK (Unary) | 约 16 倍 SQL |
+| InfluxDB Line Protocol | 约 12 倍 SQL |
+| OTLP Logs | 约 8.5 倍 SQL |
+| MySQL / PostgreSQL INSERT | 基线 |
 
 **选择建议：**
 

--- a/versioned_docs/version-1.0/faq-and-others/faq.md
+++ b/versioned_docs/version-1.0/faq-and-others/faq.md
@@ -157,13 +157,12 @@ GreptimeDB supports multiple ingestion protocols with very different throughput 
 
 | Protocol | Relative throughput |
 | --- | --- |
-| gRPC Bulk (Arrow Flight) | Highest (~55x SQL) |
-| gRPC Stream | ~40x SQL |
-| gRPC SDK (Unary) | ~33x SQL |
-| OTLP Logs | ~29x SQL |
-| InfluxDB Line Protocol | ~27x SQL |
-| MySQL INSERT | ~2x PostgreSQL |
-| PostgreSQL INSERT | Baseline |
+| gRPC Bulk (Arrow Flight) | Highest (~37x SQL) |
+| gRPC Stream | ~21x SQL |
+| gRPC SDK (Unary) | ~16x SQL |
+| InfluxDB Line Protocol | ~12x SQL |
+| OTLP Logs | ~8.5x SQL |
+| MySQL / PostgreSQL INSERT | Baseline |
 
 **How to choose:**
 


### PR DESCRIPTION
Update the ingestion protocol comparison table in FAQ (v1.0 + nightly, EN/ZH) to match the latest benchmark: https://greptime.com/blogs/2026-03-24-ingestion-protocol-benchmark