### PR TITLE
fix: miss vector image variable

### DIFF
--- a/variables/variables-nightly.ts
+++ b/variables/variables-nightly.ts
@@ -7,5 +7,6 @@ export const variables = {
   debugPodVersion: '20250606-04e3c7d',
   etcdChartVersion: "12.0.8",
   etcdImageVersion: "3.6.1-debian-12-r3",
-  greptimedbOperatorVersion: 'v0.6.0'
+  greptimedbOperatorVersion: 'v0.6.0',
+  vectorImageVersion: "0.49.0-debian"
 };


### PR DESCRIPTION
## What's Changed in this PR

as title.

Fixed to: https://docs.greptime.cn/nightly/user-guide/deployments-administration/monitoring/cluster-monitoring-deployment/#%E8%87%AA%E5%AE%9A%E4%B9%89-vector-sidecar

## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
