### PR TITLE
docs: add per-region query load metrics

### DIFF
--- a/docs/enterprise/deployments-administration/monitoring/key-metrics.md
+++ b/docs/enterprise/deployments-administration/monitoring/key-metrics.md
@@ -19,6 +19,8 @@ Since each company typically has its own alerting system with potentially differ
 | `sum(rate(greptime_table_operator_ingest_rows{instance=~"$frontend"}[$__rate_interval]))` | Current rows written per second | Drops to 0 (or below threshold) for n minutes |
 | `greptime_mito_compaction_failure_total` | Compaction failures | Recent increase greater than 0 |
 | `greptime_mito_flush_failure_total` | Flush failures | Recent increase greater than 0 |
+| `sum by (instance, pod, region_id) (rate(greptime_mito_region_query_cpu_time{instance=~"$frontend"}[$__rate_interval]))` | Per-region query CPU time in nanoseconds | Use for read-load hotspot analysis after enabling `logging.enable_per_region_metrics`; avoid broad alerting because this metric has high cardinality |
+| `sum by (instance, pod, region_id) (rate(greptime_mito_region_query_scanned_bytes{instance=~"$frontend"}[$__rate_interval]))` | Per-region scanned bytes during queries | Use for read-load hotspot analysis after enabling `logging.enable_per_region_metrics`; avoid broad alerting because this metric has high cardinality |
 | `sum by(instance, pod, path, method, code) (rate(greptime_servers_http_requests_elapsed_count{path!~"/health\|/metrics"}[$__rate_interval]))` | HTTP request count and response codes | HTTP 200 request count below threshold for n minutes or non-200 response count above normal threshold for n minutes |
 | `sum by (instance, pod) (rate(greptime_mito_write_rows_total{instance=~"$datanode"}[$__rate_interval]))` | Storage engine write row count | Below normal threshold for n minutes |
 

--- a/docs/user-guide/deployments-administration/configuration.md
+++ b/docs/user-guide/deployments-administration/configuration.md
@@ -419,6 +419,7 @@ GreptimeDB supports three WAL storage options—Local WAL, Remote WAL, and Noop 
 dir = "./greptimedb_data/logs"
 level = "info"
 enable_otlp_tracing = false
+enable_per_region_metrics = false
 otlp_endpoint = "localhost:4317"
 append_stdout = true
 [logging.tracing_sample_ratio]
@@ -428,6 +429,7 @@ default_ratio = 1.0
 - `dir`: log output directory.
 - `level`: output log level, available log level are `info`, `debug`, `error`, `warn`, the default level is `info`.
 - `enable_otlp_tracing`: whether to turn on tracing, not turned on by default.
+- `enable_per_region_metrics`: whether to expose per-region query load metrics, including `greptime_mito_region_query_cpu_time` and `greptime_mito_region_query_scanned_bytes`. This option is disabled by default because it creates one time series per region.
 - `otlp_endpoint`: Export the target endpoint of tracing using gRPC-based OTLP protocol, the default value is `localhost:4317`.
 - `append_stdout`: Whether to append logs to stdout. Defaults to `true`.
 - `tracing_sample_ratio`: This field can configure the sampling rate of tracing. How to use `tracing_sample_ratio`, please refer to [How to configure tracing sampling rate](/user-guide/deployments-administration/monitoring/tracing.md#guide-how-to-configure-tracing-sampling-rate).

--- a/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/deployments-administration/monitoring/key-metrics.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/deployments-administration/monitoring/key-metrics.md
@@ -19,6 +19,8 @@ description: 监控 GreptimeDB 集群的关键指标，包括 CPU、内存、磁
 | `sum(rate(greptime_table_operator_ingest_rows{instance=~"$frontend"}[$__rate_interval]))` | 当前每秒写入的行数 | 持续 n 分钟跌 0（或低于阈值） |
 | `greptime_mito_compaction_failure_total` | compaction 失败 | 最近新增大于 0 |
 | `greptime_mito_flush_failure_total` | flush 失败 | 最近新增大于 0 |
+| `sum by (instance, pod, region_id) (rate(greptime_mito_region_query_cpu_time{instance=~"$frontend"}[$__rate_interval]))` | Region 维度查询 CPU 时间，单位为纳秒 | 启用 `logging.enable_per_region_metrics` 后用于分析读负载热点；该指标基数较高，不建议直接作为大范围告警指标 |
+| `sum by (instance, pod, region_id) (rate(greptime_mito_region_query_scanned_bytes{instance=~"$frontend"}[$__rate_interval]))` | Region 维度查询扫描字节数 | 启用 `logging.enable_per_region_metrics` 后用于分析读负载热点；该指标基数较高，不建议直接作为大范围告警指标 |
 | `sum by(instance, pod, path, method, code) (rate(greptime_servers_http_requests_elapsed_count{path!~"/health\|/metrics"}[$__rate_interval]))` | HTTP 请求数和返回的响应码 | 响应码 200 的请求数量持续 n 分钟低于阈值或者响应码非 200 的请求数量持续 n 分钟大于正常阈值 |
 | `sum by (instance, pod) (rate(greptime_mito_write_rows_total{instance=~"$datanode"}[$__rate_interval]))` | 存储引擎写入行数 | 持续 n 分钟低于正常阈值 |
 


### PR DESCRIPTION
## Summary
- Document `logging.enable_per_region_metrics` as the opt-in for per-region query load metrics.
- Add the per-region query CPU time and scanned bytes metrics to key monitoring metrics.
- Add matching Chinese current docs entries for the new metrics.

## Test Plan
- `pnpm test`
- `pnpm build`

Fixes #2572