### PR TITLE
docs: add Query Guard plugin docs for banning DROP TABLE/DATABASE

### DIFF
--- a/docs/enterprise/deployments-administration/query-guard.md
+++ b/docs/enterprise/deployments-administration/query-guard.md
@@ -11,8 +11,10 @@ It provides the following protections:
 
 - **Ban `DROP TABLE`**: reject all `DROP TABLE` statements.
 - **Ban `DROP DATABASE`**: reject all `DROP DATABASE` statements.
-- **Disallow cross-catalog queries**: reject queries that reference tables across
-  different catalogs.
+- **Reject `COPY` statements**: reject all `COPY` statements.
+- **Disallow cross-catalog access**: reject queries that reference tables across
+  different catalogs, cross-catalog gRPC DDL requests, and Flight bulk inserts
+  targeting a different catalog.
 
 ## Overview
 
@@ -58,8 +60,10 @@ it takes effect on the frontend where it is configured.
 - **Every frontend must carry the configuration.** In a deployment with multiple
   frontends, you must add the plugin configuration to every frontend's config file;
   frontends without the configuration will still execute `DROP` statements.
-- **Enabling the plugin also disallows cross-catalog queries.** Turning on
-  `query_guard` automatically enables `disallow_cross_catalog_query`, even if you
-  only want the `DROP` bans.
+- **Enabling the plugin activates all protections except the `DROP` bans.**
+  Turning on `query_guard` automatically rejects `COPY` statements, cross-catalog
+  queries, cross-catalog gRPC DDL requests, and Flight bulk inserts targeting a
+  different catalog, even if you only want the `DROP` bans. The `DROP` bans are
+  controlled separately by `ban_drop_table` and `ban_drop_database`.
 - The bans are enforced at the protocol layer. Changing the configuration requires
   a restart of the frontend to take effect.

--- a/docs/enterprise/deployments-administration/query-guard.md
+++ b/docs/enterprise/deployments-administration/query-guard.md
@@ -29,8 +29,10 @@ protocol:
 
 - SQL path: `DROP TABLE` and `DROP DATABASE` statements are rejected with a
   `NotSupported` error.
-- gRPC path: `DROP TABLE` DDL requests are rejected. Note that `DROP DATABASE` is
-  SQL-only; the gRPC protocol has no drop-database request.
+- gRPC path: structured `DROP TABLE` DDL requests are rejected. The structured
+  gRPC DDL request has no drop-database variant; however, SQL statements sent over
+  gRPC go through the same SQL interceptors, so the `DROP DATABASE` ban applies to
+  SQL over gRPC as well.
 
 Internal operations such as TTL-based data expiration and automatic cleanup bypass
 the frontend protocol-layer interceptors and are **not** affected by these bans.

--- a/docs/enterprise/deployments-administration/query-guard.md
+++ b/docs/enterprise/deployments-administration/query-guard.md
@@ -1,0 +1,65 @@
+---
+keywords: [query guard, ban drop table, ban drop database, data protection, security, configuration]
+description: Guide to configuring the Query Guard plugin in GreptimeDB Enterprise to ban DROP TABLE / DROP DATABASE statements for all users and disallow cross-catalog queries.
+---
+
+# Query Guard
+
+Query Guard is a GreptimeDB Enterprise plugin that intercepts queries at the frontend
+protocol layer and rejects potentially dangerous statements before they are executed.
+It provides the following protections:
+
+- **Ban `DROP TABLE`**: reject all `DROP TABLE` statements.
+- **Ban `DROP DATABASE`**: reject all `DROP DATABASE` statements.
+- **Disallow cross-catalog queries**: reject queries that reference tables across
+  different catalogs.
+
+## Overview
+
+The `DROP TABLE` and `DROP DATABASE` bans are enforced in the query interceptors,
+which run **before any permission check**. This means once enabled, the bans apply
+to **every user, including administrators**. No one can drop tables or databases
+through the client protocols until the configuration is changed and the frontend
+is restarted.
+
+The bans cover both the SQL protocols (MySQL, PostgreSQL, and HTTP) and the gRPC
+protocol:
+
+- SQL path: `DROP TABLE` and `DROP DATABASE` statements are rejected with a
+  `NotSupported` error.
+- gRPC path: `DROP TABLE` DDL requests are rejected. Note that `DROP DATABASE` is
+  SQL-only; the gRPC protocol has no drop-database request.
+
+Internal operations such as TTL-based data expiration and automatic cleanup bypass
+the frontend protocol-layer interceptors and are **not** affected by these bans.
+
+## Configuration
+
+Query Guard is provided as a plugin in GreptimeDB. To enable and configure it, add
+the following TOML to your GreptimeDB config file:
+
+```toml
+[[plugins]]
+# Add the query guard plugin to your GreptimeDB.
+[plugins.query_guard]
+# Whether to enable the query guard plugin, defaults to false.
+enable = true
+# Whether to ban DROP TABLE statements for all users, defaults to false.
+ban_drop_table = true
+# Whether to ban DROP DATABASE statements for all users, defaults to false.
+ban_drop_database = true
+```
+
+The plugin works in both standalone mode and distributed mode. In distributed mode,
+it takes effect on the frontend where it is configured.
+
+## Caveats
+
+- **Every frontend must carry the configuration.** In a deployment with multiple
+  frontends, you must add the plugin configuration to every frontend's config file;
+  frontends without the configuration will still execute `DROP` statements.
+- **Enabling the plugin also disallows cross-catalog queries.** Turning on
+  `query_guard` automatically enables `disallow_cross_catalog_query`, even if you
+  only want the `DROP` bans.
+- The bans are enforced at the protocol layer. Changing the configuration requires
+  a restart of the frontend to take effect.

