### PR TITLE
docs: fix metasrv admin api docs

### DIFF
--- a/docs/contributor-guide/metasrv/admin-api.md
+++ b/docs/contributor-guide/metasrv/admin-api.md
@@ -1,6 +1,6 @@
 ---
 keywords: [admin api, health check, leader query, heartbeat, maintenance mode, RESTful API]
-description: Details the Admin API for Metasrv, including endpoints for health checks, leader queries, heartbeat data, and maintenance mode.
+description: Details the Admin API for Metasrv, including endpoints for health checks, leader queries, heartbeat data, maintenance mode, and Procedure Manager controls.
 ---
 
 # Admin API
@@ -9,15 +9,16 @@ description: Details the Admin API for Metasrv, including endpoints for health c
 Note that all Admin API endpoints in this document listen on Metasrv's `HTTP_PORT`, which defaults to `4000`.
 :::
 
-The Admin API provides a simple way to view cluster information, including metasrv health detection, metasrv leader query, database metadata query, and datanode heartbeat detection.
+The Admin API provides a simple way to view and manage cluster information, including metasrv health detection, metasrv leader query, datanode heartbeat detection, maintenance mode, and Procedure Manager controls.
 
 The Admin API is an HTTP service that provides a set of RESTful APIs that can be called through HTTP requests. The Admin API is simple, user-friendly and safe.
-Available APIs:
+This page covers the following APIs:
 
 - /health
 - /leader
 - /heartbeat
 - /maintenance
+- /procedure-manager
 
 All these APIs are under the parent resource `/admin`.
 
@@ -99,157 +100,23 @@ curl -X GET 'http://localhost:4000/admin/heartbeat?addr=127.0.0.1:4100'
 
 ```json
 [
- [{
-  "timestamp_millis": 1677049348651,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "127.0.0.1:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049344048,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "0.0.0.0:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049343624,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "127.0.0.1:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049339036,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "0.0.0.0:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049338609,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "127.0.0.1:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049334019,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "0.0.0.0:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049333592,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "127.0.0.1:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049329002,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "0.0.0.0:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049328573,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "127.0.0.1:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049323986,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "0.0.0.0:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }]
+  [
+    {
+      "timestamp_millis": 1677049348651,
+      "id": 1,
+      "addr": "127.0.0.1:4100",
+      "rcus": 0,
+      "wcus": 0,
+      "region_num": 2,
+      "region_stats": [],
+      "topic_stats": [],
+      "node_epoch": 0,
+      "datanode_workloads": {
+        "types": []
+      },
+      "gc_stat": null
+    }
+  ]
 ]
 ```
 
@@ -257,6 +124,34 @@ curl -X GET 'http://localhost:4000/admin/heartbeat?addr=127.0.0.1:4100'
 
 Cluster Maintenance Mode is a safety feature in GreptimeDB that temporarily disables automatic cluster management operations. This mode is particularly useful during cluster upgrades, planned downtime, and any operation that might temporarily affect cluster stability. For more details, please refer to [Cluster Maintenance Mode](/user-guide/deployments-administration/maintenance/maintenance-mode.md).
 
+The `/maintenance` endpoint supports the following HTTP requests:
+
+- `GET /admin/maintenance` or `GET /admin/maintenance/status`: query the maintenance mode status.
+- `POST /admin/maintenance/enable`: enable maintenance mode.
+- `POST /admin/maintenance/disable`: disable maintenance mode.
+
+The response body uses the following format:
+
+```json
+{
+  "enabled": true
+}
+```
+
 ## /procedure-manager HTTP endpoint
 
 This endpoint is used to manage the Procedure Manager status. For more details, please refer to [Prevent Metadata Changes](/user-guide/deployments-administration/maintenance/prevent-metadata-changes.md).
