### PR TITLE
docs: document auto repartition column hint

### DIFF
--- a/docs/enterprise/autopilot/auto-repartition.md
+++ b/docs/enterprise/autopilot/auto-repartition.md
@@ -31,9 +31,34 @@ Auto Repartition is useful in the following scenarios:
 - You want to split large Regions into smaller Regions and distribute potential bottlenecks through later scheduling.
 - You want to reduce the operational cost of manually identifying large Regions and running Repartition.
 
+## Auto Repartition for unpartitioned tables
+
+Auto Repartition can also work with unpartitioned tables when a repartition column hint is specified. For an unpartitioned table, GreptimeDB Enterprise does not infer partition columns automatically. You must first set the preferred column for future Auto Repartition by using `ALTER TABLE`:
+
+```sql
+ALTER TABLE sensor_readings SET 'repartition.column.hint' = 'host';
+```
+
+To remove the hint:
+
+```sql
+ALTER TABLE sensor_readings UNSET 'repartition.column.hint';
+```
+
+The hint only records metadata for future Auto Repartition. It does not trigger Repartition immediately. After the table meets the Auto Repartition trigger conditions, GreptimeDB Enterprise can use the hinted column to generate partition boundaries and submit a Repartition action.
+
+The repartition column hint has the following restrictions:
+
+- It must be set with `ALTER TABLE ... SET`; setting it in `CREATE TABLE ... WITH` is not supported.
+- It must specify exactly one column.
+- The specified column must exist in the table.
+- The specified column cannot be the time index column.
+- It can only be set on a table without partition metadata.
+- It must be set or unset separately from other table options.
+
 ## Limitations
 
-Auto Repartition only works for partitioned tables. It can only split tables that already have partition rules. If a table does not have partition rules, Auto Repartition does not generate new partition rules for it automatically.
+Auto Repartition works for partitioned tables and unpartitioned tables with `repartition.column.hint`. For unpartitioned tables, GreptimeDB Enterprise does not infer partition columns automatically.
 
 For more information about table partitioning and Repartition, see [Table Sharding](/user-guide/deployments-administration/manage-data/table-sharding.md) and [Repartition](/user-guide/deployments-administration/manage-data/repartition.md).
 

--- a/docs/enterprise/autopilot/auto-repartition.md
+++ b/docs/enterprise/autopilot/auto-repartition.md
@@ -33,7 +33,19 @@ Auto Repartition is useful in the following scenarios:
 
 ## Auto Repartition for unpartitioned tables
 
-Auto Repartition can also work with unpartitioned tables when a repartition column hint is specified. For an unpartitioned table, GreptimeDB Enterprise does not infer partition columns automatically. You must first set the preferred column for future Auto Repartition by using `ALTER TABLE`:
+Auto Repartition can also work with unpartitioned tables when a repartition column hint is specified. For an unpartitioned table, GreptimeDB Enterprise does not infer partition columns automatically. You can specify the preferred column for future Auto Repartition when creating the table:
+
+```sql
+CREATE TABLE sensor_readings (
+    host STRING,
+    cpu DOUBLE,
+    ts TIMESTAMP TIME INDEX,
+    PRIMARY KEY(host)
+)
+WITH ('repartition.column.hint'='host');
+```
+
+You can also set or update the hint later by using `ALTER TABLE`:
 
 ```sql
 ALTER TABLE sensor_readings SET 'repartition.column.hint'='host';
@@ -49,12 +61,11 @@ The hint only records metadata for future Auto Repartition. It does not trigger 
 
 The repartition column hint has the following restrictions:
 
-- It must be set with `ALTER TABLE ... SET`; setting it in `CREATE TABLE ... WITH` is not supported.
 - It must specify exactly one column.
 - The specified column must exist in the table.
 - The specified column cannot be the time index column.
 - It can only be set on a table without partition metadata.
-- It must be set or unset separately from other table options.
+- When using `ALTER TABLE`, it must be set or unset separately from other table options.
 
 ## Limitations
 

--- a/docs/enterprise/autopilot/auto-repartition.md
+++ b/docs/enterprise/autopilot/auto-repartition.md
@@ -36,7 +36,7 @@ Auto Repartition is useful in the following scenarios:
 Auto Repartition can also work with unpartitioned tables when a repartition column hint is specified. For an unpartitioned table, GreptimeDB Enterprise does not infer partition columns automatically. You must first set the preferred column for future Auto Repartition by using `ALTER TABLE`:
 
 ```sql