--- a/docs/enterprise/overview.md
+++ b/docs/enterprise/overview.md
@@ -30,6 +30,8 @@ which are described in detail in the documentation in this section:
 - [LDAP Authentication](./deployments-administration/authentication.md): Secure your system with LDAP-based authentication for access management.
 - [Audit Logging](./deployments-administration/monitoring/audit-logging.md): Track and monitor
   user activity with detailed audit logs.
+- [Query Guard](./deployments-administration/query-guard.md): Ban `DROP TABLE` / `DROP DATABASE`
+  statements for all users and reject cross-catalog access.
 - [Automatic region load balance](./autopilot/region-balancer.md): Auto balance
   datanodes workload by moving regions between them.
 - [Elasticsearch query compatibility](./elasticsearch-compatible/overview.md): Use GreptimeDB backed Kibana for your logs.

--- a/docs/reference/sql/drop.md
+++ b/docs/reference/sql/drop.md
@@ -5,6 +5,12 @@ description: Covers the SQL DROP statement for removing databases, tables, flows
 
 # DROP
 
+:::tip
+
+GreptimeDB Enterprise provides the [Query Guard](/enterprise/deployments-administration/query-guard.md) plugin, which can completely ban `DROP TABLE` / `DROP DATABASE` statements for all users, including administrators.
+
+:::
+
 ## DROP DATABASE
 
 `DROP DATABASE` drops a database. It removes the catalog entries for the database and deletes the directory containing the data.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/deployments-administration/query-guard.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/deployments-administration/query-guard.md
@@ -24,8 +24,9 @@ Query Guard 是 GreptimeDB 企业版提供的一个插件，它在 Frontend 协�
 该限制同时覆盖 SQL 协议（MySQL、PostgreSQL 和 HTTP）和 gRPC 协议：
 
 - SQL 路径：`DROP TABLE` 和 `DROP DATABASE` 语句会被拒绝，返回 `NotSupported` 错误。
-- gRPC 路径：`DROP TABLE` DDL 请求会被拒绝。注意 `DROP DATABASE` 仅存在于 SQL 协议中，
-  gRPC 协议没有删除数据库的请求。
+- gRPC 路径：结构化的 `DROP TABLE` DDL 请求会被拒绝。结构化 gRPC DDL 请求没有
+  删除数据库的变体；但通过 gRPC 发送的 SQL 语句同样会经过 SQL 拦截器，因此
+  `DROP DATABASE` 禁令对 gRPC 上的 SQL 同样生效。
 
 内部操作（例如基于 TTL 的数据过期和自动清理）不经过 Frontend 协议层拦截器，
 因此**不受**这些限制影响。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/deployments-administration/query-guard.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/deployments-administration/query-guard.md