+
+The `/procedure-manager` endpoint supports the following HTTP requests:
+
+- `GET /admin/procedure-manager/status`: query the Procedure Manager status.
+- `POST /admin/procedure-manager/pause`: pause the Procedure Manager.
+- `POST /admin/procedure-manager/resume`: resume the Procedure Manager.
+
+The response body uses the following format:
+
+```json
+{
+  "status": "running"
+}
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/contributor-guide/metasrv/admin-api.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/contributor-guide/metasrv/admin-api.md
@@ -1,19 +1,20 @@
 ---
 keywords: [Admin API, 健康检查, leader 查询, 心跳检测, 维护模式]
-description: 介绍 Metasrv 的 Admin API，包括健康检查、leader 查询和心跳检测等功能。
+description: 介绍 Metasrv 的 Admin API，包括健康检查、leader 查询、心跳检测、维护模式和 Procedure Manager 控制等功能。
 ---
 
 # Admin API
 
-Admin 提供了一种简单的方法来查看集群信息，包括 metasrv 健康检测、metasrv leader 查询、数据库元数据查询和数据节点心跳检测。
+Admin 提供了一种简单的方法来查看和管理集群信息，包括 metasrv 健康检测、metasrv leader 查询、数据节点心跳检测、维护模式和 Procedure Manager 控制。
 
 Admin API 是一个 HTTP 服务，提供一组可以通过 HTTP 请求调用的 RESTful API。Admin API 简单、用户友好且安全。
-可用的 API：
+本页介绍以下 API：
 
 - /health
 - /leader
 - /heartbeat
 - /maintenance
+- /procedure-manager
 
 所有这些 API 都在父资源 `/admin` 下。
 
@@ -95,157 +96,23 @@ curl -X GET 'http://localhost:4000/admin/heartbeat?addr=127.0.0.1:4100'
 
 ```json
 [
- [{
-  "timestamp_millis": 1677049348651,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "127.0.0.1:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049344048,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "0.0.0.0:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049343624,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "127.0.0.1:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049339036,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "0.0.0.0:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049338609,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "127.0.0.1:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049334019,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "0.0.0.0:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049333592,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "127.0.0.1:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049329002,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "0.0.0.0:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049328573,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "127.0.0.1:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049323986,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "0.0.0.0:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }]
+  [
+    {
+      "timestamp_millis": 1677049348651,
+      "id": 1,
+      "addr": "127.0.0.1:4100",
+      "rcus": 0,
+      "wcus": 0,
+      "region_num": 2,
+      "region_stats": [],
+      "topic_stats": [],
+      "node_epoch": 0,
+      "datanode_workloads": {
+        "types": []
+      },
+      "gc_stat": null
+    }
+  ]
 ]
 ```
 
@@ -253,6 +120,34 @@ curl -X GET 'http://localhost:4000/admin/heartbeat?addr=127.0.0.1:4100'
 
 集群维护模式是 GreptimeDB 中的一项安全功能，它可以临时禁用自动集群管理操作。此模式在集群升级、计划停机以及任何可能暂时影响集群稳定性的操作期间特别有用。有关更多详细信息，请参阅[集群维护模式](/user-guide/deployments-administration/maintenance/maintenance-mode.md)。
 
+`/maintenance` 端点支持以下 HTTP 请求：
+
+- `GET /admin/maintenance` 或 `GET /admin/maintenance/status`：查询维护模式状态。
+- `POST /admin/maintenance/enable`：启用维护模式。
+- `POST /admin/maintenance/disable`：禁用维护模式。
+
+响应体使用以下格式：
+
+```json
+{
+  "enabled": true
+}
+```
+
 ## /procedure-manager HTTP 端点
 
 该端点用于管理 Procedure Manager 状态。有关更多详细信息，请参阅[防止元数据变更](/user-guide/deployments-administration/maintenance/prevent-metadata-changes.md)。
+
+`/procedure-manager` 端点支持以下 HTTP 请求：
+
+- `GET /admin/procedure-manager/status`：查询 Procedure Manager 状态。
+- `POST /admin/procedure-manager/pause`：暂停 Procedure Manager。
+- `POST /admin/procedure-manager/resume`：恢复 Procedure Manager。
+
+响应体使用以下格式：
+
+```json
+{
+  "status": "running"
+}
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.0/contributor-guide/metasrv/admin-api.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.0/contributor-guide/metasrv/admin-api.md
@@ -1,19 +1,20 @@
 ---
 keywords: [Admin API, 健康检查, leader 查询, 心跳检测, 维护模式]
-description: 介绍 Metasrv 的 Admin API，包括健康检查、leader 查询和心跳检测等功能。
+description: 介绍 Metasrv 的 Admin API，包括健康检查、leader 查询、心跳检测、维护模式和 Procedure Manager 控制等功能。
 ---
 
 # Admin API
 