-ALTER TABLE sensor_readings SET 'repartition.column.hint' = 'host';
+ALTER TABLE sensor_readings SET 'repartition.column.hint'='host';
 ```
 
 To remove the hint:

--- a/docs/enterprise/autopilot/overview.md
+++ b/docs/enterprise/autopilot/overview.md
@@ -36,7 +36,7 @@ Autopilot is useful in the following scenarios:
 Different Autopilot strategies have their own limitations:
 
 - Region Balancer requires the number of schedulable Regions to be greater than the number of active Datanodes. Otherwise, moving Regions cannot make the load evenly distributed across Datanodes.
-- Auto Repartition only works for partitioned tables. It can only split tables that already have partition rules. If a table does not have partition rules, Auto Repartition does not generate new partition rules for it automatically. For more information about table partitioning and Repartition, see [Table Sharding](/user-guide/deployments-administration/manage-data/table-sharding.md) and [Repartition](/user-guide/deployments-administration/manage-data/repartition.md).
+- Auto Repartition works for partitioned tables and unpartitioned tables with `repartition.column.hint`. For unpartitioned tables, GreptimeDB Enterprise does not infer partition columns automatically. For more information about table partitioning and Repartition, see [Table Sharding](/user-guide/deployments-administration/manage-data/table-sharding.md) and [Repartition](/user-guide/deployments-administration/manage-data/repartition.md).
 
 ## Configuration
 

--- a/docs/reference/sql/alter.md
+++ b/docs/reference/sql/alter.md
@@ -222,7 +222,7 @@ ALTER TABLE monitor UNSET 'ttl';
 This option is available in GreptimeDB Enterprise. For details, see [Auto Repartition](/enterprise/autopilot/auto-repartition.md).
 :::
 
-In GreptimeDB Enterprise, `ALTER TABLE` also supports the following Enterprise-only table option.
+In GreptimeDB Enterprise, `repartition.column.hint` can be specified in `CREATE TABLE ... WITH` or changed later with `ALTER TABLE`.
 
 For an unpartitioned table, you can set the preferred column used by Auto Repartition:
 
@@ -238,7 +238,7 @@ ALTER TABLE table_name UNSET 'repartition.column.hint';
 
 The hint only records metadata for future Auto Repartition. It does not trigger Repartition immediately.
 
-The hint must be set or unset separately from other table options.
+When using `ALTER TABLE`, the hint must be set or unset separately from other table options.
 
 ### Repartition, split, or merge partitions {#split-or-merge-partitions}
 

--- a/docs/reference/sql/alter.md
+++ b/docs/reference/sql/alter.md
@@ -222,10 +222,12 @@ ALTER TABLE monitor UNSET 'ttl';
 This option is available in GreptimeDB Enterprise. For details, see [Auto Repartition](/enterprise/autopilot/auto-repartition.md).
 :::
 
+In GreptimeDB Enterprise, `ALTER TABLE` also supports the following Enterprise-only table option.
+
 For an unpartitioned table, you can set the preferred column used by Auto Repartition:
 
 ```sql
-ALTER TABLE table_name SET 'repartition.column.hint' = 'column_name';
+ALTER TABLE table_name SET 'repartition.column.hint'='column_name';
 ```
 
 To remove the hint:

--- a/docs/reference/sql/alter.md
+++ b/docs/reference/sql/alter.md
@@ -216,6 +216,28 @@ ALTER TABLE monitor SET 'sst_format'='primary_key';
 ALTER TABLE monitor UNSET 'ttl';
 ```
 
+### Set repartition column hint
+
+:::info Enterprise feature
+This option is available in GreptimeDB Enterprise. For details, see [Auto Repartition](/enterprise/autopilot/auto-repartition.md).
+:::
+
+For an unpartitioned table, you can set the preferred column used by Auto Repartition:
+
+```sql
+ALTER TABLE table_name SET 'repartition.column.hint' = 'column_name';
+```
+
+To remove the hint:
+
+```sql
+ALTER TABLE table_name UNSET 'repartition.column.hint';
+```
+
+The hint only records metadata for future Auto Repartition. It does not trigger Repartition immediately.
+
+The hint must be set or unset separately from other table options.
+
 ### Repartition, split, or merge partitions {#split-or-merge-partitions}
 
 Use `PARTITION ON COLUMNS` to repartition an unpartitioned table into multiple partitions:

--- a/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/autopilot/auto-repartition.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/autopilot/auto-repartition.md
@@ -31,9 +31,34 @@ Auto Repartition 适合以下场景：
 - 希望将大 Region 拆分为多个小 Region，并通过后续调度打散潜在的负载瓶颈；
 - 希望减少手动分析大 Region 和手动执行 Repartition 的运维成本。
 
