### PR TITLE
docs: note that append_mode hint is ignored for InfluxDB auto-created tables

### DIFF
--- a/docs/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
+++ b/docs/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
@@ -150,6 +150,7 @@ Here are the similarities and differences between the data models of GreptimeDB 
 - Both solutions are [schemaless](/user-guide/ingest-data/overview.md#automatic-schema-generation), eliminating the need to define a schema before writing data.
 - The GreptimeDB table is automatically created with the [`merge_mode` option](/reference/sql/create.md#create-a-table-with-merge-mode) set to `last_non_null`.
 That means the table merges rows with the same tags and timestamp by keeping the latest value of each field, which is the same behavior as InfluxDB.
+Because of this, the [`append_mode` hint](/user-guide/protocols/http.md#hints) in the HTTP header is also ignored for auto-created tables — the `last_non_null` merge mode always takes precedence.
 - In InfluxDB, a point represents a single data record with a measurement, tag set, field set, and a timestamp.
 In GreptimeDB, it is represented as a row of data in the time-series table,
 where the table name aligns with the measurement,

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
@@ -151,6 +151,7 @@ GreptimeDB 的[数据模型](/user-guide/concepts/data-model.md) 是值得了解
 - 两者都是 [schemaless 写入](/user-guide/ingest-data/overview.md#自动生成表结构)的解决方案，这意味着在写入数据之前无需定义表结构。
 - GreptimeDB 的表在自动创建时会设置表选项 [`merge_mode`](/reference/sql/create.md#创建带有-merge-模式的表)为 `last_non_null`。
   这意味着表会通过保留每个字段的最新值来合并具有相同主键和时间戳的行，该行为与 InfluxDB 相同。
+  因此，自动创建的表也会忽略 HTTP 请求头中的 [`append_mode` hint](/user-guide/protocols/http.md#hints)，`last_non_null` 合并模式始终优先。
 - 在 InfluxDB 中，一个点代表一条数据记录，包含一个 measurement、tag 集、field 集和时间戳。
   在 GreptimeDB 中，它被表示为时间序列表中的一行数据。
   表名对应于 measurement，列由三种类型组成：Tag、Field 和 Timestamp。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.12/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.12/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
@@ -149,6 +149,7 @@ GreptimeDB 的[数据模型](/user-guide/concepts/data-model.md) 是值得了解
 - 两者都是 [schemaless 写入](/user-guide/ingest-data/overview.md#自动生成表结构)的解决方案，这意味着在写入数据之前无需定义表结构。
 - GreptimeDB 的表在自动创建时会设置表选项 [`merge_mode`](/reference/sql/create.md#创建带有-merge-模式的表)为 `last_non_null`。
   这意味着表会通过保留每个字段的最新值来合并具有相同主键和时间戳的行，该行为与 InfluxDB 相同。
+  因此，自动创建的表也会忽略 HTTP 请求头中的 [`append_mode` hint](/user-guide/protocols/http.md#hints)，`last_non_null` 合并模式始终优先。
 - 在 InfluxDB 中，一个点代表一条数据记录，包含一个 measurement、tag 集、field 集和时间戳。
   在 GreptimeDB 中，它被表示为时间序列表中的一行数据。
   表名对应于 measurement，列由三种类型组成：Tag、Field 和 Timestamp。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.13/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.13/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
@@ -149,6 +149,7 @@ GreptimeDB 的[数据模型](/user-guide/concepts/data-model.md) 是值得了解
 - 两者都是 [schemaless 写入](/user-guide/ingest-data/overview.md#自动生成表结构)的解决方案，这意味着在写入数据之前无需定义表结构。
 - GreptimeDB 的表在自动创建时会设置表选项 [`merge_mode`](/reference/sql/create.md#创建带有-merge-模式的表)为 `last_non_null`。
   这意味着表会通过保留每个字段的最新值来合并具有相同主键和时间戳的行，该行为与 InfluxDB 相同。
+  因此，自动创建的表也会忽略 HTTP 请求头中的 [`append_mode` hint](/user-guide/protocols/http.md#hints)，`last_non_null` 合并模式始终优先。
 - 在 InfluxDB 中，一个点代表一条数据记录，包含一个 measurement、tag 集、field 集和时间戳。
   在 GreptimeDB 中，它被表示为时间序列表中的一行数据。
   表名对应于 measurement，列由三种类型组成：Tag、Field 和 Timestamp。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.14/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
@@ -151,6 +151,7 @@ GreptimeDB 的[数据模型](/user-guide/concepts/data-model.md) 是值得了解
 - 两者都是 [schemaless 写入](/user-guide/ingest-data/overview.md#自动生成表结构)的解决方案，这意味着在写入数据之前无需定义表结构。
 - GreptimeDB 的表在自动创建时会设置表选项 [`merge_mode`](/reference/sql/create.md#创建带有-merge-模式的表)为 `last_non_null`。
   这意味着表会通过保留每个字段的最新值来合并具有相同主键和时间戳的行，该行为与 InfluxDB 相同。
+  因此，自动创建的表也会忽略 HTTP 请求头中的 [`append_mode` hint](/user-guide/protocols/http.md#hints)，`last_non_null` 合并模式始终优先。
 - 在 InfluxDB 中，一个点代表一条数据记录，包含一个 measurement、tag 集、field 集和时间戳。
   在 GreptimeDB 中，它被表示为时间序列表中的一行数据。
   表名对应于 measurement，列由三种类型组成：Tag、Field 和 Timestamp。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.15/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.15/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
@@ -151,6 +151,7 @@ GreptimeDB 的[数据模型](/user-guide/concepts/data-model.md) 是值得了解
 - 两者都是 [schemaless 写入](/user-guide/ingest-data/overview.md#自动生成表结构)的解决方案，这意味着在写入数据之前无需定义表结构。
 - GreptimeDB 的表在自动创建时会设置表选项 [`merge_mode`](/reference/sql/create.md#创建带有-merge-模式的表)为 `last_non_null`。
   这意味着表会通过保留每个字段的最新值来合并具有相同主键和时间戳的行，该行为与 InfluxDB 相同。
+  因此，自动创建的表也会忽略 HTTP 请求头中的 [`append_mode` hint](/user-guide/protocols/http.md#hints)，`last_non_null` 合并模式始终优先。
 - 在 InfluxDB 中，一个点代表一条数据记录，包含一个 measurement、tag 集、field 集和时间戳。
   在 GreptimeDB 中，它被表示为时间序列表中的一行数据。
   表名对应于 measurement，列由三种类型组成：Tag、Field 和 Timestamp。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.16/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.16/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
@@ -151,6 +151,7 @@ GreptimeDB 的[数据模型](/user-guide/concepts/data-model.md) 是值得了解
 - 两者都是 [schemaless 写入](/user-guide/ingest-data/overview.md#自动生成表结构)的解决方案，这意味着在写入数据之前无需定义表结构。
 - GreptimeDB 的表在自动创建时会设置表选项 [`merge_mode`](/reference/sql/create.md#创建带有-merge-模式的表)为 `last_non_null`。
   这意味着表会通过保留每个字段的最新值来合并具有相同主键和时间戳的行，该行为与 InfluxDB 相同。
+  因此，自动创建的表也会忽略 HTTP 请求头中的 [`append_mode` hint](/user-guide/protocols/http.md#hints)，`last_non_null` 合并模式始终优先。
 - 在 InfluxDB 中，一个点代表一条数据记录，包含一个 measurement、tag 集、field 集和时间戳。
   在 GreptimeDB 中，它被表示为时间序列表中的一行数据。
   表名对应于 measurement，列由三种类型组成：Tag、Field 和 Timestamp。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.17/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.17/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
@@ -151,6 +151,7 @@ GreptimeDB 的[数据模型](/user-guide/concepts/data-model.md) 是值得了解
 - 两者都是 [schemaless 写入](/user-guide/ingest-data/overview.md#自动生成表结构)的解决方案，这意味着在写入数据之前无需定义表结构。
 - GreptimeDB 的表在自动创建时会设置表选项 [`merge_mode`](/reference/sql/create.md#创建带有-merge-模式的表)为 `last_non_null`。
   这意味着表会通过保留每个字段的最新值来合并具有相同主键和时间戳的行，该行为与 InfluxDB 相同。
+  因此，自动创建的表也会忽略 HTTP 请求头中的 [`append_mode` hint](/user-guide/protocols/http.md#hints)，`last_non_null` 合并模式始终优先。
 - 在 InfluxDB 中，一个点代表一条数据记录，包含一个 measurement、tag 集、field 集和时间戳。
   在 GreptimeDB 中，它被表示为时间序列表中的一行数据。
   表名对应于 measurement，列由三种类型组成：Tag、Field 和 Timestamp。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
@@ -151,6 +151,7 @@ GreptimeDB 的[数据模型](/user-guide/concepts/data-model.md) 是值得了解
 - 两者都是 [schemaless 写入](/user-guide/ingest-data/overview.md#自动生成表结构)的解决方案，这意味着在写入数据之前无需定义表结构。
 - GreptimeDB 的表在自动创建时会设置表选项 [`merge_mode`](/reference/sql/create.md#创建带有-merge-模式的表)为 `last_non_null`。
   这意味着表会通过保留每个字段的最新值来合并具有相同主键和时间戳的行，该行为与 InfluxDB 相同。
+  因此，自动创建的表也会忽略 HTTP 请求头中的 [`append_mode` hint](/user-guide/protocols/http.md#hints)，`last_non_null` 合并模式始终优先。
 - 在 InfluxDB 中，一个点代表一条数据记录，包含一个 measurement、tag 集、field 集和时间戳。
   在 GreptimeDB 中，它被表示为时间序列表中的一行数据。
   表名对应于 measurement，列由三种类型组成：Tag、Field 和 Timestamp。

--- a/versioned_docs/version-0.12/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
+++ b/versioned_docs/version-0.12/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
@@ -148,6 +148,7 @@ Here are the similarities and differences between the data models of GreptimeDB 
 - Both solutions are [schemaless](/user-guide/ingest-data/overview.md#automatic-schema-generation), eliminating the need to define a schema before writing data.
 - The GreptimeDB table is automatically created with the [`merge_mode` option](/reference/sql/create.md#create-a-table-with-merge-mode) set to `last_non_null`.
 That means the table merges rows with the same tags and timestamp by keeping the latest value of each field, which is the same behavior as InfluxDB.
+Because of this, the [`append_mode` hint](/user-guide/protocols/http.md#hints) in the HTTP header is also ignored for auto-created tables — the `last_non_null` merge mode always takes precedence.
 - In InfluxDB, a point represents a single data record with a measurement, tag set, field set, and a timestamp.
 In GreptimeDB, it is represented as a row of data in the time-series table,
 where the table name aligns with the measurement,

--- a/versioned_docs/version-0.13/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
+++ b/versioned_docs/version-0.13/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
@@ -148,6 +148,7 @@ Here are the similarities and differences between the data models of GreptimeDB 
 - Both solutions are [schemaless](/user-guide/ingest-data/overview.md#automatic-schema-generation), eliminating the need to define a schema before writing data.
 - The GreptimeDB table is automatically created with the [`merge_mode` option](/reference/sql/create.md#create-a-table-with-merge-mode) set to `last_non_null`.
 That means the table merges rows with the same tags and timestamp by keeping the latest value of each field, which is the same behavior as InfluxDB.
+Because of this, the [`append_mode` hint](/user-guide/protocols/http.md#hints) in the HTTP header is also ignored for auto-created tables — the `last_non_null` merge mode always takes precedence.
 - In InfluxDB, a point represents a single data record with a measurement, tag set, field set, and a timestamp.
 In GreptimeDB, it is represented as a row of data in the time-series table,
 where the table name aligns with the measurement,

--- a/versioned_docs/version-0.14/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
+++ b/versioned_docs/version-0.14/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
@@ -150,6 +150,7 @@ Here are the similarities and differences between the data models of GreptimeDB 
 - Both solutions are [schemaless](/user-guide/ingest-data/overview.md#automatic-schema-generation), eliminating the need to define a schema before writing data.
 - The GreptimeDB table is automatically created with the [`merge_mode` option](/reference/sql/create.md#create-a-table-with-merge-mode) set to `last_non_null`.
 That means the table merges rows with the same tags and timestamp by keeping the latest value of each field, which is the same behavior as InfluxDB.
+Because of this, the [`append_mode` hint](/user-guide/protocols/http.md#hints) in the HTTP header is also ignored for auto-created tables — the `last_non_null` merge mode always takes precedence.
 - In InfluxDB, a point represents a single data record with a measurement, tag set, field set, and a timestamp.
 In GreptimeDB, it is represented as a row of data in the time-series table,
 where the table name aligns with the measurement,

--- a/versioned_docs/version-0.15/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
+++ b/versioned_docs/version-0.15/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
@@ -150,6 +150,7 @@ Here are the similarities and differences between the data models of GreptimeDB 
 - Both solutions are [schemaless](/user-guide/ingest-data/overview.md#automatic-schema-generation), eliminating the need to define a schema before writing data.
 - The GreptimeDB table is automatically created with the [`merge_mode` option](/reference/sql/create.md#create-a-table-with-merge-mode) set to `last_non_null`.
 That means the table merges rows with the same tags and timestamp by keeping the latest value of each field, which is the same behavior as InfluxDB.
+Because of this, the [`append_mode` hint](/user-guide/protocols/http.md#hints) in the HTTP header is also ignored for auto-created tables — the `last_non_null` merge mode always takes precedence.
 - In InfluxDB, a point represents a single data record with a measurement, tag set, field set, and a timestamp.
 In GreptimeDB, it is represented as a row of data in the time-series table,
 where the table name aligns with the measurement,

--- a/versioned_docs/version-0.16/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
+++ b/versioned_docs/version-0.16/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
@@ -150,6 +150,7 @@ Here are the similarities and differences between the data models of GreptimeDB 
 - Both solutions are [schemaless](/user-guide/ingest-data/overview.md#automatic-schema-generation), eliminating the need to define a schema before writing data.
 - The GreptimeDB table is automatically created with the [`merge_mode` option](/reference/sql/create.md#create-a-table-with-merge-mode) set to `last_non_null`.
 That means the table merges rows with the same tags and timestamp by keeping the latest value of each field, which is the same behavior as InfluxDB.
+Because of this, the [`append_mode` hint](/user-guide/protocols/http.md#hints) in the HTTP header is also ignored for auto-created tables — the `last_non_null` merge mode always takes precedence.
 - In InfluxDB, a point represents a single data record with a measurement, tag set, field set, and a timestamp.
 In GreptimeDB, it is represented as a row of data in the time-series table,
 where the table name aligns with the measurement,

--- a/versioned_docs/version-0.17/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
+++ b/versioned_docs/version-0.17/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
@@ -150,6 +150,7 @@ Here are the similarities and differences between the data models of GreptimeDB 
 - Both solutions are [schemaless](/user-guide/ingest-data/overview.md#automatic-schema-generation), eliminating the need to define a schema before writing data.
 - The GreptimeDB table is automatically created with the [`merge_mode` option](/reference/sql/create.md#create-a-table-with-merge-mode) set to `last_non_null`.
 That means the table merges rows with the same tags and timestamp by keeping the latest value of each field, which is the same behavior as InfluxDB.
+Because of this, the [`append_mode` hint](/user-guide/protocols/http.md#hints) in the HTTP header is also ignored for auto-created tables — the `last_non_null` merge mode always takes precedence.
 - In InfluxDB, a point represents a single data record with a measurement, tag set, field set, and a timestamp.
 In GreptimeDB, it is represented as a row of data in the time-series table,
 where the table name aligns with the measurement,

--- a/versioned_docs/version-1.0/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
+++ b/versioned_docs/version-1.0/user-guide/ingest-data/for-iot/influxdb-line-protocol.md
@@ -150,6 +150,7 @@ Here are the similarities and differences between the data models of GreptimeDB 
 - Both solutions are [schemaless](/user-guide/ingest-data/overview.md#automatic-schema-generation), eliminating the need to define a schema before writing data.
 - The GreptimeDB table is automatically created with the [`merge_mode` option](/reference/sql/create.md#create-a-table-with-merge-mode) set to `last_non_null`.
 That means the table merges rows with the same tags and timestamp by keeping the latest value of each field, which is the same behavior as InfluxDB.
+Because of this, the [`append_mode` hint](/user-guide/protocols/http.md#hints) in the HTTP header is also ignored for auto-created tables — the `last_non_null` merge mode always takes precedence.
 - In InfluxDB, a point represents a single data record with a measurement, tag set, field set, and a timestamp.
 In GreptimeDB, it is represented as a row of data in the time-series table,
 where the table name aligns with the measurement,


### PR DESCRIPTION
## Summary

- Add a note to the InfluxDB line protocol docs that the `append_mode` HTTP header hint is ignored for auto-created tables, since `merge_mode` is always set to `last_non_null`.
- Update all versioned English docs (0.12–1.0), nightly English docs, and all Chinese docs (nightly + 0.12–1.0).

## Test plan

- [ ] Verify the new note renders correctly in the English nightly docs
- [ ] Verify the new note renders correctly in the Chinese nightly docs
- [ ] Confirm all versioned docs contain the same addition