### PR TITLE
docs: add region info table reference

### DIFF
--- a/docs/reference/sql/information-schema/overview.md
+++ b/docs/reference/sql/information-schema/overview.md
@@ -57,6 +57,7 @@ There is still lots of work to do for `INFORMATION_SCHEMA`. The tracking [issue]
 | --- | --- |
 | [`BUILD_INFO`](./build-info.md) | Provides the system build info. |
 | [`REGION_PEERS`](./region-peers.md) | Provides details about where regions are stored. |
+| [`REGION_INFO`](./region-info.md) | Provides Region runtime and manifest metadata, such as role and state, sequences, manifest version, Region options, SST format, and node ownership. |
 | [`REGION_STATISTICS`](./region-statistics.md) | Provides details about region statistics info, such as disk size, etc. |
 | [`CLUSTER_INFO`](./cluster-info.md)| Provides the topology information of the cluster.|
 | [`FLOWS`](./flows.md) | Provides the flow information.|

--- a/docs/reference/sql/information-schema/region-info.md
+++ b/docs/reference/sql/information-schema/region-info.md
@@ -1,0 +1,108 @@
+---
+keywords: [region info, region metadata, manifest version, region state, SST format]
+description: Provides runtime and manifest metadata for regions, including role and state, sequence numbers, manifest version, region options, SST format, and node ownership.
+---
+
+# REGION_INFO
+
+The `REGION_INFO` table provides runtime and manifest metadata for Regions. Use it to inspect a Region's role and state, writable status, sequence numbers, manifest version, Region options, SST format, and the Datanode that reports the Region.
+
+```sql
+USE INFORMATION_SCHEMA;
+DESC REGION_INFO;
+```
+
+The output is as follows:
+
+```sql
++------------------------+---------+-----+------+---------+---------------+
+| Column                 | Type    | Key | Null | Default | Semantic Type |
++------------------------+---------+-----+------+---------+---------------+
+| region_id              | UInt64  |     | NO   |         | FIELD         |
+| table_id               | UInt32  |     | NO   |         | FIELD         |
+| region_number          | UInt32  |     | NO   |         | FIELD         |
+| region_group           | UInt8   |     | NO   |         | FIELD         |
+| region_sequence        | UInt32  |     | NO   |         | FIELD         |
+| state                  | String  |     | NO   |         | FIELD         |
+| role                   | String  |     | NO   |         | FIELD         |
+| writable               | Boolean |     | NO   |         | FIELD         |
+| committed_sequence     | UInt64  |     | NO   |         | FIELD         |
+| flushed_sequence       | UInt64  |     | YES  |         | FIELD         |
+| manifest_version       | UInt64  |     | NO   |         | FIELD         |
+| compaction_time_window | String  |     | YES  |         | FIELD         |
+| region_options         | String  |     | NO   |         | FIELD         |
+| sst_format             | String  |     | NO   |         | FIELD         |
+| node_id                | UInt64  |     | YES  |         | FIELD         |
++------------------------+---------+-----+------+---------+---------------+
+```
+
+Fields in the `REGION_INFO` table are described as follows:
+
+- `region_id`: The ID of the Region.
+- `table_id`: The ID of the table that the Region belongs to.
+- `region_number`: The Region number inside the table.
+- `region_group`: The Region group encoded in the Region ID.
+- `region_sequence`: The Region sequence inside the group.
+- `state`: The full runtime role and state of the Region. Possible values include `Follower`, `Leader(Writable)`, `Leader(Staging)`, `Leader(EnteringStaging)`, `Leader(Altering)`, `Leader(Dropping)`, `Leader(Truncating)`, `Leader(Editing)`, and `Leader(Downgrading)`.
+- `role`: The coarse Region role, `Leader` or `Follower`.
+- `writable`: Whether the Region accepts writes.
+- `committed_sequence`: The committed sequence of the Region.
+- `flushed_sequence`: The latest sequence persisted into SSTs. The value is `NULL` if no sequence has been flushed.
+- `manifest_version`: The manifest version of the Region.
+- `compaction_time_window`: The human-readable compaction time window of the Region.
+- `region_options`: The Region options encoded as JSON.
+- `sst_format`: The SST format used by the Region, such as `primary_key` or `flat`.
+- `node_id`: The ID of the Datanode that reports the row. The value can be `NULL` when the row is not reported by a Datanode.
+
+Query a table's Region runtime and manifest information as follows:
+
+```sql
+SELECT
+  i.region_id,
+  i.state,
+  i.role,
+  i.writable,
+  i.committed_sequence,
+  i.flushed_sequence,
+  i.manifest_version,
+  i.compaction_time_window,
+  i.region_options,
+  i.sst_format,
+  i.node_id
+FROM REGION_INFO i
+WHERE i.region_id IN (
+  SELECT region_id FROM REGION_PEERS WHERE table_name = 'system_metrics'
+)
+ORDER BY i.region_id;
+```
+
+
+Query the maximum manifest version difference between leaders and followers as follows:
+
+```sql
+SELECT
+  MAX(
+    CAST(l.manifest_version AS INT64) - CAST(f.manifest_version AS INT64)
+  ) AS max_manifest_version_diff
+FROM REGION_INFO l
+JOIN REGION_INFO f ON l.region_id = f.region_id
+WHERE l.role = 'Leader' AND f.role = 'Follower';
+```
+
+To find the Region and Datanode pair with the largest manifest version difference, use the following query:
+
+```sql
+SELECT
+  l.region_id,
+  l.node_id AS leader_node_id,
+  f.node_id AS follower_node_id,
+  l.manifest_version AS leader_manifest_version,
+  f.manifest_version AS follower_manifest_version,
+  CAST(l.manifest_version AS INT64) - CAST(f.manifest_version AS INT64)
+    AS manifest_version_diff
+FROM REGION_INFO l
+JOIN REGION_INFO f ON l.region_id = f.region_id
+WHERE l.role = 'Leader' AND f.role = 'Follower'
+ORDER BY manifest_version_diff DESC
+LIMIT 1;
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/information-schema/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/information-schema/overview.md
@@ -55,6 +55,7 @@ description: INFORMATION_SCHEMA 提供对系统元数据的访问，例如数据
 | --- | --- |
 | [`BUILD_INFO`](./build-info.md) | 提供了系统构建的信息。 |
 | [`REGION_PEERS`](./region-peers.md) | 提供了表的 Region 存储的详细信息。 |
+| [`REGION_INFO`](./region-info.md) | 提供 Region 的运行时和 manifest 元数据，例如角色和状态、序列号、manifest 版本、Region 选项、SST 格式以及节点归属。 |
 | [`REGION_STATISTICS`](./region-statistics.md) | 提供 Region 的详细统计信息，例如行数等。 |
 | [`CLUSTER_INFO`](./cluster-info.md)| 提供了集群的节点拓扑信息。|
 | [`FLOWS`](./flows.md) | 提供 Flow 相关信息。|

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/information-schema/region-info.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/information-schema/region-info.md
@@ -1,0 +1,108 @@
+---
+keywords: [Region 信息, Region 元数据, manifest 版本, Region 状态, SST 格式]
+description: REGION_INFO 表提供 Region 的运行时和 manifest 元数据，包括角色和状态、序列号、manifest 版本、Region 选项、SST 格式以及节点归属。
+---
+
+# REGION_INFO
+
+`REGION_INFO` 表提供 Region 的运行时和 manifest 元数据。你可以使用该表查看 Region 的角色和状态、是否可写、序列号、manifest 版本、Region 选项、SST 格式以及上报该 Region 的 Datanode。
+
+```sql
+USE INFORMATION_SCHEMA;
+DESC REGION_INFO;
+```
+
+输出如下：
+
+```sql
++------------------------+---------+-----+------+---------+---------------+
+| Column                 | Type    | Key | Null | Default | Semantic Type |
++------------------------+---------+-----+------+---------+---------------+
+| region_id              | UInt64  |     | NO   |         | FIELD         |
+| table_id               | UInt32  |     | NO   |         | FIELD         |
+| region_number          | UInt32  |     | NO   |         | FIELD         |
+| region_group           | UInt8   |     | NO   |         | FIELD         |
+| region_sequence        | UInt32  |     | NO   |         | FIELD         |
+| state                  | String  |     | NO   |         | FIELD         |
+| role                   | String  |     | NO   |         | FIELD         |
+| writable               | Boolean |     | NO   |         | FIELD         |
+| committed_sequence     | UInt64  |     | NO   |         | FIELD         |
+| flushed_sequence       | UInt64  |     | YES  |         | FIELD         |
+| manifest_version       | UInt64  |     | NO   |         | FIELD         |
+| compaction_time_window | String  |     | YES  |         | FIELD         |
+| region_options         | String  |     | NO   |         | FIELD         |
+| sst_format             | String  |     | NO   |         | FIELD         |
+| node_id                | UInt64  |     | YES  |         | FIELD         |
++------------------------+---------+-----+------+---------+---------------+
+```
+
+`REGION_INFO` 表中的字段描述如下：
+
+- `region_id`: Region 的 ID。
+- `table_id`: Region 所属表的 ID。
+- `region_number`: Region 在表中的编号。
+- `region_group`: Region ID 中编码的 Region 分组。
+- `region_sequence`: Region 在分组内的序列号。
+- `state`: Region 完整的运行时角色和状态。可能的值包括 `Follower`、`Leader(Writable)`、`Leader(Staging)`、`Leader(EnteringStaging)`、`Leader(Altering)`、`Leader(Dropping)`、`Leader(Truncating)`、`Leader(Editing)` 和 `Leader(Downgrading)`。
+- `role`: Region 的粗粒度角色，可以是 `Leader` 或 `Follower`。
+- `writable`: Region 是否接受写入。
+- `committed_sequence`: Region 已提交的序列号。
+- `flushed_sequence`: 已持久化到 SST 的最新序列号。如果尚未 flush，值为 `NULL`。
+- `manifest_version`: Region 的 manifest 版本。
+- `compaction_time_window`: Region 的可读 compaction 时间窗口。
+- `region_options`: 以 JSON 编码的 Region 选项。
+- `sst_format`: Region 使用的 SST 格式，例如 `primary_key` 或 `flat`。
+- `node_id`: 上报该行的 Datanode ID。当该行不是由 Datanode 上报时，值可以为 `NULL`。
+
+按如下方式查询某张表的 Region 运行时和 manifest 信息：
+
+```sql
+SELECT
+  i.region_id,
+  i.state,
+  i.role,
+  i.writable,
+  i.committed_sequence,
+  i.flushed_sequence,
+  i.manifest_version,
+  i.compaction_time_window,
+  i.region_options,
+  i.sst_format,
+  i.node_id
+FROM REGION_INFO i
+WHERE i.region_id IN (
+  SELECT region_id FROM REGION_PEERS WHERE table_name = 'system_metrics'
+)
+ORDER BY i.region_id;
+```
+
+
+按如下方式查询 Leader 与 Follower 之间最大的 manifest 版本差：
+
+```sql
+SELECT
+  MAX(
+    CAST(l.manifest_version AS INT64) - CAST(f.manifest_version AS INT64)
+  ) AS max_manifest_version_diff
+FROM REGION_INFO l
+JOIN REGION_INFO f ON l.region_id = f.region_id
+WHERE l.role = 'Leader' AND f.role = 'Follower';
+```
+
+如果需要找出 manifest 版本差最大的 Region 和 Datanode 组合，可以使用如下查询：
+
+```sql
+SELECT
+  l.region_id,
+  l.node_id AS leader_node_id,
+  f.node_id AS follower_node_id,
+  l.manifest_version AS leader_manifest_version,
+  f.manifest_version AS follower_manifest_version,
+  CAST(l.manifest_version AS INT64) - CAST(f.manifest_version AS INT64)
+    AS manifest_version_diff
+FROM REGION_INFO l
+JOIN REGION_INFO f ON l.region_id = f.region_id
+WHERE l.role = 'Leader' AND f.role = 'Follower'
+ORDER BY manifest_version_diff DESC
+LIMIT 1;
+```

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -656,6 +656,7 @@ const sidebars: SidebarsConfig = {
                 'reference/sql/information-schema/views',
                 'reference/sql/information-schema/flows',
                 'reference/sql/information-schema/region-peers',
+                'reference/sql/information-schema/region-info',
                 'reference/sql/information-schema/region-statistics',
                 'reference/sql/information-schema/cluster-info',
                 'reference/sql/information-schema/process-list',


### PR DESCRIPTION
## Summary
- Add the `REGION_INFO` inspection table reference under Information Schema.
- Include the Chinese localized reference page and overview entries.
- Register the new page in the docs sidebar.

## Related Issue
Closes #2505

## Test Plan
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