+## 未分区表的 Auto Repartition
+
+当指定了重分区列 hint 时，Auto Repartition 也可以作用于未分区表。对于未分区表，GreptimeDB Enterprise 不会自动推断分区列。你需要先通过 `ALTER TABLE` 设置后续 Auto Repartition 使用的候选列：
+
+```sql
+ALTER TABLE sensor_readings SET 'repartition.column.hint' = 'host';
+```
+
+取消该 hint：
+
+```sql
+ALTER TABLE sensor_readings UNSET 'repartition.column.hint';
+```
+
+该 hint 只会记录供后续 Auto Repartition 使用的元信息，不会立即触发重分区。当表满足 Auto Repartition 的触发条件后，GreptimeDB Enterprise 可以使用该 hint 指定的列生成分区边界，并提交 Repartition 操作。
+
+重分区列 hint 有以下限制：
+
+- 必须通过 `ALTER TABLE ... SET` 设置；不支持在 `CREATE TABLE ... WITH` 中设置。
+- 只能指定一个列。
+- 指定的列必须存在于表中。
+- 指定的列不能是 time index 列。
+- 只能在没有 partition metadata 的表上设置。
+- 必须单独设置或取消，不能和其他 table options 一起修改。
+
 ## 限制
 
-Auto Repartition 仅对多分区表有效，只能拆分已经带有分区规则的表。如果表没有分区规则，Auto Repartition 不会为它自动生成新的分区规则。
+Auto Repartition 支持已分区表，以及设置了 `repartition.column.hint` 的未分区表。对于未分区表，GreptimeDB Enterprise 不会自动推断分区列。
 
 关于表分区和重分区的说明，请参考[表分片](/user-guide/deployments-administration/manage-data/table-sharding.md)和[重分区](/user-guide/deployments-administration/manage-data/repartition.md)。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/autopilot/auto-repartition.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/autopilot/auto-repartition.md
@@ -33,7 +33,19 @@ Auto Repartition 适合以下场景：
 
 ## 未分区表的 Auto Repartition
 
-当指定了重分区列 hint 时，Auto Repartition 也可以作用于未分区表。对于未分区表，GreptimeDB Enterprise 不会自动推断分区列。你需要先通过 `ALTER TABLE` 设置后续 Auto Repartition 使用的候选列：
+当指定了重分区列 hint 时，Auto Repartition 也可以作用于未分区表。对于未分区表，GreptimeDB Enterprise 不会自动推断分区列。你可以在创建表时指定后续 Auto Repartition 使用的候选列：
+
+```sql
+CREATE TABLE sensor_readings (
+    host STRING,
+    cpu DOUBLE,
+    ts TIMESTAMP TIME INDEX,
+    PRIMARY KEY(host)
+)
+WITH ('repartition.column.hint'='host');
+```
+
+你也可以后续通过 `ALTER TABLE` 设置或更新该 hint：
 
 ```sql
 ALTER TABLE sensor_readings SET 'repartition.column.hint'='host';
@@ -49,12 +61,11 @@ ALTER TABLE sensor_readings UNSET 'repartition.column.hint';
 
 重分区列 hint 有以下限制：
 
-- 必须通过 `ALTER TABLE ... SET` 设置；不支持在 `CREATE TABLE ... WITH` 中设置。
 - 只能指定一个列。
 - 指定的列必须存在于表中。
 - 指定的列不能是 time index 列。
 - 只能在没有 partition metadata 的表上设置。
-- 必须单独设置或取消，不能和其他 table options 一起修改。
+- 使用 `ALTER TABLE` 时，必须单独设置或取消，不能和其他 table options 一起修改。
 
 ## 限制
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/autopilot/auto-repartition.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/autopilot/auto-repartition.md
@@ -36,7 +36,7 @@ Auto Repartition 适合以下场景：
 当指定了重分区列 hint 时，Auto Repartition 也可以作用于未分区表。对于未分区表，GreptimeDB Enterprise 不会自动推断分区列。你需要先通过 `ALTER TABLE` 设置后续 Auto Repartition 使用的候选列：
 
 ```sql
