### PR TITLE
docs: add self-monitoring export skill

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -10,6 +10,7 @@ This is the GreptimeDB documentation for AI agents.
 - `greptimedb-pipeline`: For creating greptimedb pipeline definition
 - `greptimedb-flow`: For creating greptimedb flow, continuous aggregation tasks
 - `greptimedb-trigger`: For creating greptimedb trigger
+- `self-monitoring-export`: For GreptimeDB Cluster incidents — infer the required log export time range from the user's abnormal-behavior description, then export complete cluster self-monitoring logs and relevant monitoring metrics for engineering investigation
 
 The `greptimedb-quickstart` skill is also hosted at <https://docs.greptime.com/SKILL.md> (and <https://docs.greptime.cn/SKILL.md>), so any AI coding agent can load it with a single instruction:
 
@@ -34,3 +35,9 @@ Using `skills` cli tool to install the skill to your coding agents.
 ### `greptimedb-trigger`
 
 `npx skills add https://github.com/GreptimeTeam/docs/tree/main/skills/greptimedb-trigger`
+
+### `self-monitoring-export`
+
+[![asciicast](https://asciinema.org/a/N59fXqonAiRYMk4L.svg)](https://asciinema.org/a/N59fXqonAiRYMk4L)
+
+`npx skills add https://github.com/GreptimeTeam/docs/tree/main/skills/self-monitoring-export`

--- a/skills/self-monitoring-export/SKILL.md
+++ b/skills/self-monitoring-export/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: self-monitoring-export
+description: Locate GreptimeDB self-monitoring incident windows and safely export complete logs, with optional related metrics, for engineering investigation.
+---
+
+# Self-Monitoring Export
+
+You are a GreptimeDB incident log collection assistant.
+
+## Mission
+
+Locate when an incident happened using the GreptimeDB self-monitoring database, determine a safe and sufficient continuous export window, and export all logs for that window for engineering investigation.
+
+Root-cause analysis is optional. Only infer possible causes when it helps decide whether the export window should be widened or which key metrics should also be exported.
+
+## Scope
+
+Use this skill for users who enabled GreptimeDB Cluster self-monitoring, typically through GreptimeDB Operator with `monitoring.enabled=true`.
+
+Expected self-monitoring data:
+
+- Logs: SQL-queryable from `public._gt_logs`.
+- Metrics: officially exposed through the self-monitoring Prometheus endpoint; in some deployments also queryable as SQL tables such as `greptime_*`, `opendal_*`, `process_*`, etc.
+
+If the user uses their own Prometheus, Loki, ELK, OpenSearch, or custom telemetry pipeline instead of GreptimeDB Cluster self-monitoring, this skill may not directly apply. Reuse the workflow concept, but do not assume table names or SQL syntax.
+
+## Hard Rules
+
+1. The deliverable is a complete continuous log export, not a root-cause essay.
+2. Never export only top errors, sampled logs, or only `ERROR` logs.
+3. Include `WARN` during window discovery.
+4. Use metrics to locate/refine the time window, not as a replacement for log export.
+5. Prefer over-exporting to under-exporting, but protect the self-monitoring database.
+6. Before any large export, estimate row count and ask for confirmation.
+7. Split large exports by hour or smaller chunks instead of running one huge query.
+8. Record timezone assumptions explicitly.
+9. Never include credentials, tokens, passwords, or secret URLs in the final report.
+10. The final report content language must match the response language selected by the user. Keep file names, directory names, SQL, commands, table names, and metric names in English.
+11. Use MCP and GreptimeDB HTTP SQL as peer query access methods for incident analysis and time-window discovery. MCP is optional; when MCP is unavailable, use HTTP SQL or a SQL client against the self-monitoring GreptimeDB.
+12. Recommend the GreptimeDB HTTP port when reachable because it can run discovery SQL and export local files through the same `/v1/sql` endpoint. Before exporting any data, present GreptimeDB HTTP port export and `COPY TO` modes, then wait for user confirmation. `COPY TO` has three execution modes; HTTP port export writes Arrow IPC response files on the client side and should request compression by default with `zstd` first and `lz4` second. Do not offer MCP result download, PostgreSQL `\copy`, or other export methods as choices.
+13. In SQL `COPY` scenarios, prefer Parquet unless the user explicitly needs text output or Parquet is unavailable.
+14. Never run `COPY`, `COPY TO`, or any export-writing command through MCP. MCP is for analysis/read queries only.
+15. Remember that SQL `COPY TO '<path>'` writes to the self-monitoring GreptimeDB server-side or pod-local filesystem — not the agent/client local filesystem. The output file exists on the self-monitoring filesystem until explicitly retrieved.
+16. Supported export methods are GreptimeDB HTTP port export; user-executed `COPY TO`; agent-executed `COPY TO` without retrieving data, where the user downloads files later; and agent-executed `COPY TO` plus `kubectl cp` retrieval into the local artifact directory. Prefer the HTTP port when reachable; it avoids extra SQL protocol and retrieval coordination.
+17. If the user chooses user-executed `COPY TO`, provide a ready-to-run `COPY TO` script with concrete SQL values for the user to execute manually. Do not give placeholder SQL unless a required value is still unknown; ask for the missing value first.
+18. The final deliverable must be a local artifact directory on the user's/client machine. For agent-executed `COPY TO` without retrieval, the local directory contains command records, manifest entries, expected self-monitoring filesystem paths, and download instructions, but not the remote data files. For agent-executed `COPY TO` with `kubectl cp`, retrieve exported files into the local directory.
+19. Treat skill `scripts/` as the canonical implementation. Execute helper scripts directly from the installed skill directory by default. Artifact `commands/` files should record concrete SQL and wrapper invocations for audit/replay, not duplicate helper implementation, unless the user explicitly requests a self-contained artifact.
+20. Every output artifact must be placed under the fixed layout defined in [`references/export-layout.md`](references/export-layout.md). Do not create ad-hoc files outside the layout; if a new artifact type is needed, add it to the nearest existing fixed subdirectory and record it in the manifest.
+21. For very long incident ranges, do not default to exporting the entire long range. Identify critical windows and possibly useful context windows, then export necessary logs plus justified context windows.
+22. Use the built-in SQL templates in [`references/sql-cheatsheet.md`](references/sql-cheatsheet.md) before searching docs or launching subagents for common time-bucketing, aggregation, and `COPY TO` syntax.
+23. When the agent CLI supports interactive UI, use single-select, multi-select, confirm, and true free-text/textbox controls appropriately. Use selection controls only for closed choices. Use true free-text/textbox controls for arbitrary values. If no true textbox exists, ask a plain text question instead of using a custom option in a selection control.
+
+## Guide Map
+
+Follow these detailed guides when needed:
+
+- [`references/inputs.md`](references/inputs.md) — language, timezone, symptom, query access, export capability, and Kubernetes capability prompts.
+- [`references/query-access.md`](references/query-access.md) — MCP, HTTP SQL, and SQL-client query access for discovery and validation.
+- [`references/discovery.md`](references/discovery.md) — schema inspection, cluster/version discovery, and description-driven log window discovery.
+- [`references/signal-index.md`](references/signal-index.md) — symptom-to-source/keyword/metric index for description-driven window discovery.
+- [`references/sql-cheatsheet.md`](references/sql-cheatsheet.md) — common GreptimeDB SQL templates for time bucketing, range aggregation, row counts, and `COPY TO` exports.
+- [`references/export-layout.md`](references/export-layout.md) — artifact directory layout, command records, and file naming.
+- [`references/export-mcp.md`](references/export-mcp.md) — MCP read-only analysis rules and final-export prohibition.
+- [`references/export-copy.md`](references/export-copy.md) — SQL `COPY TO`, Parquet preference, self-monitoring filesystem output, and optional `kubectl cp` retrieval.
+- [`references/export-http.md`](references/export-http.md) — GreptimeDB HTTP port export, client-side `.<encoding>.arrow` artifacts, compression, chunking, and PyArrow validation.
+- [`references/export-metrics.md`](references/export-metrics.md) — optional metric correlation/export.
+- [`references/validation.md`](references/validation.md) — post-export row-count validation and mismatch handling.
+- [`references/report-template.md`](references/report-template.md) — final report structure.
+- [`references.md`](references.md) — official docs and source references.
+
+## Workflow
+
+1. Ask only the response language question. Use an interactive single-select if supported. Do not combine it with timezone, incident, access, or export questions. Use [`references/inputs.md`](references/inputs.md).
+2. After the user answers the language question, ask for the user's timezone as the first localized follow-up question. Use a true interactive free-text/textbox input if supported; otherwise ask a plain text question. This timezone question is required.
+3. Ask the remaining minimum required input questions in the selected language, including whether the GreptimeDB HTTP port is reachable, `COPY TO` availability only when needed, `kubectl cp` capability only when a `COPY TO` retrieval mode is considered, and whether the local client can validate Arrow with PyArrow. Prefer interactive single-select, multi-select, confirm, and free-text controls when supported.
+4. Explain the data source model: query and export from the GreptimeDB Cluster self-monitoring instance — typically a GreptimeDB Standalone instance — that stores logs and metrics for the GreptimeDB cluster being investigated. Do not use the business or production GreptimeDB endpoint as the log export source unless it is also the self-monitoring instance.
+5. Inspect `public._gt_logs` schema and discover cluster metadata/version from self-monitoring data. Use [`references/discovery.md`](references/discovery.md).
+6. Analyze incident timing through one available query access path: MCP, GreptimeDB HTTP SQL, or a SQL client. Treat MCP and HTTP SQL as peer options. Interpret the user's description first, use [`references/signal-index.md`](references/signal-index.md) to map symptoms to components, source modules, log keywords, and metrics. If no direct log keyword match exists, follow [`references.md`](references.md): clone GreptimeDB source into a temporary source checkout, prefer the investigated GreptimeDB version, fall back to main when no matching version is available, and search exact strings, module names, and metric names before falling back to generic `ERROR` / `WARN` aggregation. Use built-in SQL templates from [`references/sql-cheatsheet.md`](references/sql-cheatsheet.md) for targeted discovery.
+7. Decide export windows from ranked signal hypotheses. For short incidents, use one continuous window. For very long ranges, identify critical windows and possibly useful context windows instead of blindly exporting the whole range.
+8. Estimate row count and ask confirmation for large exports.
+9. Create or propose the fixed local artifact directory layout. This local directory is the final deliverable for both agent-executed and user-executed modes. All generated files must go under this layout. Use [`references/export-layout.md`](references/export-layout.md).
+10. Present the supported export choices as peers:
+    1. **GreptimeDB HTTP port export** — use the GreptimeDB HTTP port for both discovery SQL and export; POST SQL to `/v1/sql?db=<db>&format=arrow`, request compression with `zstd` then `lz4`, save Arrow IPC files directly into the local artifact directory, and validate with PyArrow when available. Do not set an HTTP timeout header.
+    2. **User-executed `COPY TO`** — generate ready-to-run SQL/shell scripts with concrete values in the local artifact directory; the user runs them manually and downloads files manually.
+    3. **Agent-executed `COPY TO`, no retrieval** — the agent runs the confirmed non-MCP `COPY TO`; output remains on the self-monitoring filesystem for the user to download later.
+    4. **Agent-executed `COPY TO` + `kubectl cp` retrieval** — the agent runs the confirmed non-MCP `COPY TO`, then uses `kubectl cp` to retrieve files into the local artifact directory.
+    Include local artifact directory path, self-monitoring filesystem COPY output path or HTTP port export local output path, format/compression, chunking, selected export windows, row count, and whether data files will be retrieved. Use an interactive picker/confirm when supported, and wait for user confirmation before exporting or generating final scripts.
+11. Export all logs for the continuous window using the confirmed export choice. Do not offer MCP result download, PostgreSQL `\copy`, `kubectl exec ... cat`, tarball transfer, or other transfer modes as user-facing options.
+12. For `COPY TO`, follow [`references/sql-cheatsheet.md`](references/sql-cheatsheet.md) and [`references/export-copy.md`](references/export-copy.md). Make it explicit that `COPY TO` writes on the self-monitoring filesystem, not the client side. For HTTP port export, follow [`references/export-http.md`](references/export-http.md).
+13. Optionally export relevant metrics using [`references/export-metrics.md`](references/export-metrics.md), using the same confirmed export choice.
+14. Validate exported row counts against pre-export counts using [`references/validation.md`](references/validation.md). For HTTP port exports, run the Arrow validation script on the exported `.arrow` files.
+15. Produce the final report using [`references/report-template.md`](references/report-template.md). The report content language must match the user-selected response language; file names and technical identifiers remain English.
+
+## Export Method Selection
+
+Prefer GreptimeDB HTTP port export when the port is reachable because the same endpoint supports discovery SQL and local file export. Still present the three `COPY TO` modes as alternatives when HTTP is unavailable or the user prefers server-side export. Explain the tradeoff: HTTP port export writes local Arrow IPC files directly through the client HTTP path; `COPY TO` writes on the self-monitoring filesystem first and may require user download or `kubectl cp`. MCP and HTTP SQL are peer query access methods for analysis/discovery only, not final export choices.
+
+## Documentation Recovery Rule
+
+If a `COPY` command fails, do not retry blindly. Capture the exact error, discover GreptimeDB version if possible, then consult the version-appropriate docs in [`references.md`](references.md) and [`references/export-copy.md`](references/export-copy.md).

--- a/skills/self-monitoring-export/references.md
+++ b/skills/self-monitoring-export/references.md
@@ -1,0 +1,62 @@
+# Self-Monitoring Export References
+
+GreptimeDB source:
+
+- https://github.com/GreptimeTeam/greptimedb
+
+For source lookup, do not assume the user has a local GreptimeDB repository and do not search the user's current workspace unless explicitly instructed. Prefer to clone <https://github.com/GreptimeTeam/greptimedb> into a temporary source checkout, search that checkout, and clean it up after use. Match the checkout to the investigated GreptimeDB version whenever possible; if the version, tag, or commit cannot be determined or checked out, use the main branch. Use public HTTPS only; do not require or store credentials. If cloning is unavailable, search the remote GreptimeDB repository instead. Use source lookup before generic `ERROR` / `WARN` aggregation when the user's description does not directly map to known log keywords.
+
+Suggested source lookup flow:
+
+1. Create a temporary directory under `${TMPDIR:-/tmp}`.
+2. Determine the investigated GreptimeDB version from self-monitoring data when available, such as `greptime_app_version`.
+3. Clone `https://github.com/GreptimeTeam/greptimedb` into that directory. Prefer a shallow clone when possible.
+4. Check out the matching release tag or commit when it can be identified. If no matching version can be identified or checked out, use the main branch.
+5. Search only inside that temporary source checkout.
+6. Remove the temporary source checkout after the lookup.
+
+Do not confuse this temporary source checkout with server-side `/tmp/...` paths used by `COPY TO` export examples.
+
+GreptimeDB documentation:
+
+- https://docs.greptime.com
+
+GreptimeDB documentation repository:
+
+- https://github.com/GreptimeTeam/docs
+
+Self-monitoring GreptimeDB clusters:
+
+- https://docs.greptime.com/user-guide/deployments-administration/monitoring/cluster-monitoring-deployment/
+
+SQL `COPY`:
+
+- https://docs.greptime.com/reference/sql/copy/
+
+SQL functions / date_bin:
+
+- https://docs.greptime.com/reference/sql/functions/df-functions/
+
+SQL range query:
+
+- https://docs.greptime.com/reference/sql/range/
+
+HTTP API:
+
+- https://docs.greptime.com/user-guide/protocols/http/
+
+HTTP endpoints:
+
+- https://docs.greptime.com/reference/http-endpoints/
+
+CLI data export:
+
+- https://docs.greptime.com/reference/command-lines/utilities/data/
+
+Timezone:
+
+- https://docs.greptime.com/user-guide/timezone/
+
+Troubleshooting:
+
+- https://docs.greptime.com/user-guide/deployments-administration/troubleshooting/

--- a/skills/self-monitoring-export/references/discovery.md
+++ b/skills/self-monitoring-export/references/discovery.md
@@ -218,7 +218,7 @@ Default rules:
 
 - Exact spike known: export `T-30min` to `T+30min`.
 - Ramp-up: export from first anomaly minus 30min to recovery plus 30min.
-- Related WARNs precede ERRORs: start from first related WARN.
+- Related WARNs precede ERROR: start from first related WARN.
 - Meta, heartbeat, region migration, or repartition appears involved: widen to `T-2h` to `T+2h`.
 - Storage/network timeouts appear intermittent: include at least one full retry cycle before and after.
 - Unsure: export a wider window, but ask for confirmation if large.

--- a/skills/self-monitoring-export/references/discovery.md
+++ b/skills/self-monitoring-export/references/discovery.md
@@ -1,0 +1,251 @@
+# Discovery Guide
+
+## Timezone rules
+
+Use UTC internally whenever possible.
+
+Always report both:
+
+- UTC time
+- User timezone time
+
+Do not assume timestamps are UTC without checking. For HTTP SQL, prefer:
+
+```text
+X-Greptime-Timezone: UTC
+```
+
+Prefer RFC3339 timestamps with explicit offsets when forming queries.
+
+## Verify access and inspect schema
+
+Do not assume schema.
+
+```sql
+SHOW TABLES FROM public;
+DESCRIBE TABLE _gt_logs;
+```
+
+Identify:
+
+- timestamp column
+- level column
+- cluster / namespace labels
+- pod / role labels
+- message / err fields
+
+Common `_gt_logs` columns may include:
+
+```text
+timestamp
+level
+target
+role
+pod
+message
+err
+cluster
+namespace
+```
+
+If MCP is available but the user is unsure whether it points to the self-monitoring instance that monitors the GreptimeDB cluster being investigated, verify by checking whether `_gt_logs` exists and whether self-monitoring metric/log tables are present.
+
+## Discover cluster and namespace
+
+```sql
+SELECT `cluster`, namespace, count(*) AS rows
+FROM _gt_logs
+WHERE timestamp >= now() - INTERVAL '2' DAY
+GROUP BY `cluster`, namespace
+ORDER BY rows DESC;
+```
+
+Note: `cluster` may need backticks because it can be parsed as a keyword.
+
+## Discover GreptimeDB version
+
+First check whether `greptime_app_version` exists:
+
+```sql
+SHOW TABLES FROM public;
+```
+
+If available:
+
+```sql
+SELECT
+  app,
+  version,
+  short_version,
+  `cluster`,
+  namespace,
+  count(DISTINCT pod) AS pods,
+  max(greptime_timestamp) AS last_seen
+FROM greptime_app_version
+WHERE greptime_timestamp >= now() - INTERVAL '1' HOUR
+GROUP BY app, version, short_version, `cluster`, namespace
+ORDER BY app, version, short_version;
+```
+
+If unavailable, ask the user for version only if relevant to the engineering handoff.
+
+## Discover candidate incident windows
+
+Start from the user's abnormal-behavior description, not from generic `ERROR` / `WARN` counts. Use [`signal-index.md`](signal-index.md) to map the description to likely roles, source modules, log keywords, and metrics. If the description does not directly map to known log keywords, inspect GreptimeDB source code first. Do not assume a user-local repository; follow [`../references.md`](../references.md), clone <https://github.com/GreptimeTeam/greptimedb> into a temporary source checkout, prefer the investigated GreptimeDB version, fall back to main when no matching version is available, or use remote source search when cloning is unavailable.
+
+Use [`sql-cheatsheet.md`](sql-cheatsheet.md) for common GreptimeDB time-bucketing templates before searching docs or launching subagents for syntax.
+
+When using HTTP SQL, save small aggregate outputs with [`../scripts/http_sql_query.sh`](../scripts/http_sql_query.sh). Keep discovery queries narrow and aggregated; do not use Arrow bulk export for routine discovery.
+
+Description-driven workflow:
+
+1. Extract symptoms from the user description: affected operation, visible error, role/pod if known, approximate time, and recovery signal.
+2. Pick one or more entries from [`signal-index.md`](signal-index.md).
+3. Build a targeted log filter from role, target, message, and err keywords.
+4. Query around the user-provided time first if available; otherwise use a short recent range such as 2 days.
+5. Check related metrics only after `SHOW TABLES FROM public;` proves the metric tables exist.
+6. Rank candidate windows by symptom match, source-derived keyword match, metric correlation, and temporal clustering.
+
+Targeted keyword discovery example:
+
+```sql
+SELECT
+  date_trunc('minute', timestamp) AS minute,
+  level,
+  role,
+  target,
+  count(*) AS cnt
+FROM _gt_logs
+WHERE timestamp >= '<start_utc>'
+  AND timestamp < '<end_utc>'
+  AND (
+    lower(message) LIKE '%<keyword_1>%'
+    OR lower(err) LIKE '%<keyword_1>%'
+    OR lower(target) LIKE '%<component_or_module>%'
+    OR lower(role) LIKE '%<role>%'
+  )
+GROUP BY minute, level, role, target
+ORDER BY minute, cnt DESC;
+```
+
+Use source-derived strings literally when possible:
+
+```sql
+SELECT
+  timestamp,
+  level,
+  role,
+  pod,
+  target,
+  message,
+  err
+FROM _gt_logs
+WHERE timestamp >= '<start_utc>'
+  AND timestamp < '<end_utc>'
+  AND (
+    message LIKE '%<Exact source log string>%'
+    OR err LIKE '%<Exact source error string>%'
+  )
+ORDER BY timestamp
+LIMIT 200;
+```
+
+Use generic level aggregation only as a fallback or sanity check:
+
+```sql
+SELECT
+  date_trunc('hour', timestamp) AS hour,
+  level,
+  count(*) AS cnt
+FROM _gt_logs
+WHERE timestamp >= now() - INTERVAL '2' DAY
+GROUP BY hour, level
+ORDER BY hour, level;
+```
+
+Fallback top error/warn categories:
+
+```sql
+SELECT
+  date_trunc('hour', timestamp) AS hour,
+  target,
+  message,
+  err,
+  count(*) AS cnt
+FROM _gt_logs
+WHERE timestamp >= now() - INTERVAL '2' DAY
+  AND level IN ('ERROR', 'WARN')
+GROUP BY hour, target, message, err
+ORDER BY cnt DESC
+LIMIT 100;
+```
+
+If the user provided approximate time, search around that time first, but still include pre-window warnings that match the chosen signal index entry or source-derived keyword set.
+
+## Refine the window
+
+Prefer `date_trunc` or `date_bin` examples from [`sql-cheatsheet.md`](sql-cheatsheet.md). Search docs only if the query fails or the target GreptimeDB version requires different syntax.
+
+```sql
+SELECT
+  date_trunc('minute', timestamp) AS minute,
+  level,
+  count(*) AS cnt
+FROM _gt_logs
+WHERE timestamp >= '<start_utc>'
+  AND timestamp < '<end_utc>'
+GROUP BY minute, level
+ORDER BY minute, level;
+```
+
+If supported:
+
+```sql
+SELECT
+  date_bin(INTERVAL '10' MINUTE, timestamp, '1970-01-01 00:00:00'::TIMESTAMP) AS bucket,
+  level,
+  count(*) AS cnt
+FROM _gt_logs
+WHERE timestamp >= '<start_utc>'
+  AND timestamp < '<end_utc>'
+GROUP BY bucket, level
+ORDER BY bucket, level;
+```
+
+## Decide export window
+
+Default rules:
+
+- Exact spike known: export `T-30min` to `T+30min`.
+- Ramp-up: export from first anomaly minus 30min to recovery plus 30min.
+- Related WARNs precede ERRORs: start from first related WARN.
+- Meta, heartbeat, region migration, or repartition appears involved: widen to `T-2h` to `T+2h`.
+- Storage/network timeouts appear intermittent: include at least one full retry cycle before and after.
+- Unsure: export a wider window, but ask for confirmation if large.
+
+## Long-range export strategy
+
+If the suspected incident range is very long, do not mechanically export all logs for the entire range. First compress the investigation into ranked windows:
+
+1. **Critical windows** — must export. These include the first anomaly, peak error period, recovery period, and any state-transition period such as leader change, region migration, repartition, heartbeat loss/recovery, storage timeout burst, or compaction/manifest failure burst.
+2. **Possibly useful context windows** — export when they explain buildup or recovery. These include related WARN ramps, intermittent retries, low-frequency precursors, or metric spikes that precede the main error burst.
+3. **Low-signal background range** — do not export by default. Summarize with counts/aggregations and only export if the user explicitly confirms.
+
+For long ranges, produce an export plan with multiple windows instead of one huge window:
+
+```text
+Critical windows:
+- <start_utc> to <end_utc>: first ERROR burst / peak / recovery
+
+Possibly useful context windows:
+- <start_utc> to <end_utc>: WARN ramp before errors
+
+Not exported by default:
+- <start_utc> to <end_utc>: low-signal background; summarized only
+```
+
+Each exported window must still be continuous within itself and must include all log levels for that window, not only matching errors. If the user asks for the full long range after seeing the plan, estimate row count and require explicit confirmation.
+
+## Signal-to-metric index
+
+Use [`signal-index.md`](signal-index.md) for the maintained symptom-to-source/keyword/metric map. Before querying metrics as SQL tables, always run `SHOW TABLES FROM public;`. Do not assume a generic `public.metrics` table exists.

--- a/skills/self-monitoring-export/references/export-copy.md
+++ b/skills/self-monitoring-export/references/export-copy.md
@@ -1,0 +1,277 @@
+# SQL COPY Export Guide
+
+## Failure recovery
+
+If a SQL `COPY` command fails, do not retry blindly.
+
+Capture:
+
+- exact command or SQL statement, with secrets redacted
+- full error message and status code
+- GreptimeDB version from `greptime_app_version`, if available
+- COPY mode: user-executed, agent-executed without retrieval, or agent-executed plus `kubectl cp`
+- target format: `parquet`, `csv.gz`, or `json.gz`
+- target path on the self-monitoring filesystem, with secrets redacted
+
+Use version-aware documentation lookup:
+
+1. If GreptimeDB version is known, look for docs matching exact version or closest matching stable version.
+2. If exact version is unavailable, use the closest lower supported release.
+3. Use `nightly` docs only for nightly builds or when stable docs clearly do not contain the feature.
+4. If version is unknown, use current stable docs and note uncertainty.
+
+Docs URL patterns:
+
+- Latest stable `1.0`: root paths, e.g. `https://docs.greptime.com/reference/sql/copy/`.
+- Nightly: `/nightly/`, e.g. `https://docs.greptime.com/nightly/reference/sql/copy/`.
+- Historical releases: `/<version>/`, e.g. `https://docs.greptime.com/0.17/reference/sql/copy/`.
+- Do not assume `/1.0/...` is the latest stable path.
+
+Core docs:
+
+- SQL `COPY`: `https://docs.greptime.com/reference/sql/copy/`
+- HTTP API: `https://docs.greptime.com/user-guide/protocols/http/`
+- HTTP endpoints: `https://docs.greptime.com/reference/http-endpoints/`
+- CLI data export: `https://docs.greptime.com/reference/command-lines/utilities/data/`
+- Timezone: `https://docs.greptime.com/user-guide/timezone/`
+- General troubleshooting: `https://docs.greptime.com/user-guide/deployments-administration/troubleshooting/`
+- Docs repo: `https://github.com/GreptimeTeam/docs`
+
+Apply the smallest correction: fix unsupported options, path requirements, server filesystem access, response size, or timezone ambiguity. Record failed command, doc reference, correction, and final command in `commands/` and `summary/gaps_and_risks.md`.
+
+## SQL COPY TO export
+
+Use SQL `COPY TO` as a supported export method when HTTP port export is unavailable or the user prefers server-side files. Before using SQL `COPY TO`, ask the user to choose exactly one of the three supported `COPY TO` modes. Include output format, chunking plan, expected row count, self-monitoring filesystem output path, whether files will be retrieved, local artifact directory target path, and manual script fallback when applicable.
+
+GreptimeDB HTTP port export is preferred when the HTTP port is reachable, especially when the user prefers local output without remote retrieval. Follow [`export-http.md`](export-http.md) instead of inventing another transfer path.
+
+Critical location rule: `COPY TO '<path>'` writes on the self-monitoring GreptimeDB server-side or pod-local filesystem. It does not write to the agent/client local filesystem. The local artifact directory receives exported data files only when the confirmed mode includes `kubectl cp` retrieval. Otherwise, the local artifact directory contains scripts, manifest entries, expected remote paths, and user download instructions, but not the remote data files.
+
+Use [`sql-cheatsheet.md`](sql-cheatsheet.md) for common `COPY TO` Parquet, row-count, and caution templates before searching docs or launching subagents for syntax.
+
+If interactive controls are supported, present the three supported modes as a single-select picker and ask only the selected mode's required values with true free-text/textbox controls. If no true textbox exists, ask plain text questions for those values.
+
+Supported modes:
+
+1. **User-executed `COPY TO`** — the agent generates ready-to-run SQL/shell scripts with concrete self-monitoring filesystem output paths in the local artifact directory; the user runs them manually and downloads files manually.
+2. **Agent-executed `COPY TO`, no retrieval** — the user confirms and the agent runs non-MCP SQL over HTTP/MySQL/PostgreSQL, possibly through `kubectl port-forward`, then leaves output files on the self-monitoring filesystem for the user to download later.
+3. **Agent-executed `COPY TO` + `kubectl cp` retrieval** — the user confirms and the agent runs non-MCP SQL over HTTP/MySQL/PostgreSQL, then uses `kubectl cp` to retrieve the output files into the local artifact directory.
+
+For `COPY TO`, use Parquet first. Do not use CSV/JSON unless the user explicitly needs text output, downstream tools cannot read Parquet, or the GreptimeDB version/export target does not support Parquet.
+
+When using SQL `COPY`, ask which mode to use:
+
+1. User executes `COPY TO` manually.
+2. Agent executes `COPY TO`; user downloads from the self-monitoring filesystem later.
+3. Agent executes `COPY TO`; agent retrieves files with `kubectl cp`.
+
+If interactive controls are supported, present those modes as a single-select prompt. Then ask only the selected mode's required values with true free-text/textbox controls, or plain text questions if no true textbox exists.
+
+`COPY TO` requires a non-MCP SQL/HTTP execution path such as HTTP SQL endpoint, MySQL/PostgreSQL SQL client, `kubectl port-forward` to one of those endpoints, or a user-executed script. MCP must not be used to run the `COPY TO` statement. Regardless of which mode is selected, the final handoff must be represented in the local artifact directory.
+
+Do not assume the GreptimeDB server filesystem is the user's local machine. Treat server-side local paths, including pod-local paths like `/tmp/...`, as remote paths until retrieved.
+
+Make retrieval explicit:
+
+```text
+COPY writes the files on the self-monitoring filesystem, not this client. Choose whether I should retrieve them with kubectl cp or leave them for you to download manually.
+```
+
+If the user chooses agent-executed `COPY TO` without retrieval, state this explicitly:
+
+```text
+I will run COPY TO and leave the files on the self-monitoring filesystem, for example under `/tmp/greptimedb-incident-export/`. The local artifact directory will record paths and download instructions, but it will not contain the data files until you download them.
+```
+
+When using the pod-local option:
+
+- choose a dedicated directory, for example `/tmp/greptimedb-incident-export/<incident-id>/`
+- record the pod name, namespace, container, absolute file path, and expected file list
+- warn that files may be lost if the pod restarts, is rescheduled, or `/tmp` is cleaned
+- warn the user to download files promptly if pod lifecycle changes may delete pod-local data
+- include later-download commands if the user has `kubectl cp` access, but do not require immediate download
+
+The only agent-side retrieval method offered as a user-facing option is:
+
+1. `kubectl cp`
+
+If `kubectl cp` is unavailable, do not offer alternate transfer modes. Use user-executed `COPY TO` or agent-executed `COPY TO` without retrieval.
+
+## Manual COPY TO script fallback
+
+If the user chooses manual execution or the agent cannot execute the confirmed commands, provide a ready-to-run `COPY TO` script for the user to execute manually.
+
+The script must be directly executable after copy/paste. Do not leave placeholders such as `<export_start_utc>`, `<path>`, `<pod>`, or `<chunk_start_utc>` in the final script. If any required value is unknown, ask the user for that value before producing the final script.
+
+The manual script must:
+
+- use fixed UTC boundaries
+- export complete logs, not sampled/top/error-only rows
+- prefer Parquet
+- include chunked statements for large windows
+- use concrete output paths, endpoints, and time boundaries collected from the user or discovered earlier
+- include comments that explain what the script does, not comments requiring user edits
+- include a post-export row-count validation query
+- avoid embedding secrets in the script
+
+Save or present it as `commands/manual_copy_to.sql` in the local artifact directory when an artifact layout is being created. The file content should be final executable SQL, not a template.
+
+If values are missing, ask a focused question before generating the script:
+
+```text
+I can generate a ready-to-run COPY TO SQL script, but I still need the final output path on the self-monitoring filesystem where GreptimeDB can write Parquet files.
+```
+
+Single-file Parquet template:
+
+```sql
+-- Manual GreptimeDB incident log export.
+-- Output path is on the self-monitoring filesystem, not the client side.
+
+-- Pre-export validation count.
+SELECT count(*) AS expected_rows
+FROM _gt_logs
+WHERE timestamp >= '<export_start_utc>'
+  AND timestamp < '<export_end_utc>';
+
+COPY (
+  SELECT *
+  FROM _gt_logs
+  WHERE timestamp >= '<export_start_utc>'
+    AND timestamp < '<export_end_utc>'
+  ORDER BY timestamp
+) TO '/tmp/greptimedb-incident-export/<incident-id>/gt_logs_<export_start>_<export_end>.parquet'
+WITH (FORMAT = 'parquet');
+```
+
+Chunked Parquet template:
+
+```sql
+-- Critical window: first error burst.
+COPY (
+  SELECT *
+  FROM _gt_logs
+  WHERE timestamp >= '<critical_start_utc>'
+    AND timestamp < '<critical_end_utc>'
+  ORDER BY timestamp
+) TO '/tmp/greptimedb-incident-export/<incident-id>/gt_logs_critical_<critical_start>_<critical_end>.parquet'
+WITH (FORMAT = 'parquet');
+
+-- Possibly useful context window: WARN ramp before peak.
+COPY (
+  SELECT *
+  FROM _gt_logs
+  WHERE timestamp >= '<context_start_utc>'
+    AND timestamp < '<context_end_utc>'
+  ORDER BY timestamp
+) TO '/tmp/greptimedb-incident-export/<incident-id>/gt_logs_context_<context_start>_<context_end>.parquet'
+WITH (FORMAT = 'parquet');
+```
+
+## Format preference
+
+Prefer export formats in this order:
+
+1. `parquet` — default and preferred for all COPY incident exports, large windows, and typed offline analysis.
+2. `csv` with `compression_type = 'gzip'` — text fallback; extension `.csv.gz`.
+3. `json` with `compression_type = 'gzip'` — only when JSON is explicitly needed; extension `.json.gz`.
+
+Do not choose CSV/JSON for large exports unless text output is required or Parquet is not usable.
+
+## Server-side examples
+
+Use the canonical templates in [`sql-cheatsheet.md`](sql-cheatsheet.md) first. These examples are kept here for quick COPY-specific context.
+
+Parquet:
+
+```sql
+COPY (
+  SELECT *
+  FROM _gt_logs
+  WHERE timestamp >= '<export_start_utc>'
+    AND timestamp < '<export_end_utc>'
+  ORDER BY timestamp
+) TO '/tmp/gt_logs_incident.parquet'
+WITH (FORMAT = 'parquet');
+```
+
+Compressed CSV fallback:
+
+```sql
+COPY (
+  SELECT *
+  FROM _gt_logs
+  WHERE timestamp >= '<export_start_utc>'
+    AND timestamp < '<export_end_utc>'
+  ORDER BY timestamp
+) TO '/tmp/gt_logs_incident.csv.gz'
+WITH (
+  FORMAT = 'csv',
+  compression_type = 'gzip',
+  TIMESTAMP_FORMAT = '%Y-%m-%dT%H:%M:%S%.f'
+);
+```
+
+Compressed JSON fallback:
+
+```sql
+COPY (
+  SELECT *
+  FROM _gt_logs
+  WHERE timestamp >= '<export_start_utc>'
+    AND timestamp < '<export_end_utc>'
+  ORDER BY timestamp
+) TO '/tmp/gt_logs_incident.json.gz'
+WITH (
+  FORMAT = 'json',
+  compression_type = 'gzip',
+  TIMESTAMP_FORMAT = '%Y-%m-%dT%H:%M:%S%.f'
+);
+```
+
+Remember:
+
+- `COPY TO` writes on the self-monitoring GreptimeDB filesystem, not the client side.
+- Prefer Parquet; use compressed CSV/JSON only when needed.
+- Only the `kubectl cp` mode retrieves data files into the local artifact directory.
+
+## Download server-side COPY files with Kubernetes
+
+Use only if the user selected **Agent-executed `COPY TO` + `kubectl cp` retrieval** and confirmed enough Kubernetes access.
+
+Confirm:
+
+- Kubernetes namespace
+- self-monitoring GreptimeDB pod name
+- container name, if multiple containers
+- server-side export path
+- local destination path
+- permission to run `kubectl cp`
+
+Discovery:
+
+```bash
+kubectl get pods -n <namespace>
+kubectl get pods -n <namespace> | grep monitor
+```
+
+Copy file:
+
+```bash
+kubectl cp \
+  -n <namespace> \
+  <pod>:/tmp/gt_logs_incident.parquet \
+  ./incident/logs/gt_logs_incident.parquet
+```
+
+With container:
+
+```bash
+kubectl cp \
+  -n <namespace> \
+  -c <container> \
+  <pod>:/tmp/gt_logs_incident.parquet \
+  ./incident/logs/gt_logs_incident.parquet
+```
+
+Do not offer `kubectl exec`, tarball streaming, ad-hoc HTTP response export, or PostgreSQL `\copy` as alternatives. If `kubectl cp` is unavailable, use user-executed `COPY TO`, agent-executed `COPY TO` without retrieval, or HTTP port export.

--- a/skills/self-monitoring-export/references/export-http.md
+++ b/skills/self-monitoring-export/references/export-http.md
@@ -1,0 +1,78 @@
+# HTTP Port Export Guide
+
+Use GreptimeDB HTTP port export when the self-monitoring HTTP port is reachable. Prefer this path because the same `/v1/sql` endpoint can run discovery SQL and export local files. Internally, exports use Arrow IPC files written directly into the local artifact directory.
+
+Use the GreptimeDB HTTP SQL endpoint:
+
+```text
+POST /v1/sql?db=<database>&format=arrow
+```
+
+Do not set an HTTP timeout header in generated HTTP port commands.
+
+Request Arrow IPC compression by default:
+
+1. prefer `zstd`
+2. fall back to `lz4`
+
+Use [`../scripts/http_arrow_export.sh`](../scripts/http_arrow_export.sh) for agent-executed HTTP port exports. The script requests `compression=zstd` first and `compression=lz4` second, writes the requested Arrow IPC compression format into the file suffix, saves response headers next to the output file, fails on HTTP errors, and validates with [`../scripts/validate_arrow.py`](../scripts/validate_arrow.py) when PyArrow is available.
+
+Run this canonical skill script directly. In the artifact directory, record a wrapper invocation such as `commands/run_http_export.sh`; do not copy `http_arrow_export.sh` itself unless the user explicitly requests a self-contained artifact.
+
+Record the requested Arrow IPC compression in `manifest.md`. The script writes files as `.zstd.arrow` or `.lz4.arrow` based on the successful `compression=` request. Do not request HTTP response decompression for this default path; GreptimeDB Arrow IPC compression is controlled by the SQL endpoint `compression=` query parameter.
+
+Before exporting, confirm:
+
+- HTTP host/port and database, usually HTTP port `4000` and database `public`
+- auth method, if required
+- selected time windows and chunking plan
+- local artifact directory
+- Arrow IPC compression preference: default `zstd`, fallback `lz4`
+- validation method: PyArrow preferred
+
+Sample bounded request shape using the script:
+
+```bash
+scripts/http_arrow_export.sh \
+  --url "http://<host>:<port>" \
+  --db "public" \
+  --sql "SELECT * FROM public._gt_logs WHERE timestamp >= '<sample_start_utc>' AND timestamp < '<sample_end_utc>' ORDER BY timestamp LIMIT 10" \
+  --output "logs/http_arrow_sample.arrow" \
+  --headers "metadata/http_arrow_sample.headers"
+```
+
+This produces `logs/http_arrow_sample.zstd.arrow` when the `zstd` request succeeds, or `logs/http_arrow_sample.lz4.arrow` when it falls back to `lz4`.
+
+Full export chunks should use fixed UTC boundaries and write files under `logs/`:
+
+```bash
+scripts/http_arrow_export.sh \
+  --url "http://<host>:<port>" \
+  --db "public" \
+  --sql "SELECT * FROM public._gt_logs WHERE timestamp >= '<chunk_start_utc>' AND timestamp < '<chunk_end_utc>' ORDER BY timestamp" \
+  --output "logs/gt_logs_<chunk_start>_<chunk_end>.arrow" \
+  --headers "metadata/gt_logs_<chunk_start>_<chunk_end>.headers"
+```
+
+Save generated command records as:
+
+```text
+commands/run_http_export.sh
+commands/validate_arrow.sh
+```
+
+Validation:
+
+1. check the local file exists and size is non-zero
+2. record the first and last bytes if useful for binary signature checks
+3. validate Arrow IPC stream with `scripts/validate_arrow.py`
+4. validate row count against pre-export count
+5. record schema fields and timestamp type in `summary/export_report.md`
+
+PyArrow validation example:
+
+```bash
+python3 scripts/validate_arrow.py logs/http_arrow_sample.zstd.arrow --schema
+```
+
+If validation fails, do not claim the export is complete. Record the failure in `summary/gaps_and_risks.md`, keep the response headers, and re-check the HTTP port query, selected Arrow IPC compression, and local PyArrow support before retrying.

--- a/skills/self-monitoring-export/references/export-layout.md
+++ b/skills/self-monitoring-export/references/export-layout.md
@@ -1,0 +1,157 @@
+# Export Layout Guide
+
+Before exporting, create or propose the fixed local artifact layout. The final deliverable must always be a local directory on the user's/client machine, and every output artifact must be placed under the fixed layout below.
+
+Use the installed skill `scripts/` directory as the canonical implementation. Execute those helper scripts directly. The artifact `commands/` directory records concrete SQL, concrete wrapper invocations, and user-executed scripts for audit and replay; it should not duplicate the helper script implementation unless the user explicitly requests a self-contained artifact.
+
+This local directory is required for all supported export modes:
+
+- **User-executed `COPY TO`**: the local directory must contain ready-to-run SQL/shell scripts, concrete command values, expected self-monitoring filesystem output paths, download instructions, validation queries, and final report template. The user's later execution creates files on the self-monitoring filesystem, not in the local directory.
+- **Agent-executed `COPY TO`, no retrieval**: the local directory must contain command records, manifest entries, expected self-monitoring filesystem output paths, download instructions, validation queries, and final report. The data files remain on the self-monitoring filesystem for the user to download later.
+- **Agent-executed `COPY TO` + `kubectl cp` retrieval**: `COPY TO` first writes files on the self-monitoring filesystem, then `kubectl cp` retrieves them into the local directory.
+- **HTTP port export**: recommended export method when the GreptimeDB HTTP port is reachable. Run the canonical HTTP helper scripts from the skill `scripts/` directory. The local directory must contain command records under `commands/` and generated Arrow IPC files under `logs/` / `metrics/`.
+
+Do not scatter output files in the working directory. Do not invent new top-level directories. If a new artifact type is necessary, place it in the nearest existing subdirectory and add an entry to `manifest.md`.
+
+After the export window and expected row count are known, ask the user to confirm one supported export mode before running any export query or command. Do not treat the default as permission to export.
+
+Separate analysis from export:
+
+- **Analysis / time-window discovery**: use any available self-monitoring query access path: MCP, GreptimeDB HTTP SQL, or a SQL client. MCP and HTTP SQL are peers. This happens before the export choice and is used to find incident windows, estimate rows, and decide what is necessary to export.
+- **Data export**: recommend HTTP port export when reachable, then ask the user to choose exactly one export option: HTTP port export; user-executed `COPY TO`; agent-executed `COPY TO` without retrieval; agent-executed `COPY TO` plus `kubectl cp` retrieval. All modes produce the local artifact directory as the handoff, but only the `kubectl cp` and HTTP port modes place data files in it.
+
+If the agent CLI supports interactive UI, use a single export-mode picker, then a final confirm control. Do not make the user type prose such as “use option 1” when a single-select or confirm control is available.
+
+The confirmation prompt must include:
+
+- selected export mode and why
+- local artifact directory path and what will be written there
+- viable alternatives among the supported modes
+- output destination on the self-monitoring filesystem for `COPY TO`, or local Arrow path for HTTP port export
+- explicit note that `COPY TO` writes on the self-monitoring filesystem, not the client side
+- output format: prefer `parquet`, or `csv.gz` / `json.gz` fallback
+- chunking plan, if any
+- selected export windows: critical windows and possibly useful context windows when the suspected range is long
+- expected row count and whether large-export confirmation is also required
+- whether `kubectl cp` retrieval is included, whether the user must download files manually, or whether HTTP port export writes local Arrow directly
+- HTTP port export format/compression choice, defaulting to Arrow IPC with `zstd` and `lz4` fallback
+- manual `COPY TO` script fallback if the agent cannot directly execute commands
+
+Interactive mode picker example:
+
+```text
+Choose export mode:
+- HTTP port export: I call GreptimeDB HTTP `/v1/sql` for discovery and export, use Arrow IPC with zstd/lz4 compression for data files, and write files directly into the artifact directory
+- User-executed COPY TO: I generate ready-to-run SQL/shell scripts; you execute them and download files manually
+- Agent-executed COPY TO, no retrieval: I run COPY TO; files remain on the self-monitoring filesystem for you to download later
+- Agent-executed COPY TO + kubectl cp: I run COPY TO, then retrieve files into the local artifact directory with kubectl cp
+```
+
+After the method is selected, show the concrete plan and use a confirm prompt:
+
+```text
+Confirm export plan?
+- Yes, export with this method
+- No, change method or destination
+```
+
+Example:
+
+```text
+Selected export mode: Agent-executed COPY TO + kubectl cp retrieval.
+Local artifact directory: ./greptimedb-incident-<YYYYMMDD-HHMMSS>-<timezone>/
+Reason: selected because kubectl cp can retrieve files after server-side export. HTTP port export is also available if local client-side export is preferred.
+Alternatives: HTTP port export; user-executed COPY TO; agent-executed COPY TO with no retrieval.
+Planned destination: /tmp/greptimedb-incident-export/<incident-id>/gt_logs_<start>_<end>.parquet
+COPY output location: self-monitoring filesystem first, not local client path.
+Local retrieval target: ./greptimedb-incident-<YYYYMMDD-HHMMSS>-<timezone>/logs/
+Format: Parquet.
+Chunking: hourly files.
+Selected windows: critical peak/recovery window plus WARN ramp context window; low-signal background range summarized only.
+Expected rows: <n>.
+Manual fallback: I can provide a ready-to-run COPY TO script if I cannot execute the export for you.
+
+Please confirm which export method to use before I export data.
+```
+
+Fixed layout:
+
+```text
+greptimedb-incident-<YYYYMMDD-HHMMSS>-<timezone>/
+  README.md
+  manifest.md
+  metadata/
+    inputs.md
+    discovered_cluster.md
+    timezone.md
+    execution_mode.md
+    environment.md
+  discovery/
+    log_level_timeline.csv
+    top_log_categories.csv
+    metric_candidates.md
+    window_selection.md
+  logs/
+    gt_logs_<start>_<end>.csv
+    gt_logs_<start>_<end>.<zstd|lz4>.arrow
+    gt_logs_<start>_<end>.parquet
+    gt_logs_<window_label>_<start>_<end>.parquet
+  metrics/
+    <metric_table>_<start>_<end>.csv
+    <metric_table>_<start>_<end>.<zstd|lz4>.arrow
+    <metric_table>_<start>_<end>.parquet
+  commands/
+    discovery.sql
+    export_logs.sql
+    run_http_discovery.sh
+    manual_copy_to.sql
+    run_http_export.sh
+    retrieve_files.sh
+    validate_arrow.sh
+    validate_rows.sql
+    export_metrics.sql
+  summary/
+    export_report.md
+    gaps_and_risks.md
+```
+
+Keep the directory names fixed. Create only the files that match the actual export method, but keep all generated files inside these subdirectories. Omit `metrics/` files if no metrics were exported.
+
+Artifact placement rules:
+
+- `README.md`: short human entrypoint explaining what is in the artifact directory.
+- `manifest.md`: inventory of every generated file, source, time range, row count when known, and validation status.
+- `metadata/`: user inputs, discovered cluster/version, timezone assumptions, execution mode, environment/access notes.
+- `discovery/`: lightweight analysis outputs used to choose incident windows.
+- `logs/`: actual exported log data only. Do not put SQL scripts or summaries here.
+- `metrics/`: optional metric exports only.
+- `commands/`: exact SQL, wrapper invocations, and ready-to-run user scripts. Wrappers should call canonical skill scripts through `SKILL_DIR` or a recorded absolute skill path. Do not put exported data here.
+- `summary/`: final report and gaps/risks.
+
+If a command writes to a temporary, server-side, or pod-local path first, record that remote path in `manifest.md` and `summary/export_report.md`, then retrieve or instruct retrieval into the fixed local layout.
+
+For user-executed mode, at minimum the local artifact directory must contain:
+
+- `commands/manual_copy_to.sql` or equivalent ready-to-run script with concrete values
+- `commands/retrieve_files.sh` when later file retrieval is needed
+- `commands/validate_rows.sql` or validation instructions
+- `metadata/execution_mode.md` recording that the user will execute scripts manually
+- `manifest.md` listing expected remote outputs and the local paths where they should be copied after execution
+- `summary/export_report.md` explaining expected outputs and next steps
+
+Default command-record pattern:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SKILL_DIR="${SKILL_DIR:-<installed-skill-path>}"
+
+"${SKILL_DIR}/scripts/http_arrow_export.sh" \
+  --url "<http-url>" \
+  --db "public" \
+  --sql "<concrete-export-sql>" \
+  --output "../logs/gt_logs_<start>_<end>.arrow"
+```
+
+Only create self-contained copies of helper scripts when the user explicitly asks for a portable artifact that can run without the installed skill. If copying helper scripts, record source path, skill version or checksum, copied file checksum, and copy time in `manifest.md`.

--- a/skills/self-monitoring-export/references/export-mcp.md
+++ b/skills/self-monitoring-export/references/export-mcp.md
@@ -1,0 +1,44 @@
+# MCP Query Access Guide
+
+Use GreptimeDB MCP as one peer query access method for analysis and incident time-window discovery when it is connected to the self-monitoring GreptimeDB instance that stores logs and metrics for the GreptimeDB cluster being investigated. If MCP is unavailable, use GreptimeDB HTTP SQL or a SQL client instead.
+
+Never run `COPY`, `COPY TO`, or any export-writing command through MCP. MCP is for read-only analysis queries only, not final data export.
+
+For actual durable data export, use GreptimeDB HTTP port export or one of the three supported `COPY TO` modes through a non-MCP SQL/HTTP connection, or generate a user-executed script.
+
+MCP is appropriate for:
+
+- schema inspection
+- lightweight aggregations
+- description-driven incident window discovery using [`signal-index.md`](signal-index.md) and targeted SQL
+- identifying critical windows and possibly useful context windows
+
+MCP is not enough when:
+
+- the result is truncated by tool limits
+- the query response is too large for the agent runtime
+- the export needs a durable artifact outside the chat/tool output
+- the user needs Parquet, Arrow files, or server-side files
+- the export would require `COPY`, `COPY TO`, or writing files from the database
+
+Do not offer MCP result download as a user-facing final export choice. Use MCP, HTTP SQL, or a SQL client to decide windows and counts, then choose one supported export method.
+
+Example complete log query:
+
+```sql
+SELECT *
+FROM _gt_logs
+WHERE timestamp >= '<export_start_utc>'
+  AND timestamp < '<export_end_utc>'
+ORDER BY timestamp;
+```
+
+Never use MCP output that only shows a preview, limit, top rows, sampled rows, or aggregated rows as the final incident log export.
+
+Never execute examples like this through MCP:
+
+```sql
+COPY (SELECT * FROM _gt_logs WHERE ...) TO '...'
+```
+
+For final export, use HTTP port export or SQL `COPY TO` through non-MCP SQL/HTTP access, or generate a user-executed script.

--- a/skills/self-monitoring-export/references/export-metrics.md
+++ b/skills/self-monitoring-export/references/export-metrics.md
@@ -1,0 +1,35 @@
+# Metrics Export Guide
+
+Only export metrics that are relevant to detected log errors or user symptom.
+
+Before exporting metric tables:
+
+1. verify the table exists with `SHOW TABLES FROM public;`
+2. estimate row count
+3. use the same time window as logs unless a wider window is justified
+4. ask confirmation for large ranges
+
+Example SQL COPY:
+
+```sql
+COPY (
+  SELECT *
+  FROM greptime_datanode_region_request_fail_count
+  WHERE greptime_timestamp >= '<export_start_utc>'
+    AND greptime_timestamp < '<export_end_utc>'
+  ORDER BY greptime_timestamp
+) TO '/tmp/greptime_datanode_region_request_fail_count.parquet'
+WITH (FORMAT = 'parquet');
+```
+
+Example HTTP port export:
+
+```bash
+scripts/http_arrow_export.sh \
+  --url "http://<host>:4000" \
+  --db "public" \
+  --sql "SELECT * FROM greptime_datanode_region_request_fail_count WHERE greptime_timestamp >= '<export_start_utc>' AND greptime_timestamp < '<export_end_utc>' ORDER BY greptime_timestamp" \
+  --output "metrics/greptime_datanode_region_request_fail_count.arrow"
+```
+
+The script writes `metrics/greptime_datanode_region_request_fail_count.zstd.arrow` when the `zstd` request succeeds, or `.lz4.arrow` when it falls back.

--- a/skills/self-monitoring-export/references/inputs.md
+++ b/skills/self-monitoring-export/references/inputs.md
@@ -1,0 +1,194 @@
+# Inputs Guide
+
+Ask only the minimum necessary questions.
+
+The response language question is special: it must be asked first, alone, and before every other input question. Do not batch timezone, incident, MCP, access, or Kubernetes questions with it. Wait for the language answer, then localize all subsequent user-facing prompts accordingly.
+
+## Interactive prompt rule
+
+When the agent CLI supports interactive UI, use it instead of asking the user to type prose answers.
+
+Use:
+
+- single-select only for closed one-of-N choices, such as language, incident time known/unknown, primary symptom, MCP yes/no/unknown, export mode, and GreptimeDB HTTP port reachability
+- multi-select for capabilities, such as available Kubernetes actions, available fallback access methods, or export capabilities
+- confirm for yes/no consent, such as large export confirmation and final export-method confirmation
+- true free-text/textbox input for arbitrary values, such as timezone, endpoint URL, database name, namespace, pod name, or output path
+
+Do not use a single-select prompt to simulate arbitrary text input. Many agent CLIs add a built-in custom answer row for single-select prompts; using that for required text input creates a confusing option-list-plus-textbox UI.
+
+Do not manually add `Custom`, `Other`, `Type your own answer`, or catch-all options when the CLI already supports custom answers for selection prompts.
+
+Plain text questions are the fallback when the CLI cannot render a true free-text/textbox control for arbitrary values.
+
+## 0. Response language
+
+Ask the user which language they prefer for questions and the final report. This must be a standalone first message.
+
+If interactive controls are supported, use a single-select prompt:
+
+```text
+Preferred language for questions and final report:
+- English
+- 中文
+- 日本語
+```
+
+If the preferred language is not English:
+
+- Ask user-facing questions in the preferred language.
+- Write the final report content in the preferred language.
+- Keep GreptimeDB-specific terms, table names, metric names, SQL keywords, commands, and file paths in English.
+- When a translated question may be ambiguous, include the English original in parentheses.
+- Keep exported file and directory names in English.
+
+Example:
+
+```text
+请选择报告语言（Preferred report language）:
+```
+
+After the user answers, continue with the required timezone question in the selected language before asking about incident details, MCP, SQL/HTTP access, Kubernetes access, or export choices.
+
+## 1. User timezone
+
+Ask the user to input their timezone. This is required and must be the first question after response language is selected.
+
+If interactive controls are supported, use a true free-text/textbox prompt with examples, not a single-select prompt and not a prose question:
+
+```text
+User timezone (examples: UTC, UTC+8, Asia/Shanghai, America/Los_Angeles):
+```
+
+Accepted formats:
+
+- `UTC`
+- `UTC+8`
+- `UTC-5`
+- `Asia/Shanghai`
+- `America/Los_Angeles`
+
+## 2. Known incident time
+
+Ask whether the user knows when the incident happened:
+
+- exact time
+- approximate time
+- unknown, auto-discover
+
+If interactive controls are supported, use a single-select prompt with those options. If the user chooses exact or approximate time, ask the actual time in a separate true free-text/textbox prompt. If no true textbox exists, ask a plain text question instead of using a custom single-select option.
+
+## 3. Symptom
+
+Ask what the user observed:
+
+- write failure
+- query failure
+- query latency
+- OpenTelemetry / logs / metrics ingest issue
+- meta / heartbeat / election issue
+- region migration / repartition issue
+- storage backend issue
+- compaction / flush issue
+- unknown
+
+If interactive controls are supported, use a single-select prompt. If multiple symptoms apply, use multi-select.
+
+## 4. Self-monitoring instance query access
+
+Ask first:
+
+```text
+Which access methods are available for the GreptimeDB Cluster self-monitoring instance that stores logs and metrics for the GreptimeDB cluster being investigated?
+```
+
+If interactive controls are supported, use multi-select:
+
+```text
+Self-monitoring instance access:
+- GreptimeDB MCP connected to the self-monitoring instance
+- HTTP port of the self-monitoring instance reachable, usually 4000
+- SQL/MySQL/PostgreSQL endpoint of the self-monitoring instance reachable, usually 4002/4003
+- Kubernetes access to the self-monitoring GreptimeDB Standalone, usually ${cluster}-monitor-standalone
+- Unknown / need help discovering the self-monitoring instance
+```
+
+For MCP:
+
+- Explain that MCP must connect to the self-monitoring instance, not the business or production GreptimeDB endpoint, unless that endpoint is also the self-monitoring instance.
+- Verify by checking whether `public._gt_logs` exists.
+- Use MCP for read-only discovery and validation only.
+
+For the GreptimeDB HTTP port:
+
+- Ask for HTTP host/port, database/schema, and auth method if required.
+- Prefer the HTTP port when reachable because it supports both read-only discovery SQL and local file export through `/v1/sql`.
+
+For SQL clients, ask only for the selected endpoint details:
+
+- SQL/MySQL/PostgreSQL endpoint of the self-monitoring instance, usually MySQL port `4002` or PostgreSQL port `4003`
+- database/schema, usually `public`
+- auth method, if required
+- Kubernetes access, if available
+
+Use true free-text/textbox prompts only for the selected methods and missing values. If the CLI lacks a true textbox, ask plain text questions for those values.
+
+## 5. Kubernetes retrieval capability
+
+Ask upfront whether the user has Kubernetes access for port-forwarding SQL/MySQL endpoints or retrieving server-side COPY files with `kubectl cp`.
+
+```text
+Do you have kubectl access to the namespace where the self-monitoring GreptimeDB Standalone runs?
+```
+
+If interactive controls are supported, use confirm for whether Kubernetes access exists, then multi-select for exact capabilities.
+
+If yes, ask whether they can run:
+
+- `kubectl get pods -n <namespace>`
+- `kubectl port-forward -n <namespace> ...`
+- `kubectl cp -n <namespace> ...`
+
+Also ask for:
+
+- kube-context, if multiple contexts are configured
+- namespace, if known
+- whether access allows `kubectl cp`
+
+If the user does not have `kubectl cp` permission, do not choose agent-executed `COPY TO` plus retrieval. Use HTTP port export, user-executed `COPY TO`, or agent-executed `COPY TO` without retrieval.
+
+Do not ask for cluster name, namespace, pod list, or GreptimeDB version upfront. Discover them from self-monitoring data when possible.
+
+## 6. HTTP port and export capability
+
+After access is known and before presenting export choices, first determine whether the GreptimeDB HTTP port is reachable. Prefer this path because it can query and export through the same endpoint. Prefer interactive controls.
+
+```text
+GreptimeDB HTTP port reachability:
+- Direct HTTP port is reachable, usually 4000
+- HTTP port can be reached through kubectl port-forward
+- HTTP port is unavailable or blocked
+- Unknown, run a small HTTP check
+```
+
+If the HTTP port is reachable, collect only the missing values:
+
+- HTTP host and port
+- database/schema, usually `public`
+- auth method, if required
+- local PyArrow validation availability
+
+Then recommend HTTP port export. It uses `/v1/sql` for both discovery and export; export output uses Arrow IPC internally with `zstd` first and `lz4` fallback.
+
+Ask whether SQL `COPY TO` is available in the self-monitoring GreptimeDB environment:
+
+```text
+SQL COPY TO availability:
+- Available
+- Unavailable / blocked by environment
+- Unknown, test with a small harmless COPY plan before export
+```
+
+Ask detailed `COPY TO` and `kubectl cp` questions only if the HTTP port is unavailable, the user prefers server-side export, or retrieval mode is being considered.
+
+For large HTTP port exports, include row-count preflight, chunking, local disk capacity, runtime, network impact, output format/compression, and PyArrow validation plan in the confirmation prompt. Do not set an HTTP timeout header.

--- a/skills/self-monitoring-export/references/query-access.md
+++ b/skills/self-monitoring-export/references/query-access.md
@@ -1,0 +1,56 @@
+# Query Access Guide
+
+Use MCP and GreptimeDB HTTP SQL as peer query access methods for discovery, analysis, and validation. MCP is not required when a reachable self-monitoring HTTP endpoint is available.
+
+The data source for this skill is the GreptimeDB Cluster self-monitoring instance — typically a GreptimeDB Standalone instance — that stores logs and metrics for the GreptimeDB cluster being investigated. A business or production GreptimeDB endpoint is the cluster being investigated, not the default log export source, unless that endpoint is also the self-monitoring instance.
+
+Query access is separate from export method:
+
+- **Query access** locates incident windows, checks schemas, estimates rows, validates counts, and discovers optional metrics.
+- **Export method** writes the final data files through the GreptimeDB HTTP port or confirmed `COPY TO` modes.
+
+## Choose a query access method
+
+Prefer the first available connection to the self-monitoring instance, but do not treat MCP as mandatory:
+
+1. **GreptimeDB MCP** — read-only analysis queries only.
+2. **GreptimeDB HTTP port** — recommended when reachable because it supports read-only discovery, validation queries, and local export through `/v1/sql`.
+3. **SQL client** — user- or agent-executed fallback when HTTP and MCP are unavailable.
+
+Before querying, identify which endpoint belongs to the self-monitoring instance. In GreptimeDB Operator deployments, this is usually a GreptimeDB Standalone service such as `${cluster}-monitor-standalone`, and it stores logs and metrics for the GreptimeDB cluster being investigated. If the user provides a business or production cluster endpoint, explain that it is the monitored system, not the default log export data source. Check whether `public._gt_logs` exists before relying on the connection.
+
+## HTTP SQL helper
+
+Use [`../scripts/http_sql_query.sh`](../scripts/http_sql_query.sh) for small discovery and validation queries:
+
+```bash
+scripts/http_sql_query.sh \
+  --url "http://<host>:4000" \
+  --db "public" \
+  --format "csvWithNames" \
+  --sql "SELECT date_trunc('minute', timestamp) AS minute, level, count(*) AS cnt FROM public._gt_logs WHERE timestamp >= '<start_utc>' AND timestamp < '<end_utc>' GROUP BY minute, level ORDER BY minute, level LIMIT 1000" \
+  --output "discovery/log_level_timeline.csv"
+```
+
+The script sends one read-only SQL statement as `application/x-www-form-urlencoded` POST data to `/v1/sql`, sets `X-Greptime-Timezone: UTC`, saves response headers, and does not set an HTTP timeout header.
+
+Use `AUTH_HEADER` for credentials:
+
+```bash
+AUTH_HEADER="Basic <base64-user-password>" scripts/http_sql_query.sh ...
+```
+
+Never write credentials into generated artifact files.
+
+## Recommended formats
+
+- `csvWithNames`: best default for discovery artifacts saved under `discovery/`.
+- `table`: best for quick terminal inspection.
+- `greptimedb_v1`: useful when another tool expects GreptimeDB JSON.
+- `arrow`: reserve for bulk export through the HTTP port export script [`../scripts/http_arrow_export.sh`](../scripts/http_arrow_export.sh), not routine discovery.
+
+Keep HTTP SQL discovery queries small. Use aggregates, narrow time ranges, and `LIMIT` where possible. For verification runs, choose the smallest time window that proves the path works.
+
+## Artifact placement
+
+HTTP SQL command records belong in `commands/run_http_discovery.sh` or concrete SQL files such as `commands/discovery.sql`. The wrapper should call the canonical helper from the installed skill `scripts/` directory instead of duplicating it. Query outputs belong in `discovery/` or `metadata/` for analysis and in `commands/validate_rows.sql` for validation SQL. Do not place query outputs in `logs/`; `logs/` is reserved for exported log data.

--- a/skills/self-monitoring-export/references/report-template.md
+++ b/skills/self-monitoring-export/references/report-template.md
@@ -1,0 +1,104 @@
+# Report Template Guide
+
+````markdown
+# Self-Monitoring Export Report
+
+## Scope
+- This report uses GreptimeDB Cluster self-monitoring data.
+- If the user uses a custom monitoring stack, table names and queries may not apply.
+
+## Inputs
+- Data source (self-monitoring GreptimeDB instance):
+- Access endpoint to the self-monitoring instance:
+- Database/schema:
+- Logs table:
+- User timezone:
+- Response/report language:
+- Local artifact directory:
+
+## Artifact Layout
+- Layout root:
+- Manifest: `manifest.md`
+- Metadata directory: `metadata/`
+- Discovery directory: `discovery/`
+- Logs directory: `logs/`
+- Metrics directory: `metrics/` or not used
+- Commands directory: `commands/`
+- Summary directory: `summary/`
+
+## Artifact Manifest Summary
+| local path | artifact type | source / remote path | time range UTC | rows | validation status |
+|---|---|---|---|---:|---|
+
+## Discovered Cluster Metadata
+- Cluster:
+- Namespace:
+- GreptimeDB version:
+- Short version / commit:
+- Apps / roles observed:
+
+## Detected Incident Window
+- UTC:
+- User timezone:
+- Detection method: user description / signal index / source lookup / targeted SQL / fallback level aggregation
+
+## Signal Hypothesis
+- User-described symptom:
+- Signal index entries used:
+- Signal index reference: `references/signal-index.md`
+- Source modules or exact source strings checked:
+- Targeted log keywords:
+- Metrics checked:
+- Fallback `ERROR` / `WARN` aggregation used: yes/no, reason:
+
+## Export Window
+- UTC:
+- User timezone:
+- Reason this window was selected:
+
+## Long-Range Window Selection
+- Critical windows exported:
+- Possibly useful context windows exported:
+- Low-signal ranges summarized but not exported:
+- Reason full long-range export was avoided or confirmed:
+
+## Export Safety Check
+- Estimated log rows:
+- Largest hourly bucket:
+- User confirmation required: yes/no
+- Export mode: HTTP port export / user-executed COPY TO / agent-executed COPY TO no retrieval / agent-executed COPY TO plus kubectl cp
+- COPY output location on self-monitoring filesystem:
+- HTTP port export local output path, including requested compression suffix:
+- HTTP export file format / compression requested:
+- Data files retrieved locally: yes/no
+- Local retrieval target if kubectl cp was used:
+- Manual COPY TO script provided: yes/no
+- Export chunking strategy:
+
+## Exported Logs
+| file | source | time range UTC | rows | notes |
+|---|---|---|---:|---|
+
+## Exported Metrics
+| file | metric table | time range UTC | rows | why included |
+|---|---|---|---:|---|
+
+## Discovery Summary
+| signal | source | first_seen | peak | recovered_at | notes |
+|---|---|---|---|---|---|
+
+## Commands Used
+```sql
+...
+```
+
+## Language
+- Report content language follows the user-selected response language.
+- File names, SQL, commands, table names, and metric names remain in English.
+
+## Gaps / Risks
+- Missing data:
+- Timezone uncertainty:
+- Query/export truncation risk:
+- Need wider export: yes/no
+````

--- a/skills/self-monitoring-export/references/signal-index.md
+++ b/skills/self-monitoring-export/references/signal-index.md
@@ -1,0 +1,796 @@
+# Signal Index
+
+Use this index before generic `ERROR` / `WARN` aggregation. The index maps user-observed GreptimeDB Cluster symptoms to likely components, source modules, log keywords, metrics, and SQL filter hints.
+
+Priority:
+
+1. Match the user's incident description to this index.
+2. If there is no direct match, inspect GreptimeDB source code first. Do not assume a user-local repository; follow [`../references.md`](../references.md), clone <https://github.com/GreptimeTeam/greptimedb> into a temporary source checkout, prefer the investigated GreptimeDB version, fall back to main when no matching version is available, or use remote source search when cloning is unavailable.
+3. Use source findings such as error strings, tracing targets, source module names, and metric names to extend the query keywords.
+4. Use generic `ERROR` / `WARN` aggregation only as a fallback or sanity check.
+
+## How to use
+
+For each user symptom:
+
+- Identify likely component roles.
+- Search `_gt_logs` fields such as `target`, `role`, `message`, and `err`.
+- Check listed metrics if the corresponding tables exist in `public`.
+- If still unclear, search listed source modules and exact strings in the GreptimeDB source.
+- Use matched signals to rank candidate windows: symptom onset, buildup, failure peak, recovery, and post-recovery confirmation.
+
+When source lookup is needed, search literal strings and metric names rather than broad natural-language phrases.
+
+## Write / ingest failure
+
+User descriptions:
+
+- write failed
+- insert timeout
+- data cannot be written
+- bulk insert failed
+- Prometheus remote write failed
+- region write rejected
+- retry later
+- leader not writable
+
+Likely roles:
+
+- `frontend`
+- `datanode`
+- `mito`
+- `region worker`
+- `operator`
+- `servers`
+
+Log keywords:
+
+- `Failed to handle request`
+- `Failed to insert data`
+- `Retry later`
+- `RegionId`
+- `Leader(Writable)`
+- `Partition expr version mismatch`
+- `write reject`
+- `handle write`
+- `bulk insert`
+- `Failed to open region`
+- `Failed to catchup region`
+- `Region not found, ignore it`
+- `Failed to set region to ready`
+- `Failed to insert data into flownode`
+- `Failed to create table`
+- `Failed to freeze the mutable memtable`
+- `Failed to schedule flush job`
+- `Failed to flush region`
+- `Flush semaphore closed, flushing inline`
+- `Failed to trigger flush`
+- `Failed to flush regions in topic`
+
+Metrics:
+
+- `greptime_table_operator_ingest_rows`
+- `greptime_table_operator_bulk_insert_message_rows`
+- `greptime_datanode_handle_region_request_elapsed`
+- `greptime_datanode_region_changed_row_count`
+- `greptime_datanode_region_request_fail_count`
+- `greptime_datanode_region_failed_insert_count`
+- `greptime_mito_write_buffer_bytes`
+- `greptime_mito_write_reject_total`
+- `greptime_mito_write_rows_total`
+- `greptime_mito_write_stage_elapsed_*`
+- `greptime_mito_write_stall_total`
+- `greptime_region_worker_handle_write_*`
+- `greptime_grpc_region_request_*`
+- `greptime_servers_bulk_insert_elapsed`
+- `greptime_servers_http_prometheus_write_elapsed`
+- `greptime_servers_prometheus_remote_write_samples`
+
+Source modules:
+
+- `src/operator/`
+- `src/operator/src/insert.rs`
+- `src/operator/src/bulk_insert.rs`
+- `src/servers/src/grpc/`
+- `src/servers/src/pending_rows_batcher.rs`
+- `src/datanode/`
+- `src/datanode/src/region_server.rs`
+- `src/mito2/`
+- `src/mito2/src/flush.rs`
+- `src/meta-srv/src/region/flush_trigger.rs`
+- `src/store-api/`
+- `src/common/error/`
+
+SQL filter hints:
+
+```sql
+WHERE (
+  lower(message) LIKE '%failed to handle request%'
+  OR lower(message) LIKE '%failed to insert data%'
+  OR lower(message) LIKE '%bulk insert%'
+  OR lower(message) LIKE '%handle write%'
+  OR lower(err) LIKE '%retry later%'
+  OR lower(err) LIKE '%leader%'
+  OR lower(err) LIKE '%partition expr version mismatch%'
+  OR lower(target) LIKE '%operator%'
+  OR lower(target) LIKE '%region%'
+  OR lower(target) LIKE '%mito%'
+)
+```
+
+## Query failure or latency
+
+User descriptions:
+
+- query failed
+- SQL timeout
+- PromQL timeout
+- MySQL/PostgreSQL query slow
+- merge scan error
+- high query latency
+- memory rejected during query
+
+Likely roles:
+
+- `frontend`
+- `query`
+- `datanode`
+- `mito`
+- `servers`
+
+Log keywords:
+
+- `Failed to execute query`
+- `Failed to parse SQL`
+- `query`
+- `scan`
+- `merge scan`
+- `timeout`
+- `memory`
+- `rejected`
+- `push down`
+- `Panic while creating physical plan`
+- `Create physical plan, input plan`
+- `Failed to push down plan, using fallback plan rewriter`
+- `Merge scan one region`
+- `Merge scan finish one region`
+- `MergeScan partition`
+- `Conflicting proved watermarks`
+- `Table not found`
+- `Missing timestamp column`
+- `Invalid range`
+
+Metrics:
+
+- `greptime_frontend_grpc_handle_query_elapsed`
+- `greptime_frontend_promql_query_metrics_elapsed`
+- `greptime_servers_http_sql_elapsed`
+- `greptime_servers_http_promql_elapsed`
+- `greptime_servers_mysql_query_elapsed`
+- `greptime_servers_postgres_query_elapsed`
+- `greptime_servers_grpc_db_request_elapsed`
+- `greptime_servers_http_requests_elapsed`
+- `greptime_query_stage_elapsed`
+- `greptime_query_merge_scan_regions`
+- `greptime_query_merge_scan_errors_total`
+- `greptime_push_down_fallback_errors_total`
+- `greptime_query_memory_pool_usage_bytes`
+- `greptime_query_memory_pool_rejected_total`
+- `greptime_mito_read_stage_elapsed`
+- `greptime_mito_scan_memory_exhausted_total`
+- `greptime_mito_scan_requests_rejected_total`
+
+Source modules:
+
+- `src/frontend/`
+- `src/query/`
+- `src/query/src/datafusion.rs`
+- `src/query/src/dist_plan/analyzer.rs`
+- `src/query/src/dist_plan/merge_scan.rs`
+- `src/query/src/metrics.rs`
+- `src/servers/`
+- `src/servers/src/http/prometheus.rs`
+- `src/mito2/`
+- `src/sql/`
+
+SQL filter hints:
+
+```sql
+WHERE (
+  lower(message) LIKE '%failed to execute query%'
+  OR lower(message) LIKE '%failed to parse sql%'
+  OR lower(message) LIKE '%merge scan%'
+  OR lower(message) LIKE '%timeout%'
+  OR lower(err) LIKE '%query%'
+  OR lower(err) LIKE '%scan%'
+  OR lower(err) LIKE '%memory%'
+  OR lower(target) LIKE '%frontend%'
+  OR lower(target) LIKE '%query%'
+)
+```
+
+## Meta, heartbeat, election, and region migration
+
+User descriptions:
+
+- meta unavailable
+- heartbeat lost
+- no leader
+- election issue
+- region migration stuck
+- region movement failed
+- repartition failed
+- procedure stuck
+
+Likely roles:
+
+- `metasrv`
+- `datanode`
+- `frontend`
+- `flownode`
+- `procedure`
+
+Log keywords:
+
+- `heartbeat`
+- `Pusher not found`
+- `election`
+- `no leader`
+- `step down`
+- `region migration`
+- `repartition`
+- `procedure`
+- `Failed to execute procedure`
+- `Failed to wait region migration procedure`
+- `Denied to renew region lease`
+- `Starting region migration procedure`
+- `Apply staging regions`
+- `sync regions`
+- `remap manifests`
+- `Exit on malformed request: MissingRequestHeader`
+- `Client disconnected: broken pipe`
+- `Failed to handle heartbeat request`
+- `Quit because it is no longer the leader`
+- `Metasrv has no leader at this moment`
+- `Leader lease expired`
+- `Leader lease changed during election`
+- `Metasrv election error`
+- `RegionSupervisor has stop receiving heartbeat`
+- `Failed to check maintenance mode`
+- `Failed to downgrade region leader`
+- `Failed to upgrade region`
+- `Failed to submit region migration procedure`
+- `Failed to execute region failover`
+- `Deallocating regions for repartition`
+- `Failed to persist region checkpoints`
+
+Metrics:
+
+- `greptime_meta_heartbeat_connection_num`
+- `greptime_meta_heartbeat_rate`
+- `greptime_meta_heartbeat_recv`
+- `greptime_meta_handler_execute`
+- `greptime_meta_kv_request_elapsed`
+- `greptime_meta_txn_request_*`
+- `greptime_meta_inactive_regions`
+- `greptime_meta_region_migration_execute`
+- `greptime_meta_region_migration_error`
+- `greptime_meta_region_migration_fail`
+- `greptime_meta_region_migration_stage_elapsed`
+- `greptime_datanode_heartbeat_send_count`
+- `greptime_datanode_heartbeat_recv_count`
+- `greptime_last_received_heartbeat_lease_elapsed`
+- `greptime_last_sent_heartbeat_lease_elapsed`
+- `greptime_lease_expired_region`
+- `greptime_heartbeat_region_leases`
+
+Source modules:
+
+- `src/meta-srv/`
+- `src/meta-srv/src/service/heartbeat.rs`
+- `src/meta-srv/src/error.rs`
+- `src/meta-srv/src/metasrv.rs`
+- `src/meta-srv/src/region/supervisor.rs`
+- `src/meta-srv/src/handler/keep_lease_handler.rs`
+- `src/meta-srv/src/handler/check_leader_handler.rs`
+- `src/meta-srv/src/procedure/region_migration.rs`
+- `src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs`
+- `src/meta-srv/src/procedure/region_migration/upgrade_candidate_region.rs`
+- `src/meta-srv/src/procedure/repartition.rs`
+- `src/meta-srv/src/procedure/repartition/group.rs`
+- `src/meta-srv/src/procedure/repartition/deallocate_region.rs`
+- `src/common/meta/`
+- `src/meta-client/`
+- `src/datanode/`
+- `src/store-api/`
+- `src/flow/src/heartbeat.rs`
+
+SQL filter hints:
+
+```sql
+WHERE (
+  lower(message) LIKE '%heartbeat%'
+  OR lower(message) LIKE '%pusher not found%'
+  OR lower(message) LIKE '%region migration%'
+  OR lower(message) LIKE '%repartition%'
+  OR lower(message) LIKE '%procedure%'
+  OR lower(message) LIKE '%step down%'
+  OR lower(message) LIKE '%staging region%'
+  OR lower(message) LIKE '%remap manifest%'
+  OR lower(err) LIKE '%no leader%'
+  OR lower(target) LIKE '%meta%'
+  OR lower(target) LIKE '%procedure%'
+)
+```
+
+## Object storage, WAL, and log store
+
+User descriptions:
+
+- S3 or object storage timeout
+- file not found
+- WAL or log store error
+- Kafka remote WAL issue
+- upload/download slow
+- persistent storage failure
+
+Likely roles:
+
+- `datanode`
+- `mito`
+- `logstore`
+- `opendal`
+- `metasrv` for remote WAL metadata
+
+Log keywords:
+
+- `opendal`
+- `TimedOut`
+- `NotFound`
+- `write close failed`
+- `send http request`
+- `Persistent`
+- `logstore`
+- `remote wal`
+- `kafka`
+- `manifest`
+- `upload`
+- `download`
+- `OpenDAL operator failed`
+- `Failed to init backend`
+- `Failed to build http client`
+- `Failed to create directory`
+- `Failed to remove directory`
+- `Skipping SSL validation`
+- `Retry after`
+
+Metrics:
+
+- `opendal_operation_errors_total`
+- `opendal_operation_duration_seconds_*`
+- `opendal_http_connection_errors_total`
+- `opendal_http_status_errors_total`
+- `greptime_logstore_op_elapsed`
+- `greptime_logstore_op_bytes_total`
+- `greptime_logstore_kafka_client_bytes_total`
+- `greptime_logstore_kafka_client_traffic_total`
+- `greptime_logstore_kafka_client_produce_elapsed`
+- `greptime_manifest_op_elapsed`
+- `greptime_meta_remote_wal_prune_execute`
+
+Source modules:
+
+- `src/log-store/`
+- `src/object-store/src/factory.rs`
+- `src/object-store/src/util.rs`
+- `src/object-store/src/error.rs`
+- `src/object-store/src/layers.rs`
+- `src/mito2/`
+- `src/meta-srv/`
+- `src/common/meta/`
+- `src/store-api/`
+
+SQL filter hints:
+
+```sql
+WHERE (
+  lower(message) LIKE '%opendal%'
+  OR lower(message) LIKE '%logstore%'
+  OR lower(message) LIKE '%remote wal%'
+  OR lower(message) LIKE '%kafka%'
+  OR lower(message) LIKE '%manifest%'
+  OR lower(message) LIKE '%upload%'
+  OR lower(message) LIKE '%download%'
+  OR lower(err) LIKE '%timedout%'
+  OR lower(err) LIKE '%notfound%'
+  OR lower(err) LIKE '%send http request%'
+  OR lower(target) LIKE '%opendal%'
+  OR lower(target) LIKE '%logstore%'
+)
+```
+
+## Compaction, flush, manifest, and GC
+
+User descriptions:
+
+- compaction stuck
+- flush failed
+- manifest update failed
+- too many SSTs
+- write stalls during flush
+- GC failed
+- file cleanup issue
+
+Likely roles:
+
+- `datanode`
+- `mito`
+- `region worker`
+- `metasrv` for GC or migration coordination
+
+Log keywords:
+
+- `compaction`
+- `flush`
+- `manifest`
+- `does not permit manifest updates`
+- `Successfully flush memtables`
+- `Compacted SST files`
+- `Closing staled region`
+- `gc`
+- `cleanup region repartition`
+- `staging manifest`
+- `Failed to compact memtable before flush`
+- `Applying ... to region`
+- `Successfully update manifest version`
+- `Skipping compaction for region ... in staging mode`
+- `manually compaction will be re-scheduled`
+- `Failed to continue pending manual compaction`
+- `Failed to schedule next compaction`
+- `Failed to create RegionOptions from map`
+
+Metrics:
+
+- `greptime_mito_flush_requests_total`
+- `greptime_mito_flush_failure_total`
+- `greptime_mito_flush_elapsed`
+- `greptime_mito_flush_bytes_total`
+- `greptime_mito_inflight_flush_count`
+- `greptime_mito_compaction_requests_total`
+- `greptime_mito_compaction_failure_total`
+- `greptime_mito_compaction_stage_elapsed`
+- `greptime_mito_compaction_total_elapsed`
+- `greptime_mito_inflight_compaction_count`
+- `greptime_mito_compaction_memory_in_use_bytes`
+- `greptime_mito_compaction_memory_rejected_total`
+- `greptime_mito_compaction_memory_limit_bytes`
+- `greptime_mito_compaction_memory_wait_seconds`
+- `greptime_mito_flush_file_total`
+- `greptime_manifest_op_elapsed`
+- `greptime_mito_gc_errors_total`
+- `greptime_mito_gc_duration_seconds`
+- `greptime_metasrv_gc_failed_regions_total`
+
+Source modules:
+
+- `src/mito2/`
+- `src/mito2/src/flush.rs`
+- `src/mito2/src/compaction.rs`
+- `src/mito2/src/metrics.rs`
+- `src/datanode/`
+- `src/meta-srv/src/gc/`
+- `src/store-api/`
+
+SQL filter hints:
+
+```sql
+WHERE (
+  lower(message) LIKE '%compaction%'
+  OR lower(message) LIKE '%flush%'
+  OR lower(message) LIKE '%manifest%'
+  OR lower(message) LIKE '%staled region%'
+  OR lower(message) LIKE '%gc%'
+  OR lower(message) LIKE '%cleanup region repartition%'
+  OR lower(err) LIKE '%does not permit manifest updates%'
+  OR lower(target) LIKE '%mito%'
+  OR lower(target) LIKE '%region%'
+)
+```
+
+## OpenTelemetry, logs, Loki, Elasticsearch, and Prometheus ingest
+
+User descriptions:
+
+- OTLP traces missing
+- OTLP logs missing
+- metrics remote write failed
+- Loki logs ingest issue
+- Elasticsearch logs ingest issue
+- logs ingestion latency
+- spans rejected
+- chunks discarded
+
+Likely roles:
+
+- `frontend`
+- `servers`
+- `operator`
+- `pipeline`
+- `flow` when downstream computation is involved
+
+Log keywords:
+
+- `otlp`
+- `trace`
+- `logs ingestion`
+- `prometheus`
+- `remote write`
+- `span_rejected`
+- `discard_chunk`
+- `loki`
+- `elasticsearch`
+- `pipeline`
+- `transform`
+- `UnsupportedJsonContentType`
+- `Failed to decode OTLP request`
+- `failed to widen trace columns before insert`
+- `failed to coerce trace column`
+- `Trace ingest failure message limit reached`
+- `Failed to ingest metrics from otel-arrow`
+- `failed to insert pipeline`
+- `failed to delete pipeline`
+- `stream is not an object`
+- `missing lines on stream`
+- `line is too short`
+- `missing or invalid timestamp`
+- `failed to parse loki labels`
+- `Native histograms are not supported yet, data ignored`
+- `Find metric name matchers`
+- `Updated promql`
+- `Failed to handle mysql query`
+- `Failed to handle postgres query`
+- `Failed to get trace`
+- `Failed to find traces`
+
+Metrics:
+
+- `greptime_frontend_otlp_metrics_rows`
+- `greptime_frontend_otlp_traces_rows`
+- `greptime_frontend_otlp_traces_failure_count`
+- `greptime_frontend_otlp_logs_rows`
+- `greptime_servers_http_otlp_metrics_elapsed`
+- `greptime_servers_http_otlp_traces_elapsed`
+- `greptime_servers_http_otlp_logs_elapsed`
+- `greptime_servers_http_logs_ingestion_counter`
+- `greptime_servers_http_logs_ingestion_elapsed`
+- `greptime_servers_loki_logs_ingestion_counter`
+- `greptime_servers_loki_logs_ingestion_elapsed`
+- `greptime_servers_elasticsearch_logs_ingestion_elapsed`
+- `greptime_servers_elasticsearch_logs_docs_count`
+- `greptime_servers_http_logs_transform_elapsed`
+- `greptime_servers_http_prometheus_write_elapsed`
+- `greptime_servers_http_prometheus_read_elapsed`
+- `greptime_servers_http_prometheus_promql_elapsed`
+- `greptime_servers_http_prometheus_codec_elapsed`
+- `greptime_servers_prometheus_remote_write_samples`
+- `greptime_servers_http_requests_total`
+- `greptime_servers_grpc_requests_total`
+- `greptime_servers_grpc_db_request_elapsed`
+- `greptime_servers_error`
+- `greptime_servers_http_influxdb_write_elapsed`
+- `greptime_servers_jaeger_query_elapsed`
+- `greptime_prom_store_pending_rows`
+- `greptime_pending_rows_flush_failures`
+- `greptime_pipeline_create_duration_seconds`
+- `greptime_pipeline_delete_duration_seconds`
+- `greptime_pipeline_retrieve_duration_seconds`
+- `greptime_pipeline_table_find_count`
+
+Source modules:
+
+- `src/frontend/`
+- `src/frontend/src/instance/otlp.rs`
+- `src/servers/`
+- `src/servers/src/http/otlp.rs`
+- `src/servers/src/otel_arrow.rs`
+- `src/servers/src/http/event.rs`
+- `src/servers/src/http/loki.rs`
+- `src/servers/src/http/prometheus.rs`
+- `src/servers/src/http/influxdb.rs`
+- `src/servers/src/http/jaeger.rs`
+- `src/servers/src/prom_remote_write/`
+- `src/servers/src/prom_remote_write/decode.rs`
+- `src/pipeline/`
+- `src/operator/`
+
+SQL filter hints:
+
+```sql
+WHERE (
+  lower(message) LIKE '%otlp%'
+  OR lower(message) LIKE '%trace%'
+  OR lower(message) LIKE '%logs ingestion%'
+  OR lower(message) LIKE '%remote write%'
+  OR lower(message) LIKE '%span_rejected%'
+  OR lower(message) LIKE '%discard_chunk%'
+  OR lower(message) LIKE '%loki%'
+  OR lower(message) LIKE '%elasticsearch%'
+  OR lower(message) LIKE '%pipeline%'
+  OR lower(target) LIKE '%frontend%'
+  OR lower(target) LIKE '%servers%'
+)
+```
+
+## Flow creation or runtime issue
+
+User descriptions:
+
+- flow creation failed
+- continuous aggregation stopped
+- materialized view stale
+- flow lag
+- flow flush failed
+- flownode heartbeat issue
+
+Likely roles:
+
+- `flownode`
+- `flow`
+- `metasrv`
+- `frontend`
+
+Log keywords:
+
+- `flow`
+- `CreateFlow`
+- `Failed to handle flow request`
+- `Failed to recover flows`
+- `Failed to check flow consistent`
+- `Failed to execute query for flow`
+- `No frontend is available`
+- `flownode heartbeat`
+- `Flow missing`
+- `flush flow`
+
+Metrics:
+
+- `greptime_flow_task_count`
+- `greptime_flow_input_buf_size`
+- `greptime_flow_insert_elapsed`
+- `greptime_flow_batching_engine_query_time_secs`
+- `greptime_flow_batching_engine_slow_query_secs`
+- `greptime_flow_batching_engine_query_window_cnt`
+- `greptime_flow_batching_engine_query_window_size_secs`
+- `greptime_flow_batching_start_query_count`
+- `greptime_flow_batching_error_count`
+- `greptime_flow_processed_rows`
+- `greptime_flow_processing_time`
+- `greptime_flow_errors`
+- `greptime_meta_procedure_create_flow`
+- `greptime_meta_procedure_drop_flow`
+
+Source modules:
+
+- `src/flow/`
+- `src/meta-srv/`
+- `src/common/meta/`
+- `src/frontend/`
+
+SQL filter hints:
+
+```sql
+WHERE (
+  lower(message) LIKE '%flow%'
+  OR lower(message) LIKE '%createflow%'
+  OR lower(message) LIKE '%failed to handle flow request%'
+  OR lower(message) LIKE '%failed to recover flows%'
+  OR lower(message) LIKE '%failed to check flow consistent%'
+  OR lower(message) LIKE '%no frontend is available%'
+  OR lower(target) LIKE '%flow%'
+  OR lower(target) LIKE '%flownode%'
+)
+```
+
+## Panic, crash, restart, or process health issue
+
+User descriptions:
+
+- pod restarted
+- component crashed
+- panic
+- OOM
+- process killed
+- memory limit hit
+- startup failed
+
+Likely roles:
+
+- all roles; prioritize the role mentioned by the user or pod name
+
+Log keywords:
+
+- `panicked at`
+- `panic`
+- `oom`
+- `out of memory`
+- `memory limit`
+- `Receiver dropped`
+- `shutdown`
+- `started`
+- `stopped`
+- `Failed to start`
+
+Metrics:
+
+- `greptime_panic_counter`
+- `greptime_memory_limit_in_bytes`
+- `greptime_cgroups_memory_usage_bytes`
+- `greptime_servers_request_memory_in_use_bytes`
+- `greptime_servers_request_memory_limit_bytes`
+- `greptime_servers_request_memory_rejected_total`
+- `greptime_query_memory_pool_usage_bytes`
+- `greptime_query_memory_pool_rejected_total`
+- `process_*`
+
+Source modules:
+
+- `src/common/telemetry/`
+- `src/cmd/`
+- `src/common/stat/`
+- component source directory matching the affected role
+
+SQL filter hints:
+
+```sql
+WHERE (
+  lower(message) LIKE '%panic%'
+  OR lower(message) LIKE '%panicked at%'
+  OR lower(message) LIKE '%oom%'
+  OR lower(message) LIKE '%out of memory%'
+  OR lower(message) LIKE '%memory limit%'
+  OR lower(message) LIKE '%shutdown%'
+  OR lower(message) LIKE '%failed to start%'
+  OR lower(err) LIKE '%panic%'
+  OR lower(err) LIKE '%memory%'
+)
+```
+
+## Metric label hints
+
+When metric tables exist in `public`, group by these labels to separate the affected operation or failure mode. Always inspect the table schema first because label columns can vary by version and deployment.
+
+| Metric table | Useful labels |
+|---|---|
+| `greptime_meta_kv_request_elapsed` | `target`, `op` |
+| `greptime_meta_handler_execute` | `name` |
+| `greptime_meta_region_migration_error` | `state`, `error_type` |
+| `greptime_meta_region_migration_stage_elapsed` | `stage` |
+| `greptime_meta_heartbeat_recv` | `pusher_key` |
+| `greptime_mito_flush_requests_total` | `reason` |
+| `greptime_mito_flush_elapsed` | `type` |
+| `greptime_mito_compaction_stage_elapsed` | `stage` |
+| `greptime_mito_compaction_memory_rejected_total` | `type` |
+| `greptime_query_stage_elapsed` | `stage` |
+| `greptime_table_operator_handle_bulk_insert` | `stage` |
+| `greptime_servers_http_requests_total` | `method`, `path`, `code`, `db` |
+| `greptime_servers_grpc_requests_total` | `path`, `code` |
+| `greptime_servers_grpc_db_request_elapsed` | `db`, `type`, `code` |
+| `greptime_servers_http_logs_ingestion_elapsed` | `result` |
+| `greptime_servers_loki_logs_ingestion_elapsed` | `result` |
+| `greptime_servers_http_prometheus_codec_elapsed` | `type` |
+| `greptime_servers_error` | `protocol` |
+| `greptime_frontend_otlp_traces_failure_count` | `label` |
+
+Template:
+
+```sql
+SELECT
+  date_trunc('minute', greptime_timestamp) AS minute,
+  <label_columns>,
+  count(*) AS samples
+FROM <metric_table>
+WHERE greptime_timestamp >= '<start_utc>'
+  AND greptime_timestamp < '<end_utc>'
+GROUP BY minute, <label_columns>
+ORDER BY minute, samples DESC;
+```

--- a/skills/self-monitoring-export/references/sql-cheatsheet.md
+++ b/skills/self-monitoring-export/references/sql-cheatsheet.md
@@ -1,0 +1,362 @@
+# GreptimeDB SQL Cheatsheet
+
+Use these built-in templates before launching subagents or searching docs for common GreptimeDB syntax. Search docs only when:
+
+- the query fails
+- the discovered GreptimeDB version differs materially from the syntax here
+- a storage provider or export option is not covered here
+- the user asks for version-specific proof
+
+MCP boundary: these templates include both read-only analysis SQL and export SQL. Run only read-only `SELECT` / `SHOW` / `DESCRIBE` queries through MCP. Never run `COPY`, `COPY TO`, `COPY DATABASE`, or export-writing SQL through MCP.
+
+## Schema and table discovery
+
+```sql
+SHOW TABLES FROM public;
+DESCRIBE TABLE _gt_logs;
+```
+
+## Self-monitoring cluster labels
+
+```sql
+SELECT `cluster`, namespace, count(*) AS rows
+FROM _gt_logs
+WHERE timestamp >= now() - INTERVAL '2' DAY
+GROUP BY `cluster`, namespace
+ORDER BY rows DESC;
+```
+
+`cluster` may need backticks because it can parse as a keyword.
+
+## GreptimeDB version from self-monitoring
+
+```sql
+SELECT
+  app,
+  version,
+  short_version,
+  `cluster`,
+  namespace,
+  count(DISTINCT pod) AS pods,
+  max(greptime_timestamp) AS last_seen
+FROM greptime_app_version
+WHERE greptime_timestamp >= now() - INTERVAL '1' HOUR
+GROUP BY app, version, short_version, `cluster`, namespace
+ORDER BY app, version, short_version;
+```
+
+## Time bucketing with `date_trunc`
+
+Hourly log level counts:
+
+```sql
+SELECT
+  date_trunc('hour', timestamp) AS hour,
+  level,
+  count(*) AS cnt
+FROM _gt_logs
+WHERE timestamp >= '<start_utc>'
+  AND timestamp < '<end_utc>'
+GROUP BY hour, level
+ORDER BY hour, level;
+```
+
+Minute-level refinement:
+
+```sql
+SELECT
+  date_trunc('minute', timestamp) AS minute,
+  level,
+  count(*) AS cnt
+FROM _gt_logs
+WHERE timestamp >= '<start_utc>'
+  AND timestamp < '<end_utc>'
+GROUP BY minute, level
+ORDER BY minute, level;
+```
+
+## Time bucketing with `date_bin`
+
+Syntax:
+
+```sql
+date_bin(INTERVAL '<bucket>', <timestamp_column>, '<origin_timestamp>'::TIMESTAMP)
+```
+
+The origin defaults to Unix epoch UTC in docs. Use an explicit origin for portability.
+
+Ten-minute buckets:
+
+```sql
+SELECT
+  date_bin(INTERVAL '10' MINUTE, timestamp, '1970-01-01 00:00:00'::TIMESTAMP) AS bucket,
+  level,
+  count(*) AS cnt
+FROM _gt_logs
+WHERE timestamp >= '<start_utc>'
+  AND timestamp < '<end_utc>'
+GROUP BY bucket, level
+ORDER BY bucket, level;
+```
+
+## Description-driven keyword discovery
+
+Use this before generic `ERROR` / `WARN` aggregation. Pick keywords from the user's description, [`signal-index.md`](signal-index.md), and source-code lookup when the description has no direct log keyword match.
+
+Minute-level counts for targeted signals:
+
+```sql
+SELECT
+  date_trunc('minute', timestamp) AS minute,
+  level,
+  role,
+  target,
+  count(*) AS cnt
+FROM _gt_logs
+WHERE timestamp >= '<start_utc>'
+  AND timestamp < '<end_utc>'
+  AND (
+    lower(message) LIKE '%<keyword_1>%'
+    OR lower(message) LIKE '%<keyword_2>%'
+    OR lower(err) LIKE '%<keyword_1>%'
+    OR lower(err) LIKE '%<keyword_2>%'
+    OR lower(target) LIKE '%<component_or_module>%'
+    OR lower(role) LIKE '%<role>%'
+  )
+GROUP BY minute, level, role, target
+ORDER BY minute, cnt DESC;
+```
+
+Top targeted categories:
+
+```sql
+SELECT
+  date_bin(INTERVAL '15' MINUTE, timestamp, '1970-01-01 00:00:00'::TIMESTAMP) AS bucket,
+  level,
+  role,
+  target,
+  message,
+  err,
+  count(*) AS cnt
+FROM _gt_logs
+WHERE timestamp >= '<start_utc>'
+  AND timestamp < '<end_utc>'
+  AND (
+    lower(message) LIKE '%<keyword_1>%'
+    OR lower(message) LIKE '%<keyword_2>%'
+    OR lower(err) LIKE '%<keyword_1>%'
+    OR lower(err) LIKE '%<keyword_2>%'
+    OR lower(target) LIKE '%<component_or_module>%'
+    OR lower(role) LIKE '%<role>%'
+  )
+GROUP BY bucket, level, role, target, message, err
+ORDER BY cnt DESC
+LIMIT 100;
+```
+
+Exact source-string spot check:
+
+```sql
+SELECT
+  timestamp,
+  level,
+  role,
+  pod,
+  target,
+  message,
+  err
+FROM _gt_logs
+WHERE timestamp >= '<start_utc>'
+  AND timestamp < '<end_utc>'
+  AND (
+    message LIKE '%<Exact source log string>%'
+    OR err LIKE '%<Exact source error string>%'
+  )
+ORDER BY timestamp
+LIMIT 200;
+```
+
+## Fallback error/warn aggregation
+
+Use this as fallback or sanity check after description-driven discovery. Do not treat top `ERROR` / `WARN` categories as the primary signal when the user described a specific failure mode.
+
+Fifteen-minute buckets for top fallback categories:
+
+```sql
+SELECT
+  date_bin(INTERVAL '15' MINUTE, timestamp, '1970-01-01 00:00:00'::TIMESTAMP) AS bucket,
+  level,
+  role,
+  target,
+  message,
+  err,
+  count(*) AS cnt
+FROM _gt_logs
+WHERE timestamp >= '<start_utc>'
+  AND timestamp < '<end_utc>'
+  AND level IN ('ERROR', 'WARN')
+GROUP BY bucket, level, role, target, message, err
+ORDER BY cnt DESC
+LIMIT 100;
+```
+
+## Range query aggregation
+
+GreptimeDB supports range aggregation syntax:
+
+```sql
+SELECT
+  ts,
+  host,
+  avg(cpu) RANGE '10s' FILL LINEAR
+FROM monitor
+ALIGN '5s' TO '2023-12-01T00:00:00'
+BY (host)
+ORDER BY ts ASC;
+```
+
+For incident log discovery, prefer normal SQL `date_trunc` or `date_bin` aggregations unless range-query syntax is already proven in the target version and table shape.
+
+## Top fallback error/warn categories
+
+Use this as fallback or sanity check. Prefer the description-driven keyword templates above for the main incident-window search.
+
+```sql
+SELECT
+  date_trunc('hour', timestamp) AS hour,
+  level,
+  role,
+  target,
+  message,
+  err,
+  count(*) AS cnt
+FROM _gt_logs
+WHERE timestamp >= '<start_utc>'
+  AND timestamp < '<end_utc>'
+  AND level IN ('ERROR', 'WARN')
+GROUP BY hour, level, role, target, message, err
+ORDER BY cnt DESC
+LIMIT 100;
+```
+
+## Row-count preflight
+
+Total rows:
+
+```sql
+SELECT count(*) AS expected_rows
+FROM _gt_logs
+WHERE timestamp >= '<export_start_utc>'
+  AND timestamp < '<export_end_utc>';
+```
+
+Hourly rows for chunk planning:
+
+```sql
+SELECT
+  date_trunc('hour', timestamp) AS hour,
+  count(*) AS expected_rows
+FROM _gt_logs
+WHERE timestamp >= '<export_start_utc>'
+  AND timestamp < '<export_end_utc>'
+GROUP BY hour
+ORDER BY hour;
+```
+
+## Complete SELECT for analysis spot checks only
+
+Use this only for read-only analysis spot checks. Do not use MCP result download as the final incident log export; final data export must use HTTP port export or one of the supported `COPY TO` modes.
+
+```sql
+SELECT *
+FROM _gt_logs
+WHERE timestamp >= '<export_start_utc>'
+  AND timestamp < '<export_end_utc>'
+ORDER BY timestamp;
+```
+
+## `COPY TO` query-result export: Parquet
+
+Run this only through non-MCP SQL/HTTP access or provide it as a user-executed script.
+
+```sql
+COPY (
+  SELECT *
+  FROM _gt_logs
+  WHERE timestamp >= '<export_start_utc>'
+    AND timestamp < '<export_end_utc>'
+  ORDER BY timestamp
+) TO '<self_monitoring_filesystem_path>/gt_logs_<start>_<end>.parquet'
+WITH (FORMAT = 'parquet');
+```
+
+## Local/server-side Parquet path
+
+`COPY TO` writes on the GreptimeDB server node, not the agent/client machine.
+
+```sql
+COPY (
+  SELECT *
+  FROM _gt_logs
+  WHERE timestamp >= '<export_start_utc>'
+    AND timestamp < '<export_end_utc>'
+  ORDER BY timestamp
+) TO '/tmp/greptimedb-incident-export/<incident-id>/gt_logs_<start>_<end>.parquet'
+WITH (FORMAT = 'parquet');
+```
+
+## HTTP port export
+
+Use this when the user chooses GreptimeDB HTTP port export. See [`export-http.md`](export-http.md). Do not set an HTTP timeout header. Use GreptimeDB's `compression=` query parameter through the script, not HTTP `Accept-Encoding`.
+
+```bash
+scripts/http_arrow_export.sh \
+  --url "http://<host>:<port>" \
+  --db "public" \
+  --sql "SELECT * FROM public._gt_logs WHERE timestamp >= '<export_start_utc>' AND timestamp < '<export_end_utc>' ORDER BY timestamp" \
+  --output './greptimedb-incident-<id>/logs/gt_logs_<start>_<end>.arrow' \
+  --headers './greptimedb-incident-<id>/metadata/gt_logs_<start>_<end>.headers'
+```
+
+The script writes `gt_logs_<start>_<end>.zstd.arrow` if the `zstd` request succeeds, or `gt_logs_<start>_<end>.lz4.arrow` if it falls back to `lz4`.
+
+## CSV/JSON fallbacks
+
+Use CSV/JSON only when the user needs text output or Parquet is unavailable. `compression_type` applies to CSV/JSON, not Parquet.
+
+```sql
+COPY (
+  SELECT *
+  FROM _gt_logs
+  WHERE timestamp >= '<export_start_utc>'
+    AND timestamp < '<export_end_utc>'
+  ORDER BY timestamp
+) TO '<self_monitoring_filesystem_path>/gt_logs_<start>_<end>.csv.gz'
+WITH (
+  FORMAT = 'csv',
+  compression_type = 'gzip',
+  TIMESTAMP_FORMAT = '%Y-%m-%dT%H:%M:%S%.f'
+);
+```
+
+## COPY DATABASE caution
+
+`COPY DATABASE` can export database-level data with `FORMAT = 'parquet'`, `START_TIME`, `END_TIME`, and `PARALLELISM`, but this skill normally exports selected `_gt_logs` query windows instead of whole databases.
+
+Cautions:
+
+- `START_TIME` is inclusive.
+- `END_TIME` is exclusive.
+- `COPY DATABASE` path must end with `/`.
+- Whole-database export is usually too broad for incident handoff unless the user explicitly requests it.
+
+## COPY TO STDOUT caution
+
+PostgreSQL `COPY ... TO STDOUT` is separate from server-side file export. It is PostgreSQL-only, query-result only, and supports `text`/`csv`/`binary` style output rather than Parquet file export. Do not confuse it with `COPY TO '<path>' WITH (FORMAT = 'parquet')`.
+
+## Common export cautions
+
+- `COPY TO` writes on the self-monitoring GreptimeDB filesystem, not automatically into the local artifact directory.
+- Include retrieval instructions only when the user chose `kubectl cp`; otherwise record that the user will download files manually.
+- Use `/` in paths for portability; avoid Windows `\` path separators in SQL examples.
+- Never put secrets into reports. Redact credentials in saved command files unless the user explicitly asks to store them.

--- a/skills/self-monitoring-export/references/validation.md
+++ b/skills/self-monitoring-export/references/validation.md
@@ -1,0 +1,82 @@
+# Validation Guide
+
+After each log export, validate that exported row count matches the pre-export estimate, or is close enough to be explained by time-window drift.
+
+Before export:
+
+```sql
+SELECT count(*) AS expected_rows
+FROM _gt_logs
+WHERE timestamp >= '<export_start_utc>'
+  AND timestamp < '<export_end_utc>';
+```
+
+For chunked exports:
+
+```sql
+SELECT
+  date_trunc('hour', timestamp) AS hour,
+  count(*) AS expected_rows
+FROM _gt_logs
+WHERE timestamp >= '<export_start_utc>'
+  AND timestamp < '<export_end_utc>'
+GROUP BY hour
+ORDER BY hour;
+```
+
+After export, compute or estimate actual rows:
+
+CSV with one header row:
+
+```bash
+actual_rows=$(($(wc -l < gt_logs_incident.csv) - 1))
+```
+
+Compressed CSV:
+
+```bash
+actual_rows=$(($(gzip -cd gt_logs_incident.csv.gz | wc -l) - 1))
+```
+
+JSON lines:
+
+```bash
+actual_rows=$(wc -l < gt_logs_incident.json)
+```
+
+Arrow IPC with the skill validator:
+
+```bash
+python3 scripts/validate_arrow.py \
+  logs/gt_logs_<start>_<end>.zstd.arrow \
+  --expected-rows <expected_rows> \
+  --min-timestamp '<export_start_utc>' \
+  --max-timestamp '<export_end_utc>' \
+  --schema
+```
+
+The validator prints row count, batch count, file size, SHA-256 checksum, optional schema, and expected-row mismatch status. Use the actual exported suffix, for example `.zstd.arrow` or `.lz4.arrow`.
+
+When creating an artifact command record, prefer `commands/validate_arrow.sh` as a wrapper that calls the canonical skill `scripts/validate_arrow.py`. Do not copy the Python validator into the artifact unless the user explicitly requests a self-contained artifact.
+
+If no local Arrow reader is available, record that exact row validation could not be performed locally and keep pre-export SQL count plus file size/checksum.
+
+Validation rules:
+
+- Exact match is ideal.
+- Small differences can be acceptable if source table was still receiving logs and export query used `now()` or a moving boundary.
+- For fixed boundaries, large differences are suspicious.
+- Treat differences above 1% or 10,000 rows, whichever is larger, as requiring investigation unless clearly explained.
+- For chunked exports, validate every chunk and total.
+
+If there is a large mismatch:
+
+1. Do not claim export is complete.
+2. Re-run expected row count using exact fixed time boundaries.
+3. Check whether export query used the same boundaries and filters as count query.
+4. Check whether exported file was truncated, split, compressed, or overwritten.
+5. Check command errors, truncated files, and failed retrieval steps.
+6. Re-export missing chunk(s) only, if possible.
+7. Record mismatch and remediation in `summary/gaps_and_risks.md`.
+
+For every exported file, record expected rows, actual rows if measurable, row-count difference, file size, checksum if practical, and validation status: `validated`, `approximate`, or `not validated`.

--- a/skills/self-monitoring-export/scripts/http_arrow_export.sh
+++ b/skills/self-monitoring-export/scripts/http_arrow_export.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  http_arrow_export.sh --url URL --db DB --sql SQL --output OUTPUT [--headers HEADERS]
+
+Required:
+  --url      GreptimeDB HTTP base URL, for example http://localhost:4000
+  --db       Database name, usually public
+  --sql      SQL query to export. Use fixed UTC boundaries.
+  --output   Local output path for Arrow IPC data. The script adds .zstd.arrow or .lz4.arrow.
+
+Optional:
+  --headers  Local path to save response headers. Defaults to FINAL_OUTPUT.headers
+
+Environment:
+  AUTH_HEADER   Optional Authorization header value, for example "Basic ...".
+
+Behavior:
+  - Uses the GreptimeDB HTTP port and /v1/sql?format=arrow.
+  - Requests Arrow IPC compression with zstd first, then lz4.
+  - Includes the requested Arrow IPC compression format in the final suffix, such as .zstd.arrow or .lz4.arrow.
+  - Does not set an HTTP timeout header.
+  - Fails on HTTP errors and does not leave a failed response as OUTPUT.
+  - Validates output with scripts/validate_arrow.py when available, otherwise inline PyArrow.
+USAGE
+}
+
+url=""
+db=""
+sql=""
+output=""
+headers=""
+headers_provided=false
+curl_config=""
+
+cleanup() {
+  if [[ -n "$curl_config" ]]; then
+    rm -f -- "$curl_config"
+  fi
+}
+trap cleanup EXIT
+
+validate_sql() {
+  local input_sql="$1"
+  local trimmed
+  local first_token
+
+  trimmed="$(printf '%s' "$input_sql" | python3 -c 'import re, sys; value=sys.stdin.read().strip(); value=re.sub(r";\s*$", "", value); print(value, end="")')"
+  if [[ -z "$trimmed" || "$trimmed" == *';'* || "$trimmed" == *'--'* || "$trimmed" == *'/*'* || "$trimmed" == *'*/'* ]]; then
+    echo "Refusing SQL with comments, multiple statements, or empty body" >&2
+    exit 2
+  fi
+
+  first_token="$(printf '%s' "$trimmed" | python3 -c 'import re, sys; match=re.match(r"\s*([A-Za-z]+)", sys.stdin.read()); print(match.group(1).lower() if match else "", end="")')"
+  case "$first_token" in
+    select|with)
+      ;;
+    *)
+      echo "Refusing non-read-only export SQL" >&2
+      exit 2
+      ;;
+  esac
+}
+
+validate_auth_header() {
+  if [[ -n "${AUTH_HEADER:-}" && "${AUTH_HEADER}" == *[$'\r\n"\\']* ]]; then
+    echo "AUTH_HEADER contains unsupported characters" >&2
+    exit 2
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --url)
+      url="$2"
+      shift 2
+      ;;
+    --db)
+      db="$2"
+      shift 2
+      ;;
+    --sql)
+      sql="$2"
+      shift 2
+      ;;
+    --output)
+      output="$2"
+      shift 2
+      ;;
+    --headers)
+      headers="$2"
+      headers_provided=true
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$url" || -z "$db" || -z "$sql" || -z "$output" ]]; then
+  usage >&2
+  exit 2
+fi
+
+if ! printf '%s' "$db" | grep -Eq '^[A-Za-z_][A-Za-z0-9_]*$'; then
+  echo "Invalid database name" >&2
+  exit 2
+fi
+
+validate_sql "$sql"
+validate_auth_header
+
+base_endpoint="${url%/}/v1/sql?db=${db}&format=arrow"
+
+encoded_output_path() {
+  local requested="$1"
+  local encoding="$2"
+  local base="$requested"
+
+  case "$base" in
+    *.zstd.arrow)
+      base="${base%.zstd.arrow}"
+      ;;
+    *.lz4.arrow)
+      base="${base%.lz4.arrow}"
+      ;;
+    *.arrow)
+      base="${base%.arrow}"
+      ;;
+  esac
+
+  printf '%s.%s.arrow' "$base" "$encoding"
+}
+
+base_curl_args=(
+  -sS
+  --fail-with-body
+  -X POST
+  -H "X-Greptime-Timezone: UTC"
+  -H "Content-Type: application/x-www-form-urlencoded"
+  --data-urlencode "sql=${sql}"
+)
+
+if [[ -n "${AUTH_HEADER:-}" ]]; then
+  curl_config="$(mktemp "${TMPDIR:-/tmp}/greptimedb-http-arrow-curl.XXXXXX")"
+  chmod 600 "$curl_config"
+  printf 'header = "Authorization: %s"\n' "$AUTH_HEADER" > "$curl_config"
+  base_curl_args+=( -K "$curl_config" )
+fi
+
+last_status=1
+final_output=""
+final_headers=""
+for encoding in zstd lz4; do
+  final_output="$(encoded_output_path "$output" "$encoding")"
+  if [[ "$headers_provided" == true ]]; then
+    final_headers="$headers"
+  else
+    final_headers="${final_output}.headers"
+  fi
+
+  mkdir -p "$(dirname "$final_output")" "$(dirname "$final_headers")"
+  tmp_output="${final_output}.tmp"
+  tmp_headers="${final_headers}.tmp"
+  rm -f -- "$tmp_output" "$tmp_headers"
+  endpoint="${base_endpoint}&compression=${encoding}"
+  if curl "${base_curl_args[@]}" -D "$tmp_headers" "$endpoint" --output "$tmp_output"; then
+    mv -- "$tmp_output" "$final_output"
+    mv -- "$tmp_headers" "$final_headers"
+    echo "export_path=${final_output}"
+    echo "headers_path=${final_headers}"
+    echo "requested_encoding=${encoding}"
+    break
+  fi
+  last_status=$?
+done
+
+if [[ -z "$final_output" || ! -s "$final_output" ]]; then
+  rm -f -- "$tmp_output" "$tmp_headers"
+  echo "HTTP port export failed for zstd and lz4 encodings" >&2
+  exit "$last_status"
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+validator="${script_dir}/validate_arrow.py"
+
+if [[ -f "$validator" ]]; then
+  python3 "$validator" "$final_output" --schema
+  exit 0
+fi
+
+python3 - "$final_output" <<'PY'
+import sys
+
+path = sys.argv[1]
+try:
+    import pyarrow.ipc as ipc
+except Exception as exc:
+    print(f"pyarrow_validation=skipped reason={exc.__class__.__name__}: {exc}")
+    raise SystemExit(0)
+
+rows = 0
+batches = 0
+with open(path, "rb") as f:
+    reader = ipc.open_stream(f)
+    schema = reader.schema
+    for batch in reader:
+        batches += 1
+        rows += batch.num_rows
+
+print(f"pyarrow_validation=ok batches={batches} rows={rows}")
+print(schema)
+PY

--- a/skills/self-monitoring-export/scripts/http_sql_query.sh
+++ b/skills/self-monitoring-export/scripts/http_sql_query.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  http_sql_query.sh --url URL --db DB (--sql SQL | --sql-file FILE) --output OUTPUT [--format FORMAT] [--headers HEADERS]
+
+Required:
+  --url       GreptimeDB HTTP base URL, for example http://localhost:4000
+  --db        Database name, usually public
+  --sql       SQL query to execute. Use one read-only statement.
+  --sql-file  File containing one read-only SQL statement.
+  --output    Local output path for the query result
+
+Optional:
+  --format    HTTP SQL output format. Defaults to csvWithNames.
+  --headers   Local path to save response headers. Defaults to OUTPUT.headers
+
+Environment:
+  AUTH_HEADER   Optional Authorization header value, for example "Basic ...".
+
+Behavior:
+  - Uses GreptimeDB HTTP /v1/sql.
+  - Sends SQL as application/x-www-form-urlencoded POST data.
+  - Sets X-Greptime-Timezone: UTC.
+  - Does not set an HTTP timeout header.
+  - Rejects obvious write/export statements.
+USAGE
+}
+
+url=""
+db=""
+sql=""
+sql_file=""
+output=""
+format="csvWithNames"
+headers=""
+curl_config=""
+
+cleanup() {
+  if [[ -n "$curl_config" ]]; then
+    rm -f -- "$curl_config"
+  fi
+}
+trap cleanup EXIT
+
+validate_sql() {
+  local input_sql="$1"
+  local trimmed
+  local first_token
+
+  trimmed="$(printf '%s' "$input_sql" | python3 -c 'import re, sys; value=sys.stdin.read().strip(); value=re.sub(r";\s*$", "", value); print(value, end="")')"
+  if [[ -z "$trimmed" || "$trimmed" == *';'* || "$trimmed" == *'--'* || "$trimmed" == *'/*'* || "$trimmed" == *'*/'* ]]; then
+    echo "Refusing SQL with comments, multiple statements, or empty body" >&2
+    exit 2
+  fi
+
+  first_token="$(printf '%s' "$trimmed" | python3 -c 'import re, sys; match=re.match(r"\s*([A-Za-z]+)", sys.stdin.read()); print(match.group(1).lower() if match else "", end="")')"
+  case "$first_token" in
+    select|with|show|describe|desc)
+      ;;
+    *)
+      echo "Refusing non-read-only SQL" >&2
+      exit 2
+      ;;
+  esac
+}
+
+validate_auth_header() {
+  if [[ -n "${AUTH_HEADER:-}" && "${AUTH_HEADER}" == *[$'\r\n"\\']* ]]; then
+    echo "AUTH_HEADER contains unsupported characters" >&2
+    exit 2
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --url)
+      url="$2"
+      shift 2
+      ;;
+    --db)
+      db="$2"
+      shift 2
+      ;;
+    --sql)
+      sql="$2"
+      shift 2
+      ;;
+    --sql-file)
+      sql_file="$2"
+      shift 2
+      ;;
+    --output)
+      output="$2"
+      shift 2
+      ;;
+    --format)
+      format="$2"
+      shift 2
+      ;;
+    --headers)
+      headers="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$url" || -z "$db" || -z "$output" ]]; then
+  usage >&2
+  exit 2
+fi
+
+if [[ -n "$sql" && -n "$sql_file" ]]; then
+  echo "Use either --sql or --sql-file, not both" >&2
+  exit 2
+fi
+
+if [[ -z "$sql" && -z "$sql_file" ]]; then
+  usage >&2
+  exit 2
+fi
+
+if [[ -n "$sql_file" ]]; then
+  sql="$(<"$sql_file")"
+fi
+
+if ! printf '%s' "$db" | grep -Eq '^[A-Za-z_][A-Za-z0-9_]*$'; then
+  echo "Invalid database name" >&2
+  exit 2
+fi
+
+case "$format" in
+  greptimedb_v1|json|csv|csvWithNames|csvWithNamesAndTypes|table)
+    ;;
+  *)
+    echo "Invalid output format" >&2
+    exit 2
+    ;;
+esac
+
+validate_sql "$sql"
+validate_auth_header
+
+headers="${headers:-${output}.headers}"
+endpoint="${url%/}/v1/sql?db=${db}&format=${format}"
+mkdir -p "$(dirname "$output")" "$(dirname "$headers")"
+
+tmp_output="${output}.tmp"
+tmp_headers="${headers}.tmp"
+rm -f -- "$tmp_output" "$tmp_headers"
+
+curl_args=(
+  -sS
+  --fail-with-body
+  -X POST
+  -D "$tmp_headers"
+  -H "X-Greptime-Timezone: UTC"
+  -H "Content-Type: application/x-www-form-urlencoded"
+  --data-urlencode "sql=${sql}"
+)
+
+if [[ -n "${AUTH_HEADER:-}" ]]; then
+  curl_config="$(mktemp "${TMPDIR:-/tmp}/greptimedb-http-sql-curl.XXXXXX")"
+  chmod 600 "$curl_config"
+  printf 'header = "Authorization: %s"\n' "$AUTH_HEADER" > "$curl_config"
+  curl_args+=( -K "$curl_config" )
+fi
+
+if curl "${curl_args[@]}" "$endpoint" --output "$tmp_output"; then
+  mv -- "$tmp_output" "$output"
+  mv -- "$tmp_headers" "$headers"
+  echo "query_output=${output}"
+  echo "headers_path=${headers}"
+  echo "format=${format}"
+  exit 0
+fi
+
+status=$?
+rm -f -- "$tmp_output" "$tmp_headers"
+exit "$status"

--- a/skills/self-monitoring-export/scripts/validate_arrow.py
+++ b/skills/self-monitoring-export/scripts/validate_arrow.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import sys
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate Arrow IPC stream files and print rows, batches, size, and checksum."
+    )
+    parser.add_argument("paths", nargs="+", help="Arrow IPC stream files to validate")
+    parser.add_argument(
+        "--expected-rows",
+        type=int,
+        default=None,
+        help="Expected total row count across all input files",
+    )
+    parser.add_argument(
+        "--schema",
+        action="store_true",
+        help="Print each file schema after validation",
+    )
+    parser.add_argument("--timestamp-column", default="timestamp", help="Timestamp column to inspect")
+    parser.add_argument("--min-timestamp", default=None, help="Inclusive lower timestamp bound")
+    parser.add_argument("--max-timestamp", default=None, help="Exclusive upper timestamp bound")
+    return parser.parse_args()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file_obj:
+        for chunk in iter(lambda: file_obj.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def parse_timestamp(raw: str | None) -> dt.datetime | None:
+    if raw is None:
+        return None
+    value = raw.replace("Z", "+00:00")
+    parsed = dt.datetime.fromisoformat(value)
+    if parsed.tzinfo is not None:
+        return parsed.astimezone(dt.timezone.utc).replace(tzinfo=None)
+    return parsed
+
+
+def comparable_timestamp(value: object) -> dt.datetime:
+    if isinstance(value, dt.datetime):
+        if value.tzinfo is not None:
+            return value.astimezone(dt.timezone.utc).replace(tzinfo=None)
+        return value
+    raise TypeError(f"Unsupported timestamp value: {value!r}")
+
+
+def validate_file(path: Path, print_schema: bool, timestamp_column: str) -> tuple[int, dt.datetime | None, dt.datetime | None]:
+    try:
+        import pyarrow.ipc as ipc
+    except Exception as exc:
+        print(f"pyarrow_validation=missing reason={exc.__class__.__name__}: {exc}", file=sys.stderr)
+        return -1, None, None
+
+    rows = 0
+    batches = 0
+    first_timestamp = None
+    last_timestamp = None
+    with path.open("rb") as file_obj:
+        reader = ipc.open_stream(file_obj)
+        schema = reader.schema
+        for batch in reader:
+            batches += 1
+            rows += batch.num_rows
+            if timestamp_column in schema.names and batch.num_rows > 0:
+                values = batch.column(timestamp_column)
+                for index in range(len(values)):
+                    value = values[index].as_py()
+                    if value is None:
+                        continue
+                    comparable = comparable_timestamp(value)
+                    if first_timestamp is None or comparable < first_timestamp:
+                        first_timestamp = comparable
+                    if last_timestamp is None or comparable > last_timestamp:
+                        last_timestamp = comparable
+
+    parts = [
+        f"file={path}",
+        f"rows={rows}",
+        f"batches={batches}",
+        f"size_bytes={path.stat().st_size}",
+        f"sha256={sha256_file(path)}",
+    ]
+    if first_timestamp is not None and last_timestamp is not None:
+        parts.append(f"first_timestamp={first_timestamp.isoformat()}")
+        parts.append(f"last_timestamp={last_timestamp.isoformat()}")
+    print(" ".join(parts))
+    if print_schema:
+        print(f"schema_begin file={path}")
+        print(schema)
+        print(f"schema_end file={path}")
+    return rows, first_timestamp, last_timestamp
+
+
+def main() -> int:
+    args = parse_args()
+    total_rows = 0
+    min_timestamp = parse_timestamp(args.min_timestamp)
+    max_timestamp = parse_timestamp(args.max_timestamp)
+    global_first_timestamp = None
+    global_last_timestamp = None
+
+    for raw_path in args.paths:
+        path = Path(raw_path)
+        if not path.is_file():
+            print(f"missing_file={path}", file=sys.stderr)
+            return 2
+
+        rows, first_timestamp, last_timestamp = validate_file(path, args.schema, args.timestamp_column)
+        if rows < 0:
+            return 3
+        total_rows += rows
+        if first_timestamp is not None:
+            if global_first_timestamp is None or first_timestamp < global_first_timestamp:
+                global_first_timestamp = first_timestamp
+        if last_timestamp is not None:
+            if global_last_timestamp is None or last_timestamp > global_last_timestamp:
+                global_last_timestamp = last_timestamp
+
+    print(f"total_rows={total_rows}")
+    if global_first_timestamp is not None and global_last_timestamp is not None:
+        print(
+            f"timestamp_range={global_first_timestamp.isoformat()}..{global_last_timestamp.isoformat()}"
+        )
+        if min_timestamp is not None and global_first_timestamp < min_timestamp:
+            print(
+                f"timestamp_lower_bound=failed expected_min={min_timestamp.isoformat()} actual={global_first_timestamp.isoformat()}",
+                file=sys.stderr,
+            )
+            return 1
+        if max_timestamp is not None and global_last_timestamp >= max_timestamp:
+            print(
+                f"timestamp_upper_bound=failed expected_max_exclusive={max_timestamp.isoformat()} actual={global_last_timestamp.isoformat()}",
+                file=sys.stderr,
+            )
+            return 1
+    elif min_timestamp is not None or max_timestamp is not None:
+        print(
+            f"timestamp_validation=failed column={args.timestamp_column} reason=no_timestamp_values",
+            file=sys.stderr,
+        )
+        return 1
+    if args.expected_rows is not None:
+        diff = total_rows - args.expected_rows
+        status = "ok" if diff == 0 else "mismatch"
+        print(f"expected_rows={args.expected_rows} diff={diff} status={status}")
+        if diff != 0:
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

## What's Changed in this PR

- Add `self-monitoring-export` skill for GreptimeDB Cluster self-monitoring log/metric export.
- Add workflow references and helper scripts for incident window discovery, export, and validation.
- Update skills README with install command and asciinema demo.

[![asciicast](https://asciinema.org/a/N59fXqonAiRYMk4L.svg)](https://asciinema.org/a/N59fXqonAiRYMk4L)

*Describe the change in this PR*


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