@@ -10,7 +10,9 @@ Query Guard 是 GreptimeDB 企业版提供的一个插件，它在 Frontend 协�
 
 - **禁止 `DROP TABLE`**：拒绝所有 `DROP TABLE` 语句。
 - **禁止 `DROP DATABASE`**：拒绝所有 `DROP DATABASE` 语句。
-- **禁止跨 catalog 查询**：拒绝引用不同 catalog 下表的查询。
+- **拒绝 `COPY` 语句**：拒绝所有 `COPY` 语句。
+- **禁止跨 catalog 访问**：拒绝引用不同 catalog 下表的查询、跨 catalog 的
+  gRPC DDL 请求，以及写入其他 catalog 的 Flight bulk insert。
 
 ## 工作原理
 
@@ -52,6 +54,8 @@ ban_drop_database = true
 - **每个 Frontend 都必须携带该配置。** 在多 Frontend 部署中，
   必须在每个 Frontend 的配置文件中添加该插件配置；
   未配置的 Frontend 仍会正常执行 `DROP` 语句。
-- **启用插件会同时禁止跨 catalog 查询。** 开启 `query_guard` 会自动启用
-  `disallow_cross_catalog_query`，即使你只想禁止 `DROP` 语句。
+- **启用插件会激活除 `DROP` 禁令外的所有保护。** 开启 `query_guard` 会自动拒绝
+  `COPY` 语句、跨 catalog 查询、跨 catalog 的 gRPC DDL 请求，以及写入其他
+  catalog 的 Flight bulk insert，即使你只想禁止 `DROP` 语句。`DROP` 禁令由
+  `ban_drop_table` 和 `ban_drop_database` 单独控制。
 - 该限制在协议层强制执行，修改配置后需要重启 Frontend 才能生效。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/deployments-administration/query-guard.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/deployments-administration/query-guard.md
@@ -1,0 +1,57 @@
+---
+keywords: [query guard, 禁止 drop table, 禁止 drop database, 数据保护, 安全, 配置]
+description: 介绍如何在 GreptimeDB 企业版中配置 Query Guard 插件，为所有用户禁止 DROP TABLE / DROP DATABASE 语句，并禁止跨 catalog 查询。
+---
+
+# Query Guard
+
+Query Guard 是 GreptimeDB 企业版提供的一个插件，它在 Frontend 协议层拦截查询，
+在语句执行前拒绝具有潜在危险的操作。它提供以下保护能力：
+
+- **禁止 `DROP TABLE`**：拒绝所有 `DROP TABLE` 语句。
+- **禁止 `DROP DATABASE`**：拒绝所有 `DROP DATABASE` 语句。
+- **禁止跨 catalog 查询**：拒绝引用不同 catalog 下表的查询。
+
+## 工作原理
+
+对 `DROP TABLE` 和 `DROP DATABASE` 的禁止在查询拦截器中强制执行，
+拦截器在**任何权限检查之前**运行。这意味着一旦启用，该限制对
+**所有用户（包括管理员）**生效。在修改配置并重启 Frontend 之前，
+任何人都无法通过客户端协议删除表或数据库。
+
+该限制同时覆盖 SQL 协议（MySQL、PostgreSQL 和 HTTP）和 gRPC 协议：
+
+- SQL 路径：`DROP TABLE` 和 `DROP DATABASE` 语句会被拒绝，返回 `NotSupported` 错误。
+- gRPC 路径：`DROP TABLE` DDL 请求会被拒绝。注意 `DROP DATABASE` 仅存在于 SQL 协议中，
+  gRPC 协议没有删除数据库的请求。
+
+内部操作（例如基于 TTL 的数据过期和自动清理）不经过 Frontend 协议层拦截器，
+因此**不受**这些限制影响。
+
+## 配置
+
+Query Guard 以插件形式提供。要启用并配置它，请在 GreptimeDB 配置文件中添加以下 TOML：
+
+```toml
+[[plugins]]
+# 为 GreptimeDB 添加 query guard 插件。
+[plugins.query_guard]
+# 是否启用 query guard 插件，默认为 false。
+enable = true
+# 是否对所有用户禁止 DROP TABLE 语句，默认为 false。
+ban_drop_table = true
+# 是否对所有用户禁止 DROP DATABASE 语句，默认为 false。
+ban_drop_database = true
+```
+
+该插件在 standalone 模式和分布式模式下均可工作。在分布式模式下，
+它在配置了该插件的 Frontend 上生效。
+
+## 注意事项
+
+- **每个 Frontend 都必须携带该配置。** 在多 Frontend 部署中，
+  必须在每个 Frontend 的配置文件中添加该插件配置；
+  未配置的 Frontend 仍会正常执行 `DROP` 语句。
+- **启用插件会同时禁止跨 catalog 查询。** 开启 `query_guard` 会自动启用
+  `disallow_cross_catalog_query`，即使你只想禁止 `DROP` 语句。
+- 该限制在协议层强制执行，修改配置后需要重启 Frontend 才能生效。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/overview.md
@@ -28,6 +28,7 @@ GreptimeDB Enterprise 包括以下高级功能，
 - [基于双活互备的 DR 解决方案](./deployments-administration/disaster-recovery/overview.md)：通过高级灾难恢复解决方案确保服务不中断和数据保护。
 - [部署 GreptimeDB](./deployments-administration/overview.md)：设置认证信息及其他关键配置后，将 GreptimeDB 部署在 Kubernetes 上并监控关键指标。
 - [审计日志](./deployments-administration/monitoring/audit-logging.md)：记录数据库用户行为的日志。
