### PR TITLE
docs: add multi-tenancy FAQ entry

### DIFF
--- a/docs/faq-and-others/faq.md
+++ b/docs/faq-and-others/faq.md
@@ -312,12 +312,12 @@ ORDER BY files DESC;
 
 The recommended approach is to isolate tenants at the **database** or **table** level, rather than mixing every tenant into one shared table distinguished only by a tag.
 
-- **Database per tenant**: Give each tenant its own [database](/reference/sql/create.md#create-database). This provides the cleanest isolation — separate schemas, per-tenant TTL and other table defaults, and independent access control.
+- **Database per tenant**: Give each tenant its own [database](/reference/sql/create.md#create-database). This keeps each tenant's data cleanly separated, with independent schema, TTL, and other table defaults.
 - **Table per tenant**: Within a shared database, give each tenant its own table (or table prefix). A good fit when tenants share configuration but you still want data-level separation.
 
 Don't worry about ending up with a large number of databases or tables. GreptimeDB's distributed architecture scales horizontally — tables are split into regions spread across datanodes, and you add datanodes as the table and region count grows. There is no hard limit on the number of tables, and performance depends on primary key design rather than table count (see [scalability characteristics](#what-are-greptimedbs-scalability-characteristics)).
 
-For per-tenant access control, use [user-level authentication](/user-guide/deployments-administration/authentication/overview.md) in the open-source version, or RBAC in Enterprise / GreptimeCloud.
+**Access control**: The open-source version does not enforce database- or table-level tenant isolation — its [authentication](/user-guide/deployments-administration/authentication/overview.md) authorizes a user against every catalog and schema, and the permission check only distinguishes read from write, not the target table. A read-only user can therefore still query any tenant's data. In open source you must enforce tenant isolation in your application layer (or via separate deployments). Enterprise and GreptimeCloud provide RBAC and ACL for true per-tenant access control.
 
 ### What disaster recovery options are available?
 

--- a/docs/faq-and-others/faq.md
+++ b/docs/faq-and-others/faq.md
@@ -308,6 +308,17 @@ ORDER BY files DESC;
 - Manual region migration for load balancing — see [Region Migration Guide](/user-guide/deployments-administration/manage-data/region-migration.md).
 - Automatic region failover for disaster recovery — see [Region Failover](/user-guide/deployments-administration/manage-data/region-failover.md).
 
+### How do I implement multi-tenancy?
+
+The recommended approach is to isolate tenants at the **database** or **table** level, rather than mixing every tenant into one shared table distinguished only by a tag.
+
+- **Database per tenant**: Give each tenant its own [database](/reference/sql/create.md#create-database). This provides the cleanest isolation — separate schemas, per-tenant TTL and other table defaults, and independent access control.
+- **Table per tenant**: Within a shared database, give each tenant its own table (or table prefix). A good fit when tenants share configuration but you still want data-level separation.
+
+Don't worry about ending up with a large number of databases or tables. GreptimeDB's distributed architecture scales horizontally — tables are split into regions spread across datanodes, and you add datanodes as the table and region count grows. There is no hard limit on the number of tables, and performance depends on primary key design rather than table count (see [scalability characteristics](#what-are-greptimedbs-scalability-characteristics)).
+
+For per-tenant access control, use [user-level authentication](/user-guide/deployments-administration/authentication/overview.md) in the open-source version, or RBAC in Enterprise / GreptimeCloud.
+
 ### What disaster recovery options are available?
 
 GreptimeDB offers multiple disaster recovery strategies:

--- a/i18n/zh/docusaurus-plugin-content-docs/current/faq-and-others/faq.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/faq-and-others/faq.md
@@ -312,12 +312,12 @@ ORDER BY files DESC;
 
 推荐按**数据库**或**表**的维度隔离租户，而不是把所有租户塞进同一张表、仅靠一个 tag 区分。
 
-- **每个租户一个数据库**：为每个租户单独建一个[数据库](/reference/sql/create.md#create-database)。隔离最彻底——Schema 独立，TTL 等表默认选项和访问控制都按租户区分。
+- **每个租户一个数据库**：为每个租户单独建一个[数据库](/reference/sql/create.md#create-database)。数据隔离最彻底——Schema 独立，TTL 等表默认选项按租户区分。
 - **每个租户一张表**：在同一个数据库内，给每个租户单独一张表（或用表名前缀）。适合租户共享配置、但仍希望数据层面隔离的场景。
 
 不用担心数据库或表的数量太多。GreptimeDB 的分布式架构可以水平扩展——表会切分成 Region 分布到各个 datanode 上，表和 Region 数量增长时加 datanode 即可。表的数量没有硬性上限，性能主要取决于主键设计而非表数量（参见[扩展能力](#greptimedb-的扩展能力如何)）。
 
-租户级别的访问控制，开源版可用[用户认证](/user-guide/deployments-administration/authentication/overview.md)，企业版 / GreptimeCloud 可用 RBAC。
+**访问控制**：开源版不强制数据库或表级别的租户隔离——内置[认证](/user-guide/deployments-administration/authentication/overview.md)会对每个 catalog 和 schema 授权，权限检查只区分读/写，不检查具体访问哪张表，因此一个只读用户仍然能查询任意租户的数据。开源版需要在应用层自行实现租户隔离（或通过独立部署）。企业版 / GreptimeCloud 提供 RBAC 和 ACL 来实现真正的租户级访问控制。
 
 ### 有哪些灾备方案？
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/faq-and-others/faq.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/faq-and-others/faq.md
@@ -308,6 +308,17 @@ ORDER BY files DESC;
 - 支持手动 Region 迁移进行负载均衡——参见 [Region 迁移指南](/user-guide/deployments-administration/manage-data/region-migration.md)。
 - 自动 Region 故障转移保障容灾——参见 [Region 故障转移](/user-guide/deployments-administration/manage-data/region-failover.md)。
 
+### 如何实现多租户？
+
+推荐按**数据库**或**表**的维度隔离租户，而不是把所有租户塞进同一张表、仅靠一个 tag 区分。
+
+- **每个租户一个数据库**：为每个租户单独建一个[数据库](/reference/sql/create.md#create-database)。隔离最彻底——Schema 独立，TTL 等表默认选项和访问控制都按租户区分。
+- **每个租户一张表**：在同一个数据库内，给每个租户单独一张表（或用表名前缀）。适合租户共享配置、但仍希望数据层面隔离的场景。
+
+不用担心数据库或表的数量太多。GreptimeDB 的分布式架构可以水平扩展——表会切分成 Region 分布到各个 datanode 上，表和 Region 数量增长时加 datanode 即可。表的数量没有硬性上限，性能主要取决于主键设计而非表数量（参见[扩展能力](#greptimedb-的扩展能力如何)）。
+
+租户级别的访问控制，开源版可用[用户认证](/user-guide/deployments-administration/authentication/overview.md)，企业版 / GreptimeCloud 可用 RBAC。
+
 ### 有哪些灾备方案？
 
 GreptimeDB 提供多种灾备策略：

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/faq-and-others/faq.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/faq-and-others/faq.md
@@ -312,12 +312,12 @@ ORDER BY files DESC;
 
 推荐按**数据库**或**表**的维度隔离租户，而不是把所有租户塞进同一张表、仅靠一个 tag 区分。
 
-- **每个租户一个数据库**：为每个租户单独建一个[数据库](/reference/sql/create.md#create-database)。隔离最彻底——Schema 独立，TTL 等表默认选项和访问控制都按租户区分。
+- **每个租户一个数据库**：为每个租户单独建一个[数据库](/reference/sql/create.md#create-database)。数据隔离最彻底——Schema 独立，TTL 等表默认选项按租户区分。
 - **每个租户一张表**：在同一个数据库内，给每个租户单独一张表（或用表名前缀）。适合租户共享配置、但仍希望数据层面隔离的场景。
 
 不用担心数据库或表的数量太多。GreptimeDB 的分布式架构可以水平扩展——表会切分成 Region 分布到各个 datanode 上，表和 Region 数量增长时加 datanode 即可。表的数量没有硬性上限，性能主要取决于主键设计而非表数量（参见[扩展能力](#greptimedb-的扩展能力如何)）。
 
-租户级别的访问控制，开源版可用[用户认证](/user-guide/deployments-administration/authentication/overview.md)，企业版 / GreptimeCloud 可用 RBAC。
+**访问控制**：开源版不强制数据库或表级别的租户隔离——内置[认证](/user-guide/deployments-administration/authentication/overview.md)会对每个 catalog 和 schema 授权，权限检查只区分读/写，不检查具体访问哪张表，因此一个只读用户仍然能查询任意租户的数据。开源版需要在应用层自行实现租户隔离（或通过独立部署）。企业版 / GreptimeCloud 提供 RBAC 和 ACL 来实现真正的租户级访问控制。
 
 ### 有哪些灾备方案？
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/faq-and-others/faq.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/faq-and-others/faq.md
@@ -308,6 +308,17 @@ ORDER BY files DESC;
 - 支持手动 Region 迁移进行负载均衡——参见 [Region 迁移指南](/user-guide/deployments-administration/manage-data/region-migration.md)。
 - 自动 Region 故障转移保障容灾——参见 [Region 故障转移](/user-guide/deployments-administration/manage-data/region-failover.md)。
 
+### 如何实现多租户？
+
+推荐按**数据库**或**表**的维度隔离租户，而不是把所有租户塞进同一张表、仅靠一个 tag 区分。
+
+- **每个租户一个数据库**：为每个租户单独建一个[数据库](/reference/sql/create.md#create-database)。隔离最彻底——Schema 独立，TTL 等表默认选项和访问控制都按租户区分。
+- **每个租户一张表**：在同一个数据库内，给每个租户单独一张表（或用表名前缀）。适合租户共享配置、但仍希望数据层面隔离的场景。
+
+不用担心数据库或表的数量太多。GreptimeDB 的分布式架构可以水平扩展——表会切分成 Region 分布到各个 datanode 上，表和 Region 数量增长时加 datanode 即可。表的数量没有硬性上限，性能主要取决于主键设计而非表数量（参见[扩展能力](#greptimedb-的扩展能力如何)）。
+
+租户级别的访问控制，开源版可用[用户认证](/user-guide/deployments-administration/authentication/overview.md)，企业版 / GreptimeCloud 可用 RBAC。
+
 ### 有哪些灾备方案？
 
 GreptimeDB 提供多种灾备策略：

--- a/versioned_docs/version-1.1/faq-and-others/faq.md
+++ b/versioned_docs/version-1.1/faq-and-others/faq.md
@@ -312,12 +312,12 @@ ORDER BY files DESC;
 
 The recommended approach is to isolate tenants at the **database** or **table** level, rather than mixing every tenant into one shared table distinguished only by a tag.
 
-- **Database per tenant**: Give each tenant its own [database](/reference/sql/create.md#create-database). This provides the cleanest isolation — separate schemas, per-tenant TTL and other table defaults, and independent access control.
+- **Database per tenant**: Give each tenant its own [database](/reference/sql/create.md#create-database). This keeps each tenant's data cleanly separated, with independent schema, TTL, and other table defaults.
 - **Table per tenant**: Within a shared database, give each tenant its own table (or table prefix). A good fit when tenants share configuration but you still want data-level separation.
 
 Don't worry about ending up with a large number of databases or tables. GreptimeDB's distributed architecture scales horizontally — tables are split into regions spread across datanodes, and you add datanodes as the table and region count grows. There is no hard limit on the number of tables, and performance depends on primary key design rather than table count (see [scalability characteristics](#what-are-greptimedbs-scalability-characteristics)).
 
-For per-tenant access control, use [user-level authentication](/user-guide/deployments-administration/authentication/overview.md) in the open-source version, or RBAC in Enterprise / GreptimeCloud.
+**Access control**: The open-source version does not enforce database- or table-level tenant isolation — its [authentication](/user-guide/deployments-administration/authentication/overview.md) authorizes a user against every catalog and schema, and the permission check only distinguishes read from write, not the target table. A read-only user can therefore still query any tenant's data. In open source you must enforce tenant isolation in your application layer (or via separate deployments). Enterprise and GreptimeCloud provide RBAC and ACL for true per-tenant access control.
 
 ### What disaster recovery options are available?
 

--- a/versioned_docs/version-1.1/faq-and-others/faq.md
+++ b/versioned_docs/version-1.1/faq-and-others/faq.md
@@ -308,6 +308,17 @@ ORDER BY files DESC;
 - Manual region migration for load balancing — see [Region Migration Guide](/user-guide/deployments-administration/manage-data/region-migration.md).
 - Automatic region failover for disaster recovery — see [Region Failover](/user-guide/deployments-administration/manage-data/region-failover.md).
 
+### How do I implement multi-tenancy?
+
+The recommended approach is to isolate tenants at the **database** or **table** level, rather than mixing every tenant into one shared table distinguished only by a tag.
+
+- **Database per tenant**: Give each tenant its own [database](/reference/sql/create.md#create-database). This provides the cleanest isolation — separate schemas, per-tenant TTL and other table defaults, and independent access control.
+- **Table per tenant**: Within a shared database, give each tenant its own table (or table prefix). A good fit when tenants share configuration but you still want data-level separation.
+
+Don't worry about ending up with a large number of databases or tables. GreptimeDB's distributed architecture scales horizontally — tables are split into regions spread across datanodes, and you add datanodes as the table and region count grows. There is no hard limit on the number of tables, and performance depends on primary key design rather than table count (see [scalability characteristics](#what-are-greptimedbs-scalability-characteristics)).
+
+For per-tenant access control, use [user-level authentication](/user-guide/deployments-administration/authentication/overview.md) in the open-source version, or RBAC in Enterprise / GreptimeCloud.
+
 ### What disaster recovery options are available?
 
 GreptimeDB offers multiple disaster recovery strategies:


### PR DESCRIPTION
Add a "How do I implement multi-tenancy?" FAQ entry to the Deployment & Operations section, recommending isolation by database or table dimension and noting that a large number of tables is fine given GreptimeDB's horizontally scalable architecture.

Applied to EN and ZH, current and v1.1.

Ref: https://github.com/GreptimeTeam/greptimedb/issues/8689