### PR TITLE
docs: add 1.1.1 release note

### DIFF
--- a/blog/release-1-1-0.md
+++ b/blog/release-1-1-0.md
@@ -12,6 +12,12 @@ v1.1.0 adds online partitioning for previously unpartitioned tables, experimenta
 reads for batching flows, the experimental table semantic layer, and new CSV import options,
 along with performance and stability fixes.
 
+:::warning
+
+v1.1.0 contains a critical JSON compatibility bug that affects users upgrading from v1.0.x when using the JSON data type. We strongly recommend users on v1.1.0 who use the JSON data type upgrade to [v1.1.1](./release-1-1-1.md) or later.
+
+:::
+
 ### 👍 Highlights
 
 **Partition an existing table.** Previously only tables created with `PARTITION ON COLUMNS`

--- a/blog/release-1-1-1.md
+++ b/blog/release-1-1-1.md
@@ -1,0 +1,24 @@
+---
+keywords: [release, GreptimeDB, changelog, v1.1.1]
+description: GreptimeDB v1.1.1 Changelog
+date: 2026-06-18
+---
+
+# v1.1.1
+
+Release date: June 18, 2026
+
+This release fixes a critical JSON compatibility bug that affects users upgrading from v1.0.x to v1.1.0, where legacy JSONB columns could return incorrect query results or fail during flush. It also removes a lock in the create flow procedure that could self-block sink table creation.
+
+We strongly recommend users on v1.1.0 who use the JSON data type upgrade to v1.1.1.
+
+### 🐛 Bug Fixes
+
+* fix: guard structured JSON alignment paths against legacy JSONB columns by [@evenyag](https://github.com/evenyag) in [#8323](https://github.com/GreptimeTeam/greptimedb/pull/8323)
+* fix: remove flow sink table lock by [@discord9](https://github.com/discord9) in [#8317](https://github.com/GreptimeTeam/greptimedb/pull/8317)
+
+## All Contributors
+
+We would like to thank the following contributors from the GreptimeDB community:
+
+[@discord9](https://github.com/discord9), [@evenyag](https://github.com/evenyag)


### PR DESCRIPTION
## What's Changed in this PR

Add the v1.1.1 release note blog post (`blog/release-1-1-1.md`).

v1.1.1 is a patch release that fixes a critical JSON compatibility bug affecting users upgrading from v1.0.x to v1.1.0, and removes a lock in the create flow procedure. Content mirrors the [GitHub release](https://github.com/GreptimeTeam/greptimedb/releases/tag/v1.1.1).

## Checklist

- [x] Please confirm that all corresponding versions of the documents have been revised.
- [x] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