-Admin 提供了一种简单的方法来查看集群信息，包括 metasrv 健康检测、metasrv leader 查询、数据库元数据查询和数据节点心跳检测。
+Admin 提供了一种简单的方法来查看和管理集群信息，包括 metasrv 健康检测、metasrv leader 查询、数据节点心跳检测、维护模式和 Procedure Manager 控制。
 
 Admin API 是一个 HTTP 服务，提供一组可以通过 HTTP 请求调用的 RESTful API。Admin API 简单、用户友好且安全。
-可用的 API：
+本页介绍以下 API：
 
 - /health
 - /leader
 - /heartbeat
 - /maintenance
+- /procedure-manager
 
 所有这些 API 都在父资源 `/admin` 下。
 
@@ -95,157 +96,23 @@ curl -X GET 'http://localhost:4000/admin/heartbeat?addr=127.0.0.1:4100'
 
 ```json
 [
- [{
-  "timestamp_millis": 1677049348651,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "127.0.0.1:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049344048,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "0.0.0.0:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049343624,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "127.0.0.1:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049339036,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "0.0.0.0:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049338609,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "127.0.0.1:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049334019,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "0.0.0.0:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049333592,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "127.0.0.1:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049329002,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "0.0.0.0:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049328573,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "127.0.0.1:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049323986,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "0.0.0.0:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }]
+  [
+    {
+      "timestamp_millis": 1677049348651,
+      "id": 1,
+      "addr": "127.0.0.1:4100",
+      "rcus": 0,
+      "wcus": 0,
+      "region_num": 2,
+      "region_stats": [],
+      "topic_stats": [],
+      "node_epoch": 0,
+      "datanode_workloads": {
+        "types": []
+      },
+      "gc_stat": null
+    }
+  ]
 ]
 ```
 
@@ -253,6 +120,34 @@ curl -X GET 'http://localhost:4000/admin/heartbeat?addr=127.0.0.1:4100'
 
 集群维护模式是 GreptimeDB 中的一项安全功能，它可以临时禁用自动集群管理操作。此模式在集群升级、计划停机以及任何可能暂时影响集群稳定性的操作期间特别有用。有关更多详细信息，请参阅[集群维护模式](/user-guide/deployments-administration/maintenance/maintenance-mode.md)。
 
+`/maintenance` 端点支持以下 HTTP 请求：
+
+- `GET /admin/maintenance` 或 `GET /admin/maintenance/status`：查询维护模式状态。
+- `POST /admin/maintenance/enable`：启用维护模式。
+- `POST /admin/maintenance/disable`：禁用维护模式。
+
+响应体使用以下格式：
+
+```json
+{
+  "enabled": true
+}
+```
+
 ## /procedure-manager HTTP 端点
 
 该端点用于管理 Procedure Manager 状态。有关更多详细信息，请参阅[防止元数据变更](/user-guide/deployments-administration/maintenance/prevent-metadata-changes.md)。
+
+`/procedure-manager` 端点支持以下 HTTP 请求：
+
+- `GET /admin/procedure-manager/status`：查询 Procedure Manager 状态。
+- `POST /admin/procedure-manager/pause`：暂停 Procedure Manager。
+- `POST /admin/procedure-manager/resume`：恢复 Procedure Manager。
+
+响应体使用以下格式：
+
+```json
+{
+  "status": "running"
+}
+```

--- a/versioned_docs/version-1.0/contributor-guide/metasrv/admin-api.md
+++ b/versioned_docs/version-1.0/contributor-guide/metasrv/admin-api.md
@@ -1,6 +1,6 @@
 ---
 keywords: [admin api, health check, leader query, heartbeat, maintenance mode, RESTful API]
-description: Details the Admin API for Metasrv, including endpoints for health checks, leader queries, heartbeat data, and maintenance mode.
+description: Details the Admin API for Metasrv, including endpoints for health checks, leader queries, heartbeat data, maintenance mode, and Procedure Manager controls.
 ---
 
 # Admin API
@@ -9,15 +9,16 @@ description: Details the Admin API for Metasrv, including endpoints for health c
 Note that all Admin API endpoints in this document listen on Metasrv's `HTTP_PORT`, which defaults to `4000`.
 :::
 
-The Admin API provides a simple way to view cluster information, including metasrv health detection, metasrv leader query, database metadata query, and datanode heartbeat detection.
+The Admin API provides a simple way to view and manage cluster information, including metasrv health detection, metasrv leader query, datanode heartbeat detection, maintenance mode, and Procedure Manager controls.
 
 The Admin API is an HTTP service that provides a set of RESTful APIs that can be called through HTTP requests. The Admin API is simple, user-friendly and safe.