+- [Query Guard](./deployments-administration/query-guard.md)：对所有用户（包括管理员）禁止 `DROP TABLE` / `DROP DATABASE` 语句，并拒绝跨 catalog 访问。
 - [自动分区平衡](./autopilot/region-balancer.md)：通过分区监控和迁移在 datanode 之间自动平衡负载。
 - [Elasticsearch 查询兼容性](./elasticsearch-compatible/overview.md)：在 Kibana 中以 GreptimeDB 作为后端。
 - [Greptime 企业版管理控制台](./console-ui.md)：加强版本的管理界面，提供更多的集群管理和监控功能。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/drop.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/drop.md
@@ -5,6 +5,12 @@ description: DROP 用于删除数据库、表、流或视图，操作不可撤�
 
 # DROP
 
+:::tip
+
+GreptimeDB 企业版提供了 [Query Guard](/enterprise/deployments-administration/query-guard.md) 插件，可以对所有用户（包括管理员）完全禁止 `DROP TABLE` / `DROP DATABASE` 语句。
+
+:::
+
 ## DROP DATABASE
 
 `DROP DATABASE` 用于删除数据库，它删除数据库的目录项并删除包含数据的目录。

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -453,6 +453,7 @@ const sidebars: SidebarsConfig = {
             },
             'enterprise/deployments-administration/env-affinity-region-placement',
             'enterprise/deployments-administration/authentication',
+            'enterprise/deployments-administration/query-guard',
             {
               type: 'category',
               label: 'Monitoring',


### PR DESCRIPTION
## What's changed

Add documentation for the GreptimeDB Enterprise **Query Guard** plugin, including the new `ban_drop_table` / `ban_drop_database` options introduced in [GreptimeTeam/greptimedb-enterprise#832](https://github.com/GreptimeTeam/greptimedb-enterprise/pull/832).

- **New page** `enterprise/deployments-administration/query-guard` (EN + ZH):
  - How the bans work: enforced in query interceptors **before permission checks**, so they apply to all users including admins
  - SQL path (MySQL/PostgreSQL/HTTP) rejects `DROP TABLE` / `DROP DATABASE`; gRPC path rejects `DROP TABLE` DDL requests (no drop-database variant in gRPC)
  - Internal operations (TTL, auto-cleanup) are unaffected
  - Configuration example: `[[plugins]] [plugins.query_guard]` with `enable`, `ban_drop_table`, `ban_drop_database`
  - Caveats: every frontend must carry the config in multi-frontend deployments; enabling the plugin also turns on the pre-existing `disallow_cross_catalog_query` behavior (documented here for the first time)
- **Sidebar**: registered under Enterprise → Deployments & Administration
- **Cross-links**: added a tip in the `DROP` SQL reference (EN + ZH) pointing to the new page

## Verification

- `pnpm typecheck` ✅
- `pnpm build` (EN) ✅
- `DOC_LANG=zh pnpm build` (ZH) ✅