-ALTER TABLE sensor_readings SET 'repartition.column.hint' = 'host';
+ALTER TABLE sensor_readings SET 'repartition.column.hint'='host';
 ```
 
 取消该 hint：

--- a/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/autopilot/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/autopilot/overview.md
@@ -36,7 +36,7 @@ Autopilot 适合以下场景：
 不同 Autopilot 策略有各自的适用限制：
 
 - Region Balancer 要求可调度的 Region 数量大于活跃 Datanode 数量。否则即使迁移 Region，也无法让 Datanode 之间的负载变得均衡。
-- Auto Repartition 仅对多分区表有效，只能拆分已经带有分区规则的表。如果表没有分区规则，Auto Repartition 不会为它自动生成新的分区规则。关于表分区和重分区的说明，请参考[表分片](/user-guide/deployments-administration/manage-data/table-sharding.md)和[重分区](/user-guide/deployments-administration/manage-data/repartition.md)。
+- Auto Repartition 支持已分区表，以及设置了 `repartition.column.hint` 的未分区表。对于未分区表，GreptimeDB Enterprise 不会自动推断分区列。关于表分区和重分区的说明，请参考[表分片](/user-guide/deployments-administration/manage-data/table-sharding.md)和[重分区](/user-guide/deployments-administration/manage-data/repartition.md)。
 
 ## 配置
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/alter.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/alter.md
@@ -214,6 +214,28 @@ ALTER TABLE monitor SET 'sst_format'='primary_key';
 ALTER TABLE monitor UNSET 'ttl';
 ```
 
+### 设置重分区列 hint
+
+:::info 企业版功能
+该选项仅在 GreptimeDB Enterprise 中可用。详细说明请参考 [Auto Repartition](/enterprise/autopilot/auto-repartition.md)。
+:::
+
+对于未分区表，可以设置 Auto Repartition 使用的候选列：
+
+```sql
+ALTER TABLE table_name SET 'repartition.column.hint' = 'column_name';
+```
+
+取消该 hint：
+
+```sql
+ALTER TABLE table_name UNSET 'repartition.column.hint';
+```
+
+该 hint 只会记录供后续 Auto Repartition 使用的元信息，不会立即触发重分区。
+
+该 hint 必须单独设置或取消，不能和其他 table options 一起修改。
+
 ### 重分区、拆分与合并 {#split-or-merge-partitions}
 
 使用 `PARTITION ON COLUMNS` 可以将未分区的表重分区为多个分区：

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/alter.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/alter.md
@@ -220,10 +220,12 @@ ALTER TABLE monitor UNSET 'ttl';
 该选项仅在 GreptimeDB Enterprise 中可用。详细说明请参考 [Auto Repartition](/enterprise/autopilot/auto-repartition.md)。
 :::
 
+在 GreptimeDB Enterprise 中，`ALTER TABLE` 还支持以下企业版专属表选项。
+
 对于未分区表，可以设置 Auto Repartition 使用的候选列：
 
 ```sql
-ALTER TABLE table_name SET 'repartition.column.hint' = 'column_name';
+ALTER TABLE table_name SET 'repartition.column.hint'='column_name';
 ```
 
 取消该 hint：

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/alter.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/alter.md
@@ -220,7 +220,7 @@ ALTER TABLE monitor UNSET 'ttl';
 该选项仅在 GreptimeDB Enterprise 中可用。详细说明请参考 [Auto Repartition](/enterprise/autopilot/auto-repartition.md)。
 :::
 
-在 GreptimeDB Enterprise 中，`ALTER TABLE` 还支持以下企业版专属表选项。
+在 GreptimeDB Enterprise 中，可以在 `CREATE TABLE ... WITH` 中指定 `repartition.column.hint`，也可以后续通过 `ALTER TABLE` 修改。
 
 对于未分区表，可以设置 Auto Repartition 使用的候选列：
 
@@ -236,7 +236,7 @@ ALTER TABLE table_name UNSET 'repartition.column.hint';
 
 该 hint 只会记录供后续 Auto Repartition 使用的元信息，不会立即触发重分区。
 
-该 hint 必须单独设置或取消，不能和其他 table options 一起修改。
+使用 `ALTER TABLE` 时，该 hint 必须单独设置或取消，不能和其他 table options 一起修改。
 
 ### 重分区、拆分与合并 {#split-or-merge-partitions}
 


### PR DESCRIPTION
## What's Changed in this PR

This PR documents the GreptimeDB Enterprise Auto Repartition column hint for unpartitioned tables.

Changes include:

- Update Enterprise Auto Repartition docs to explain how unpartitioned tables can use `repartition.column.hint`.
- Clarify that the hint must be set through `ALTER TABLE ... SET`, and that `CREATE TABLE ... WITH` is not supported.
- Document hint restrictions:
  - only one column is supported;
  - the column must exist;
  - the column cannot be the time index column;
  - the table must not already have partition metadata;
  - the hint must be set or unset separately from other table options.
- Update the Autopilot overview limitation text.
- Add SQL Reference coverage for `ALTER TABLE ... SET/UNSET 'repartition.column.hint'`, marked as an Enterprise feature and linked to Auto Repartition.
- Add corresponding Chinese localized docs.


## Checklist

- [ ] Please confirm that all corresponding versions of the documents have been revised.
- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.