-Available APIs:
+This page covers the following APIs:
 
 - /health
 - /leader
 - /heartbeat
 - /maintenance
+- /procedure-manager
 
 All these APIs are under the parent resource `/admin`.
 
@@ -99,157 +100,23 @@ curl -X GET 'http://localhost:4000/admin/heartbeat?addr=127.0.0.1:4100'
 
 ```json
 [
- [{
-  "timestamp_millis": 1677049348651,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "127.0.0.1:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049344048,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "0.0.0.0:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049343624,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "127.0.0.1:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049339036,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "0.0.0.0:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049338609,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "127.0.0.1:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049334019,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "0.0.0.0:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049333592,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "127.0.0.1:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049329002,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "0.0.0.0:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049328573,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "127.0.0.1:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }, {
-  "timestamp_millis": 1677049323986,
-  "cluster_id": 0,
-  "id": 1,
-  "addr": "0.0.0.0:4100",
-  "is_leader": false,
-  "rcus": 0,
-  "wcus": 0,
-  "table_num": 0,
-  "region_num": 2,
-  "cpu_usage": 0.0,
-  "load": 0.0,
-  "read_io_rate": 0.0,
-  "write_io_rate": 0.0,
-  "region_stats": []
- }]
+  [
+    {
+      "timestamp_millis": 1677049348651,
+      "id": 1,
+      "addr": "127.0.0.1:4100",
+      "rcus": 0,
+      "wcus": 0,
+      "region_num": 2,
+      "region_stats": [],
+      "topic_stats": [],
+      "node_epoch": 0,
+      "datanode_workloads": {
+        "types": []
+      },
+      "gc_stat": null
+    }
+  ]
 ]
 ```
 
@@ -257,6 +124,34 @@ curl -X GET 'http://localhost:4000/admin/heartbeat?addr=127.0.0.1:4100'
 
 Cluster Maintenance Mode is a safety feature in GreptimeDB that temporarily disables automatic cluster management operations. This mode is particularly useful during cluster upgrades, planned downtime, and any operation that might temporarily affect cluster stability. For more details, please refer to [Cluster Maintenance Mode](/user-guide/deployments-administration/maintenance/maintenance-mode.md).
 
+The `/maintenance` endpoint supports the following HTTP requests:
+
+- `GET /admin/maintenance` or `GET /admin/maintenance/status`: query the maintenance mode status.
+- `POST /admin/maintenance/enable`: enable maintenance mode.
+- `POST /admin/maintenance/disable`: disable maintenance mode.
+
+The response body uses the following format:
+
+```json
+{
+  "enabled": true
+}
+```
+
 ## /procedure-manager HTTP endpoint
 
 This endpoint is used to manage the Procedure Manager status. For more details, please refer to [Prevent Metadata Changes](/user-guide/deployments-administration/maintenance/prevent-metadata-changes.md).
+
+The `/procedure-manager` endpoint supports the following HTTP requests:
+
+- `GET /admin/procedure-manager/status`: query the Procedure Manager status.
+- `POST /admin/procedure-manager/pause`: pause the Procedure Manager.
+- `POST /admin/procedure-manager/resume`: resume the Procedure Manager.
+
+The response body uses the following format:
+
+```json
+{
+  "status": "running"
+}
+```


### PR DESCRIPTION
Part of #2417.

This audits the Contributor Guide / Metasrv Admin API docs.

Changes:
- Update the heartbeat response example to match the v1.0.0 `DatanodeStatValue` / `Stat` serialization shape.
- Document the actual maintenance mode endpoints and HTTP methods.
- Document the actual Procedure Manager endpoints and HTTP methods.
- Sync the current and v1.0 English and Chinese docs.

Validation:
- `git diff --check`
- `cargo test -p meta-srv test_get_heartbeat_with_filter -- --nocapture`
- `cargo test -p meta-srv test_admin_maintenance -- --nocapture`
- `cargo test -p meta-srv test_admin_maintenance_status -- --nocapture`
- `cargo test -p meta-srv test_admin_maintenance_enable_disable -- --nocapture`
- `cargo test -p meta-srv test_admin_procedure_manager_status -- --nocapture`
- `cargo test -p meta-srv test_admin_procedure_manager_pause_resume -- --nocapture`
- `cargo test -p meta-srv test_convert_str_to_selector_type -- --nocapture`