### PR TITLE
docs: add index guidance to performance tuning

### DIFF
--- a/docs/user-guide/deployments-administration/performance-tuning/performance-tuning-tips.md
+++ b/docs/user-guide/deployments-administration/performance-tuning/performance-tuning-tips.md
@@ -1,11 +1,13 @@
 ---
-keywords: [GreptimeDB performance tuning, query optimization, caching, primary keys, append-only tables, metrics]
-description: Tips for tuning GreptimeDB performance, including query optimization, caching, enlarging cache size, primary keys, and using append-only tables. Also covers metrics for diagnosing query and ingestion issues.
+keywords: [GreptimeDB performance tuning, query optimization, caching, schema design, indexes, primary keys, append-only tables, metrics]
+description: Tips for tuning GreptimeDB performance, including query optimization, caching, schema design, indexes, primary keys, and append-only tables. Also covers metrics for diagnosing query and ingestion issues.
 ---
 
 # Performance Tuning Tips
 
 A GreptimeDB instance's default configuration may not fit all use cases. It's important to tune the database configurations and usage according to the scenario.
+
+Performance tuning is not limited to server configuration. Table schema and index design directly affect ingestion and query efficiency. See [Design Your Table Schema](/user-guide/deployments-administration/performance-tuning/design-table.md) for guidance on primary keys, append-only and deduplicating tables, index selection, table layout, and partitioning.
 
 GreptimeDB provides various metrics to help monitor and troubleshoot performance issues. The official repository provides [Grafana dashboard templates](https://github.com/GreptimeTeam/greptimedb/tree/main/grafana) for both standalone and cluster modes.
 
@@ -28,10 +30,24 @@ If the cause is still unclear, include the full `EXPLAIN ANALYZE VERBOSE` output
 Common findings:
 
 - **Many small files to search**: A high `num_file_ranges` value, especially when many files contain less than one full row group, can mean the scan has to open many small SST files. This often comes from backfilling many different time windows or from high compaction pressure. Consider adjusting `compaction.twcs.time_window`, reviewing the write or backfill pattern so rows fill time windows more naturally, and checking compaction status. Small files do not always hurt performance if the number of files is not large.
-- **Many rows filtered after scanning**: If `scan_cost` is high and `rows_precise_filtered` is also high, the scan reads many candidate rows and then removes them with exact filters. Consider adding an appropriate [index](/user-guide/manage-data/data-index.md) for selective filter columns. Index changes apply to newly flushed data; they do not immediately rewrite all existing SST files.
+- **Many rows filtered after scanning**: If `scan_cost` is high and `rows_precise_filtered` is also high, the scan reads many candidate rows and then removes them with exact filters. See [Add indexes to improve filtering](#add-indexes-to-improve-filtering).
 - **Local cache misses during data fetch**: If `fetch_metrics.cache_miss`, `fetch_metrics.pages_to_fetch_store`, or `fetch_metrics.store_fetch_elapsed` is high, GreptimeDB is reading page data from object storage instead of local caches. Check the cache metrics below and consider increasing `write_cache_size` or `page_cache_size`.
 - **High scan preparation cost**: High `build_parts_cost` or `build_reader_cost` means GreptimeDB spends significant time building scan ranges or readers. Correlate this with `num_file_ranges`, metadata cache misses, and cache pressure.
 - **High metadata load time**: If `metadata_cache_metrics.metadata_load_cost` or `metadata_cache_metrics.cache_miss` is high, the SST metadata cache may be too small. Check `greptime_mito_cache_bytes{type="sst_meta"}` and consider increasing `sst_meta_cache_size`.
+
+### Add indexes to improve filtering
+
+Indexes can reduce the amount of data that GreptimeDB reads and filters. If `EXPLAIN ANALYZE VERBOSE` shows high `scan_cost` and many `rows_precise_filtered`, compare the query's `WHERE` predicates with the table schema. Columns that occur frequently in selective filters and are not already covered by the leading primary key columns are good index candidates.
+
+Choose the index type based on the query and the column:
+
+- Use an inverted index for filters on low-cardinality columns, including equality, range, and `IN` predicates.
+- Use a skipping index for equality filters on high-cardinality columns such as trace IDs and request IDs.
+- Use a full-text index for searches over unstructured text.
+
+Indexes have storage and memory costs and can increase flush and compaction latency, so avoid indexing every column. See [Index in the table design guide](/user-guide/deployments-administration/performance-tuning/design-table.md#index) for how indexes complement primary key ordering and how to select an index type. See [Data Index](/user-guide/manage-data/data-index.md) for index syntax and management.
+
+After adding an index, rerun the same query with `EXPLAIN ANALYZE VERBOSE` and compare `scan_cost` and `rows_precise_filtered`. Index pruning also appears in the `rg_*_filtered` and `rows_*_filtered` counters for the corresponding index type. Currently, a newly added index only takes effect for newly flushed data: the index is built for SST files produced by subsequent flushes, but is not added to existing SST files.
 
 ### Metrics
 
@@ -211,6 +227,8 @@ global_write_buffer_reject_size = "3GB"
 ```
 
 ## Schema
+
+Schema design affects both query and ingestion performance. This section describes one optimization for metric tables. For guidance on primary keys, indexes, append-only and deduplicating tables, and partitioning, see [Design Your Table Schema](/user-guide/deployments-administration/performance-tuning/design-table.md).
 
 ### Using multiple fields
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/performance-tuning/performance-tuning-tips.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/performance-tuning/performance-tuning-tips.md
@@ -1,11 +1,13 @@
 ---
-keywords: [性能调优, 查询性能, 缓存配置, 写入优化, 表结构设计, 指标监控, 对象存储, 批量写入, append-only 表]
-description: 提供 GreptimeDB 性能调优的技巧，包括查询性能指标、缓存配置、写入优化和表结构设计建议。
+keywords: [性能调优, 查询优化, 缓存配置, 表结构设计, 索引, 主键, append-only 表, 指标监控]
+description: 提供 GreptimeDB 性能调优的技巧，包括查询优化、缓存配置、表结构设计、索引、主键和 append-only 表，以及用于诊断查询和写入问题的指标。
 ---
 
 # 性能调优技巧
 
 GreptimeDB 实例的默认配置可能不适合所有场景。因此根据场景调整数据库配置和使用方式相当重要。
+
+性能调优不仅限于服务器配置。表结构和索引设计会直接影响写入和查询效率。有关主键、append-only 表与去重表、索引选择、表布局和分区的指导，请参阅[设计表结构](/user-guide/deployments-administration/performance-tuning/design-table.md)。
 
 GreptimeDB 提供了各种指标来帮助监控和排查性能问题。官方仓库里提供了用于独立模式和集群模式的 [Grafana dashboard 模版](https://github.com/GreptimeTeam/greptimedb/tree/main/grafana)。
 
@@ -28,10 +30,24 @@ EXPLAIN ANALYZE VERBOSE <SQL>;
 常见发现：
 
 - **需要搜索大量小文件**：`num_file_ranges` 较高，尤其是许多文件不足一个完整 row group 时，通常表示扫描需要打开大量小 SST 文件。这往往来自对大量不同时间窗口的回填，或 compaction 压力较高。可以考虑调整 `compaction.twcs.time_window`，检查写入或回填模式，让行更自然地填满时间窗口，并检查 compaction 状态。如果文件数量不多，小文件不一定会影响性能。
-- **扫描后过滤了大量行**：如果 `scan_cost` 较高且 `rows_precise_filtered` 也较高，说明扫描读取了大量候选行，然后又通过精确过滤移除了它们。可以考虑为选择性较高的过滤列添加合适的[索引](/user-guide/manage-data/data-index.md)。索引变更会作用于新 flush 的数据，不会立即重写所有已有 SST 文件。
+- **扫描后过滤了大量行**：如果 `scan_cost` 较高且 `rows_precise_filtered` 也较高，说明扫描读取了大量候选行，然后又通过精确过滤移除了它们。请参阅[添加索引以提升过滤性能](#添加索引以提升过滤性能)。
 - **数据读取时本地缓存未命中**：如果 `fetch_metrics.cache_miss`、`fetch_metrics.pages_to_fetch_store` 或 `fetch_metrics.store_fetch_elapsed` 较高，说明 GreptimeDB 正在从对象存储读取 page 数据，而不是从本地缓存读取。请检查下文的缓存指标，并考虑增大 `write_cache_size` 或 `page_cache_size`。
 - **扫描准备成本较高**：`build_parts_cost` 或 `build_reader_cost` 较高，表示 GreptimeDB 花了较多时间构建扫描范围或 reader。请结合 `num_file_ranges`、元数据缓存未命中以及缓存压力一起分析。
 - **元数据加载时间较高**：如果 `metadata_cache_metrics.metadata_load_cost` 或 `metadata_cache_metrics.cache_miss` 较高，可能是 SST 元数据缓存过小。请检查 `greptime_mito_cache_bytes{type="sst_meta"}`，并考虑增大 `sst_meta_cache_size`。
+
+### 添加索引以提升过滤性能
+
+索引可以减少 GreptimeDB 需要读取和过滤的数据量。如果 `EXPLAIN ANALYZE VERBOSE` 显示 `scan_cost` 较高且 `rows_precise_filtered` 很多，请将查询中的 `WHERE` 谓词与表结构进行比较。经常用于选择性过滤，且未被主键前导列覆盖的列，是较好的索引候选列。
+
+请根据查询和列选择索引类型：
+
+- 对低基数列上的过滤条件（包括等值、范围和 `IN` 谓词）使用倒排索引。
+- 对 trace ID 和 request ID 等高基数列上的等值过滤使用跳数索引。
+- 对非结构化文本搜索使用全文索引。
+
+索引会占用存储和内存，并可能增加 flush 和 compaction 延迟，因此不要为每一列都创建索引。有关索引如何补充主键排序以及如何选择索引类型，请参阅表设计指南中的[索引](/user-guide/deployments-administration/performance-tuning/design-table.md#索引)。有关索引语法和管理方式，请参阅[数据索引](/user-guide/manage-data/data-index.md)。
+
+添加索引后，请使用 `EXPLAIN ANALYZE VERBOSE` 重新运行同一查询，并比较 `scan_cost` 和 `rows_precise_filtered`。索引裁剪也会体现在对应索引类型的 `rg_*_filtered` 和 `rows_*_filtered` 计数器中。目前，新添加的索引仅对新 flush 的数据生效：后续 flush 生成 SST 文件时会为其构建索引，但不会为已有 SST 文件添加索引。
 
 ### 指标
 
@@ -209,6 +225,8 @@ global_write_buffer_reject_size = "3GB"
 ```
 
 ## 表结构
+
+表结构设计会同时影响查询和写入性能。本节介绍一项针对指标表的优化。有关主键、索引、append-only 表与去重表以及分区的指导，请参阅[设计表结构](/user-guide/deployments-administration/performance-tuning/design-table.md)。
 
 ### 使用多值
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/deployments-administration/performance-tuning/performance-tuning-tips.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/deployments-administration/performance-tuning/performance-tuning-tips.md
@@ -1,11 +1,13 @@
 ---
-keywords: [性能调优, 查询性能, 缓存配置, 写入优化, 表结构设计, 指标监控, 对象存储, 批量写入, append-only 表]
-description: 提供 GreptimeDB 性能调优的技巧，包括查询性能指标、缓存配置、写入优化和表结构设计建议。
+keywords: [性能调优, 查询优化, 缓存配置, 表结构设计, 索引, 主键, append-only 表, 指标监控]
+description: 提供 GreptimeDB 性能调优的技巧，包括查询优化、缓存配置、表结构设计、索引、主键和 append-only 表，以及用于诊断查询和写入问题的指标。
 ---
 
 # 性能调优技巧
 
 GreptimeDB 实例的默认配置可能不适合所有场景。因此根据场景调整数据库配置和使用方式相当重要。
+
+性能调优不仅限于服务器配置。表结构和索引设计会直接影响写入和查询效率。有关主键、append-only 表与去重表、索引选择、表布局和分区的指导，请参阅[设计表结构](/user-guide/deployments-administration/performance-tuning/design-table.md)。
 
 GreptimeDB 提供了各种指标来帮助监控和排查性能问题。官方仓库里提供了用于独立模式和集群模式的 [Grafana dashboard 模版](https://github.com/GreptimeTeam/greptimedb/tree/main/grafana)。
 
@@ -28,10 +30,24 @@ EXPLAIN ANALYZE VERBOSE <SQL>;
 常见发现：
 
 - **需要搜索大量小文件**：`num_file_ranges` 较高，尤其是许多文件不足一个完整 row group 时，通常表示扫描需要打开大量小 SST 文件。这往往来自对大量不同时间窗口的回填，或 compaction 压力较高。可以考虑调整 `compaction.twcs.time_window`，检查写入或回填模式，让行更自然地填满时间窗口，并检查 compaction 状态。如果文件数量不多，小文件不一定会影响性能。
-- **扫描后过滤了大量行**：如果 `scan_cost` 较高且 `rows_precise_filtered` 也较高，说明扫描读取了大量候选行，然后又通过精确过滤移除了它们。可以考虑为选择性较高的过滤列添加合适的[索引](/user-guide/manage-data/data-index.md)。索引变更会作用于新 flush 的数据，不会立即重写所有已有 SST 文件。
+- **扫描后过滤了大量行**：如果 `scan_cost` 较高且 `rows_precise_filtered` 也较高，说明扫描读取了大量候选行，然后又通过精确过滤移除了它们。请参阅[添加索引以提升过滤性能](#添加索引以提升过滤性能)。
 - **数据读取时本地缓存未命中**：如果 `fetch_metrics.cache_miss`、`fetch_metrics.pages_to_fetch_store` 或 `fetch_metrics.store_fetch_elapsed` 较高，说明 GreptimeDB 正在从对象存储读取 page 数据，而不是从本地缓存读取。请检查下文的缓存指标，并考虑增大 `write_cache_size` 或 `page_cache_size`。
 - **扫描准备成本较高**：`build_parts_cost` 或 `build_reader_cost` 较高，表示 GreptimeDB 花了较多时间构建扫描范围或 reader。请结合 `num_file_ranges`、元数据缓存未命中以及缓存压力一起分析。
 - **元数据加载时间较高**：如果 `metadata_cache_metrics.metadata_load_cost` 或 `metadata_cache_metrics.cache_miss` 较高，可能是 SST 元数据缓存过小。请检查 `greptime_mito_cache_bytes{type="sst_meta"}`，并考虑增大 `sst_meta_cache_size`。
+
+### 添加索引以提升过滤性能
+
+索引可以减少 GreptimeDB 需要读取和过滤的数据量。如果 `EXPLAIN ANALYZE VERBOSE` 显示 `scan_cost` 较高且 `rows_precise_filtered` 很多，请将查询中的 `WHERE` 谓词与表结构进行比较。经常用于选择性过滤，且未被主键前导列覆盖的列，是较好的索引候选列。
+
+请根据查询和列选择索引类型：
+
+- 对低基数列上的过滤条件（包括等值、范围和 `IN` 谓词）使用倒排索引。
+- 对 trace ID 和 request ID 等高基数列上的等值过滤使用跳数索引。
+- 对非结构化文本搜索使用全文索引。
+
+索引会占用存储和内存，并可能增加 flush 和 compaction 延迟，因此不要为每一列都创建索引。有关索引如何补充主键排序以及如何选择索引类型，请参阅表设计指南中的[索引](/user-guide/deployments-administration/performance-tuning/design-table.md#索引)。有关索引语法和管理方式，请参阅[数据索引](/user-guide/manage-data/data-index.md)。
+
+添加索引后，请使用 `EXPLAIN ANALYZE VERBOSE` 重新运行同一查询，并比较 `scan_cost` 和 `rows_precise_filtered`。索引裁剪也会体现在对应索引类型的 `rg_*_filtered` 和 `rows_*_filtered` 计数器中。目前，新添加的索引仅对新 flush 的数据生效：后续 flush 生成 SST 文件时会为其构建索引，但不会为已有 SST 文件添加索引。
 
 ### 指标
 
@@ -209,6 +225,8 @@ global_write_buffer_reject_size = "3GB"
 ```
 
 ## 表结构
+
+表结构设计会同时影响查询和写入性能。本节介绍一项针对指标表的优化。有关主键、索引、append-only 表与去重表以及分区的指导，请参阅[设计表结构](/user-guide/deployments-administration/performance-tuning/design-table.md)。
 
 ### 使用多值
 

--- a/skills/greptimedb-table-design/SKILL.md
+++ b/skills/greptimedb-table-design/SKILL.md
@@ -114,7 +114,8 @@ Be explicit about the constraints. The highest-impact choices are fixed at `CREA
 
 **Alterable on a live table:**
 
-- Add/drop **indexes** via `ALTER TABLE` — applies to **newly flushed data**, not existing
+- Add/drop **indexes** via `ALTER TABLE`. Explain that this only affects newly flushed data:
+  the index is built for SST files produced by subsequent flushes and is not added to existing
   SST files (see the data-index guide).
 - `append_mode` can change from `false` to `true`, but not from `true` back to `false`:
 

--- a/versioned_docs/version-1.1/user-guide/deployments-administration/performance-tuning/performance-tuning-tips.md
+++ b/versioned_docs/version-1.1/user-guide/deployments-administration/performance-tuning/performance-tuning-tips.md
@@ -1,11 +1,13 @@
 ---
-keywords: [GreptimeDB performance tuning, query optimization, caching, primary keys, append-only tables, metrics]
-description: Tips for tuning GreptimeDB performance, including query optimization, caching, enlarging cache size, primary keys, and using append-only tables. Also covers metrics for diagnosing query and ingestion issues.
+keywords: [GreptimeDB performance tuning, query optimization, caching, schema design, indexes, primary keys, append-only tables, metrics]
+description: Tips for tuning GreptimeDB performance, including query optimization, caching, schema design, indexes, primary keys, and append-only tables. Also covers metrics for diagnosing query and ingestion issues.
 ---
 
 # Performance Tuning Tips
 
 A GreptimeDB instance's default configuration may not fit all use cases. It's important to tune the database configurations and usage according to the scenario.
+
+Performance tuning is not limited to server configuration. Table schema and index design directly affect ingestion and query efficiency. See [Design Your Table Schema](/user-guide/deployments-administration/performance-tuning/design-table.md) for guidance on primary keys, append-only and deduplicating tables, index selection, table layout, and partitioning.
 
 GreptimeDB provides various metrics to help monitor and troubleshoot performance issues. The official repository provides [Grafana dashboard templates](https://github.com/GreptimeTeam/greptimedb/tree/main/grafana) for both standalone and cluster modes.
 
@@ -28,10 +30,24 @@ If the cause is still unclear, include the full `EXPLAIN ANALYZE VERBOSE` output
 Common findings:
 
 - **Many small files to search**: A high `num_file_ranges` value, especially when many files contain less than one full row group, can mean the scan has to open many small SST files. This often comes from backfilling many different time windows or from high compaction pressure. Consider adjusting `compaction.twcs.time_window`, reviewing the write or backfill pattern so rows fill time windows more naturally, and checking compaction status. Small files do not always hurt performance if the number of files is not large.
-- **Many rows filtered after scanning**: If `scan_cost` is high and `rows_precise_filtered` is also high, the scan reads many candidate rows and then removes them with exact filters. Consider adding an appropriate [index](/user-guide/manage-data/data-index.md) for selective filter columns. Index changes apply to newly flushed data; they do not immediately rewrite all existing SST files.
+- **Many rows filtered after scanning**: If `scan_cost` is high and `rows_precise_filtered` is also high, the scan reads many candidate rows and then removes them with exact filters. See [Add indexes to improve filtering](#add-indexes-to-improve-filtering).
 - **Local cache misses during data fetch**: If `fetch_metrics.cache_miss`, `fetch_metrics.pages_to_fetch_store`, or `fetch_metrics.store_fetch_elapsed` is high, GreptimeDB is reading page data from object storage instead of local caches. Check the cache metrics below and consider increasing `write_cache_size` or `page_cache_size`.
 - **High scan preparation cost**: High `build_parts_cost` or `build_reader_cost` means GreptimeDB spends significant time building scan ranges or readers. Correlate this with `num_file_ranges`, metadata cache misses, and cache pressure.
 - **High metadata load time**: If `metadata_cache_metrics.metadata_load_cost` or `metadata_cache_metrics.cache_miss` is high, the SST metadata cache may be too small. Check `greptime_mito_cache_bytes{type="sst_meta"}` and consider increasing `sst_meta_cache_size`.
+
+### Add indexes to improve filtering
+
+Indexes can reduce the amount of data that GreptimeDB reads and filters. If `EXPLAIN ANALYZE VERBOSE` shows high `scan_cost` and many `rows_precise_filtered`, compare the query's `WHERE` predicates with the table schema. Columns that occur frequently in selective filters and are not already covered by the leading primary key columns are good index candidates.
+
+Choose the index type based on the query and the column:
+
+- Use an inverted index for filters on low-cardinality columns, including equality, range, and `IN` predicates.
+- Use a skipping index for equality filters on high-cardinality columns such as trace IDs and request IDs.
+- Use a full-text index for searches over unstructured text.
+
+Indexes have storage and memory costs and can increase flush and compaction latency, so avoid indexing every column. See [Index in the table design guide](/user-guide/deployments-administration/performance-tuning/design-table.md#index) for how indexes complement primary key ordering and how to select an index type. See [Data Index](/user-guide/manage-data/data-index.md) for index syntax and management.
+
+After adding an index, rerun the same query with `EXPLAIN ANALYZE VERBOSE` and compare `scan_cost` and `rows_precise_filtered`. Index pruning also appears in the `rg_*_filtered` and `rows_*_filtered` counters for the corresponding index type. Currently, a newly added index only takes effect for newly flushed data: the index is built for SST files produced by subsequent flushes, but is not added to existing SST files.
 
 ### Metrics
 
@@ -211,6 +227,8 @@ global_write_buffer_reject_size = "3GB"
 ```
 
 ## Schema
+
+Schema design affects both query and ingestion performance. This section describes one optimization for metric tables. For guidance on primary keys, indexes, append-only and deduplicating tables, and partitioning, see [Design Your Table Schema](/user-guide/deployments-administration/performance-tuning/design-table.md).
 
 ### Using multiple fields
 


### PR DESCRIPTION
## What's Changed in this PR

<!--
    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
    Note: `nightly` for the weekly built version, which is not released yet.
-->

Document schema and index design as performance-tuning levers.

- Add a query-tuning workflow that uses `EXPLAIN ANALYZE VERBOSE` and query predicates to identify index candidates.
- Explain index selection, costs, validation metrics, and the newly flushed data limitation.
- Link the performance guide to the table-design and data-index documentation.
- Align the table-design skill with how indexes are built for SST files produced by subsequent flushes.


## Checklist

- [x] Please confirm that all corresponding versions of the documents have been revised.
- [x] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [ ] This change requires follow-up update in localized docs.