### PR TITLE
docs: update contributor getting started guide

### DIFF
--- a/docs/contributor-guide/getting-started.md
+++ b/docs/contributor-guide/getting-started.md
@@ -11,13 +11,13 @@ This page describes how to run GreptimeDB from source in your local environment.
 
 ### System & Architecture
 
-At the moment, GreptimeDB supports Linux(both amd64 and arm64), macOS (both amd64 and Apple Silicone) and Windows.
+At the moment, GreptimeDB supports Linux (both amd64 and arm64), macOS (both amd64 and Apple Silicon), and Windows.
 
 ### Build Dependencies
 
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-The-Command-Line) (optional)
 - C/C++ Toolchain: provides essential tools for compiling and linking. This is available either as `build-essential` on ubuntu or a similar name on other platforms.
-- Rust ([guide][1])
+- Rust nightly toolchain ([guide][1])
   - Compile the source code
 - Protobuf ([guide][2])
   - Compile the proto file
@@ -62,9 +62,9 @@ Or you can check their [docs](https://nexte.st/docs/installation/pre-built-binar
 After nextest is ready, you can run the test suite with:
 
 ```shell
-cargo nextest run
+cargo nextest run --workspace --features pg_kvbackend,mysql_kvbackend
 ```
 
 ## Docker
 
-We also provide pre-build binary via Docker. It's which is available in dockerhub: [https://hub.docker.com/r/greptime/greptimedb](https://hub.docker.com/r/greptime/greptimedb)
+We also provide prebuilt binaries via Docker, available on Docker Hub: [https://hub.docker.com/r/greptime/greptimedb](https://hub.docker.com/r/greptime/greptimedb)

--- a/i18n/zh/docusaurus-plugin-content-docs/current/contributor-guide/getting-started.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/contributor-guide/getting-started.md
@@ -11,13 +11,13 @@ description: 介绍如何在本地环境中从源代码编译和运行 GreptimeD
 
 ### 系统和架构
 
-目前，GreptimeDB 支持 Linux（amd64 和 arm64）、macOS（amd64 和 Apple Silicone）和 Windows。
+目前，GreptimeDB 支持 Linux（amd64 和 arm64）、macOS（amd64 和 Apple Silicon）和 Windows。
 
 ### 构建依赖项
 
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-The-Command-Line)（可选）
 - C/C++ 工具链：提供编译和链接的基本工具。在 Ubuntu 上，这可用作 `build-essential`。在其他平台上，也有类似的命令。
-- Rust（[指南][1]）
+- Rust nightly 工具链（[指南][1]）
   - 编译源代码
 - Protobuf（[指南][2]）
   - 编译 proto 文件
@@ -62,7 +62,7 @@ cargo install cargo-nextest --locked
 安装好 nextest 后，你可以使用以下命令运行测试套件：
 
 ```shell
-cargo nextest run
+cargo nextest run --workspace --features pg_kvbackend,mysql_kvbackend
 ```
 
 ## Docker

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.0/contributor-guide/getting-started.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.0/contributor-guide/getting-started.md
@@ -11,13 +11,13 @@ description: 介绍如何在本地环境中从源代码编译和运行 GreptimeD
 
 ### 系统和架构
 
-目前，GreptimeDB 支持 Linux（amd64 和 arm64）、macOS（amd64 和 Apple Silicone）和 Windows。
+目前，GreptimeDB 支持 Linux（amd64 和 arm64）、macOS（amd64 和 Apple Silicon）和 Windows。
 
 ### 构建依赖项
 
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-The-Command-Line)（可选）
 - C/C++ 工具链：提供编译和链接的基本工具。在 Ubuntu 上，这可用作 `build-essential`。在其他平台上，也有类似的命令。
-- Rust（[指南][1]）
+- Rust nightly 工具链（[指南][1]）
   - 编译源代码
 - Protobuf（[指南][2]）
   - 编译 proto 文件
@@ -62,7 +62,7 @@ cargo install cargo-nextest --locked
 安装好 nextest 后，你可以使用以下命令运行测试套件：
 
 ```shell
-cargo nextest run
+cargo nextest run --workspace --features pg_kvbackend,mysql_kvbackend
 ```
 
 ## Docker

--- a/versioned_docs/version-1.0/contributor-guide/getting-started.md
+++ b/versioned_docs/version-1.0/contributor-guide/getting-started.md
@@ -11,13 +11,13 @@ This page describes how to run GreptimeDB from source in your local environment.
 
 ### System & Architecture
 
-At the moment, GreptimeDB supports Linux(both amd64 and arm64), macOS (both amd64 and Apple Silicone) and Windows.
+At the moment, GreptimeDB supports Linux (both amd64 and arm64), macOS (both amd64 and Apple Silicon), and Windows.
 
 ### Build Dependencies
 
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-The-Command-Line) (optional)
 - C/C++ Toolchain: provides essential tools for compiling and linking. This is available either as `build-essential` on ubuntu or a similar name on other platforms.
-- Rust ([guide][1])
+- Rust nightly toolchain ([guide][1])
   - Compile the source code
 - Protobuf ([guide][2])
   - Compile the proto file
@@ -62,9 +62,9 @@ Or you can check their [docs](https://nexte.st/docs/installation/pre-built-binar
 After nextest is ready, you can run the test suite with:
 
 ```shell
-cargo nextest run
+cargo nextest run --workspace --features pg_kvbackend,mysql_kvbackend
 ```
 
 ## Docker
 
-We also provide pre-build binary via Docker. It's which is available in dockerhub: [https://hub.docker.com/r/greptime/greptimedb](https://hub.docker.com/r/greptime/greptimedb)
+We also provide prebuilt binaries via Docker, available on Docker Hub: [https://hub.docker.com/r/greptime/greptimedb](https://hub.docker.com/r/greptime/greptimedb)


### PR DESCRIPTION
Part of #2417

## Summary
- update Contributor Guide getting-started prerequisites to mention the Rust nightly toolchain
- align the nextest command with the v1.0 contributor instructions
- fix Apple Silicon spelling and the English Docker Hub sentence
- sync the changes across current/v1.0 English and Chinese docs

## Validation
- checked GreptimeDB v1.0.0 rust-toolchain.toml
- checked GreptimeDB v1.0.0 CONTRIBUTING.md and Makefile test command
- checked DeepWiki and Docker Hub links
- ran git diff --check