### PR TITLE
docs: improve repository contribution guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GreptimeDB Discussions
+    url: https://github.com/orgs/GreptimeTeam/discussions
+    about: Ask GreptimeDB usage and support questions
+  - name: Greptime community Slack
+    url: https://greptime.com/slack
+    about: Talk with GreptimeDB users and maintainers

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: GreptimeDB product issues
+    url: https://github.com/GreptimeTeam/greptimedb/issues/new/choose
+    about: Report a GreptimeDB bug or request a product feature
   - name: GreptimeDB Discussions
     url: https://github.com/orgs/GreptimeTeam/discussions
     about: Ask GreptimeDB usage and support questions

--- a/.github/ISSUE_TEMPLATE/documentation-problem.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-problem.yml
@@ -1,6 +1,6 @@
 name: Documentation problem
 description: Report incorrect, missing, outdated, or broken documentation
-title: "[Docs]: "
+title: "[Docs Bug]: "
 labels: ["documentation", "bug"]
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/documentation-problem.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-problem.yml
@@ -1,0 +1,45 @@
+name: Documentation problem
+description: Report incorrect, missing, outdated, or broken documentation
+title: "[Docs]: "
+labels: ["documentation", "bug"]
+body:
+  - type: input
+    id: page
+    attributes:
+      label: Page URL
+      description: Link to the affected page.
+      placeholder: https://docs.greptime.com/...
+    validations:
+      required: true
+
+  - type: input
+    id: scope
+    attributes:
+      label: Documentation version and language
+      description: For example, Nightly English, v1.1 Chinese, or all versions.
+      placeholder: Nightly English
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is wrong?
+      description: Describe the incorrect, missing, outdated, or broken content.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What should the documentation say or show?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add screenshots, logs, source links, or other useful context.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/documentation-request.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-request.yml
@@ -1,0 +1,37 @@
+name: Documentation request
+description: Suggest new documentation or an improvement to existing content
+title: "[Docs]: "
+labels: ["documentation", "enhancement"]
+body:
+  - type: textarea
+    id: need
+    attributes:
+      label: What documentation do you need?
+      description: Describe the task or question the documentation should help with.
+    validations:
+      required: true
+
+  - type: textarea
+    id: audience
+    attributes:
+      label: Who is this documentation for?
+      description: Describe the reader and their use case.
+    validations:
+      required: true
+
+  - type: input
+    id: scope
+    attributes:
+      label: Versions and languages
+      description: For example, Nightly and v1.1, English and Chinese.
+      placeholder: Nightly, English
+    validations:
+      required: false
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Suggested content
+      description: Outline the content or link to useful references.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/documentation-request.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-request.yml
@@ -1,6 +1,6 @@
 name: Documentation request
 description: Suggest new documentation or an improvement to existing content
-title: "[Docs]: "
+title: "[Docs Request]: "
 labels: ["documentation", "enhancement"]
 body:
   - type: textarea

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,19 @@
-## What's Changed in this PR
+## What changed
 
-<!--
-    Please confirm that you have revised the corresponding version of the document, ensuring it can run on the corresponding version of GreptimeDB. If other versions are involved, make the necessary adjustments accordingly.
-    Note: `nightly` for the weekly built version, which is not released yet.
--->
+<!-- Explain what changed and why. Link a related issue when applicable. -->
 
-*Describe the change in this PR*
+## Scope
 
+- Documentation versions:
+- Languages:
+
+## Verification
+
+<!-- List commands run and any manual checks. -->
 
 ## Checklist
 
-- [ ] Please confirm that all corresponding versions of the documents have been revised.
-- [ ] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
-- [ ] This change requires follow-up update in localized docs.
+- [ ] I verified the content against the applicable GreptimeDB version.
+- [ ] I updated the relevant documentation versions and languages, or explained why not.
+- [ ] I checked changed links and anchors.
+- [ ] I updated navigation when the document structure changed.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,8 +4,8 @@
 
 ## Scope
 
-- Documentation versions:
-- Languages:
+- Documentation versions: <!-- e.g. Nightly, 1.1 -->
+- Languages: <!-- e.g. English, Chinese -->
 
 ## Verification
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,9 @@ build
 
 .temp_patch
 
-# Root AGENTS.md is the shared project guide; CLAUDE.md symlinks to it.
+# Root AGENTS.md is the shared project guide; CLAUDE.md imports it.
 # Personal or machine-local agent overrides stay untracked.
 /.local/
-!CLAUDE.md
 
 # Transpiled JavaScript files (TypeScript sources are tracked)
 docusaurus.config.js

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,10 @@ build
 
 .temp_patch
 
-Claude.md
+# Root AGENTS.md is the shared project guide; CLAUDE.md symlinks to it.
+# Personal or machine-local agent overrides stay untracked.
+/.local/
+!CLAUDE.md
 
 # Transpiled JavaScript files (TypeScript sources are tracked)
 docusaurus.config.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,124 +1,114 @@
 # AGENTS.md
 
-Guidance for coding agents (Claude Code, Codex, and others) and contributors
-working in this repository. `CLAUDE.md` is a symlink to this file. If
-`.local/AGENTS.md` or `.local/CLAUDE.md` exists, read it as well; it contains
-personal or machine-local overrides and is not tracked. Put local instructions
-there instead of editing this shared guide for one machine.
+Guidance for coding agents and contributors working in this repository.
+`CLAUDE.md` is a symlink to this file. Also read `.local/AGENTS.md` or
+`.local/CLAUDE.md` when present; those files contain untracked local overrides.
 
-This repository contains the Docusaurus sources for the GreptimeDB
-documentation published at <https://docs.greptime.com> and
-<https://docs.greptime.cn>.
+This is the short operating guide. [`CONTRIBUTING.md`](CONTRIBUTING.md) is the
+source of truth for document structure, links, images, placeholders, and the
+contribution flow.
 
-## Core commands
+## Setup and commands
+
+Use Node.js 20 or newer and pnpm 8.6.0. CI currently runs Node.js 22.
 
 | Task | Command |
 | --- | --- |
 | Install dependencies | `pnpm install` |
-| Preview English docs | `pnpm start` |
-| Preview Chinese docs | `pnpm start:zh` |
-| Build English docs | `pnpm build` |
-| Build Chinese docs | `DOC_LANG=zh pnpm build` |
-| Strict English link check | `DOC_LANG=en pnpm check:links` |
-| Strict Chinese link check | `DOC_LANG=zh pnpm check:links` |
-| Unit tests | `pnpm test` |
-| Type check | `pnpm typecheck` |
-| Preview a backport | `pnpm backport:dry` |
-| Backport the last commit | `pnpm backport` |
+| Preview English | `pnpm start` |
+| Preview Chinese | `pnpm start:zh` |
+| Build English | `pnpm build` |
+| Build Chinese | `DOC_LANG=zh pnpm build` |
+| Check English links and anchors | `DOC_LANG=en pnpm check:links` |
+| Check Chinese links and anchors | `DOC_LANG=zh pnpm check:links` |
+| Run unit tests | `pnpm test` |
+| Run TypeScript checks | `pnpm typecheck` |
+| Preview the latest-version backport | `pnpm backport:dry` |
+| Apply the latest-version backport | `pnpm backport` |
 
-Use pnpm; do not update `package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`
-unless the task changes dependencies. CI uses Node.js 22 and pnpm 8.6.0.
+`DOC_LANG` selects the locale. `prestart` and `prebuild` run
+`pnpm sync-skill`; do not bypass them when checking the site. The strict link
+commands build Nightly and every released version from 1.0 onward.
+
+Use pnpm. Dependency changes should update `pnpm-lock.yaml`; docs-only changes
+must not touch lockfiles.
 
 ## Repository map
 
-- `docs/`: English Nightly documentation for unreleased GreptimeDB changes.
-- `versioned_docs/version-<version>/`: English snapshots for released versions.
+- `docs/`: English Nightly docs for unreleased changes.
+- `versioned_docs/version-<version>/`: English docs for released versions.
 - `i18n/zh/docusaurus-plugin-content-docs/current/`: Chinese Nightly docs.
 - `i18n/zh/docusaurus-plugin-content-docs/version-<version>/`: Chinese released
   docs.
-- `sidebars.ts` and `versioned_sidebars/`: English navigation.
-- `i18n/zh/docusaurus-plugin-content-docs/*.json`: Chinese navigation labels.
-- `versions.json`: released documentation versions, newest first.
-- `variables/`: values used by `VAR::<name>` placeholders for Nightly and each
-  released version.
-- `src/components/`, `src/theme/`, and `src/plugins/`: Docusaurus components,
-  theme overrides, and build plugins.
-- `skills/`: source files for published GreptimeDB agent skills.
-- `static/`: images and other site assets. Some files here are generated.
+- `sidebars.ts`, `versioned_sidebars/`, and the JSON files under
+  `i18n/zh/docusaurus-plugin-content-docs/`: navigation.
+- `versions.json`: released doc versions, newest first.
+- `variables/`: values for `VAR::<name>` placeholders.
+- `src/components/`, `src/theme/`, and `src/plugins/`: Docusaurus code.
+- `skills/`: sources for published GreptimeDB agent skills.
+- `static/`: site assets and generated skill copies.
 - `blog/`: release notes.
 
-## Read before changing docs
+High-signal files are `docusaurus.config.ts`, `package.json`, `sidebars.ts`,
+`.github/pull_request_template.md`, and the files linked from the relevant
+section of `CONTRIBUTING.md`.
 
-- [`CONTRIBUTING.md`](CONTRIBUTING.md) for document structure, links, images,
-  placeholders, and contribution flow.
-- [`docusaurus.config.ts`](docusaurus.config.ts) for locales, version routing,
-  excluded templates, and build behavior.
-- [`sidebars.ts`](sidebars.ts) when adding, moving, or deleting Nightly docs.
-- [`scripts/backport-docs.js`](scripts/backport-docs.js) before using the
-  backport command.
+## Contribution workflow
 
-For link and anchor work, also read:
+1. Read `CONTRIBUTING.md` and the existing pages around the change.
+2. Decide the version and locale scope before editing.
+3. Make the smallest consistent change. Add front matter, an H1, and navigation
+   entries for a new page.
+4. Preview or build the affected locale.
+5. Run the checks required by the change.
+6. Review the complete diff for unintended versions, locales, generated files,
+   and lockfile changes.
+7. Open a PR with a Conventional Commit-style title and complete
+   `.github/pull_request_template.md` accurately.
 
-- [`src/components/AnchorAlias/index.tsx`](src/components/AnchorAlias/index.tsx)
-- [`src/theme/MDXComponents.js`](src/theme/MDXComponents.js)
+Use `docs/` and the Chinese `current/` tree for unreleased features. Apply a fix
+to released versions only where the same problem exists and the documented
+behavior is valid for that GreptimeDB release. Keep English and Chinese aligned
+in meaning, but do not copy English headings or prose blindly into Chinese.
 
-## Version and locale scope
-
-Decide the intended versions and locales before editing:
-
-- Put unreleased features in `docs/` and the Chinese `current/` tree.
-- Apply fixes to every released version where the same problem exists, but do
-  not backport behavior or options that the corresponding GreptimeDB release
-  does not support.
-- Keep English and Chinese documents aligned in meaning. Do not copy English
-  prose, headings, or anchors blindly into Chinese files.
-- Treat versioned docs as user-facing release documentation, not generated
-  files that can be overwritten without review.
-- When creating a released documentation version, keep `versions.json`,
-  `versioned_docs/`, `versioned_sidebars/`, the Chinese version directory and
-  sidebar JSON, and `variables/variables-<version>.ts` consistent.
+Versioned docs are user-facing sources, not disposable generated files. When
+creating a version, keep `versions.json`, `versioned_docs/`,
+`versioned_sidebars/`, the matching Chinese directory and sidebar JSON, and
+`variables/variables-<version>.ts` consistent.
 
 `pnpm backport` applies the last commit to the latest released English and
-localized docs. Run `pnpm backport:dry` first, then inspect the resulting diff;
-the script cannot decide whether a change is semantically valid for that
-release.
+Chinese docs. Run `pnpm backport:dry` first and review the result. The script
+cannot determine whether a change is valid for that release.
 
-## Writing and technical accuracy
+## Writing and accuracy
 
 - Use plain, direct English. Avoid marketing filler and vague claims.
-- Write Chinese naturally for Chinese developers; avoid literal translation
-  and English sentence structure.
-- Keep commands, SQL, configuration keys, API names, and code examples exact
-  and copy-pasteable.
+- Write Chinese naturally for Chinese developers; avoid literal translation.
+- Keep commands, SQL, configuration keys, API names, and examples exact and
+  copy-pasteable.
 - Verify version-sensitive behavior against the applicable GreptimeDB release,
-  source code, or authoritative reference. Do not infer it from a nearby page.
-- New documentation pages need suitable front matter, including `keywords` and
-  `description`, an H1 title, and the appropriate sidebar entry.
+  source code, or an authoritative reference.
+- Do not infer behavior from a nearby page or a newer documentation version.
 
 ## Links and anchors
 
-Always include the `.md` extension in links to documentation source files:
+Include the `.md` extension in links to documentation source files:
 
 ```markdown
 [Ingest data](/user-guide/ingest-data/overview.md)
 ```
 
-Root-relative documentation paths are resolved inside the reader's current
-documentation version. Prefer them for links that should remain within that
-version.
+Root-relative paths keep readers in their current documentation version.
 
-Before changing a link, read both the source paragraph and the destination
-section. A link can intentionally land on an overview or option section that
-routes the reader to a more detailed page. Do not replace a valid target only
-because another page appears more direct. A passing checker proves that a
-target exists; it does not prove that the target is semantically correct.
+Read the source paragraph and the destination section before changing a link.
+A target can intentionally be an overview or option section that sends readers
+to a detailed page. A green link checker proves that the target exists, not
+that it is the right target.
 
-Heading slugs are public URLs. Renaming a heading or replacing an established
-anchor can break external links. Preserve stable anchors when the content still
-represents the same concept.
+Heading slugs are public URLs. Preserve established anchors when a heading is
+renamed or translated and the section still represents the same concept.
 
-Use the global `AnchorAlias` MDX component when a renamed or translated heading
-needs to retain an existing anchor:
+Use the global `AnchorAlias` component for a legacy or cross-locale slug:
 
 ```mdx
 <AnchorAlias id="upload-a-pipeline" />
@@ -126,50 +116,39 @@ needs to retain an existing anchor:
 ## Upload the Pipeline
 ```
 
-Rules for `AnchorAlias`:
+`AnchorAlias` is registered in `src/theme/MDXComponents.js`, so individual
+documents do not import it. It also registers the ID with Docusaurus's
+broken-link collector; a raw `<span id="...">` does not.
 
-- Place it immediately before the heading for the exact section represented by
-  the alias.
-- Use the incoming legacy or cross-locale slug as `id`; keep IDs unique within
-  the page.
-- Do not import it in individual documents. It is registered globally in
-  `src/theme/MDXComponents.js`.
-- Use it instead of a raw `<span id="...">`; the component also registers the
-  anchor with Docusaurus's broken-link collector.
-- Do not add or move an alias merely to silence the checker. If the source link
-  intends a different section, fix the link instead.
+Place an alias immediately before the exact heading it represents. Keep IDs
+unique within the page. Never add or move an alias only to silence the checker;
+fix the source link when it intends a different section.
 
-Strict link checks build Nightly and every released version from 1.0 onward.
-Run them for both locales after changing links, headings, routes, version
-configuration, or MDX anchor handling. Older 0.x docs are outside that strict
-CI scope unless the task explicitly includes them.
+Run both strict link commands after changing links, headings, routes, version
+configuration, localization, or MDX anchor handling. The strict CI scope
+excludes 0.x docs unless the task includes them.
 
-## Generated files and placeholders
+## Generated files
 
-- Edit `skills/<name>/SKILL.md`, not `static/SKILL.md` or
-  `static/skills/**`. `pnpm sync-skill`, `prestart`, and `prebuild` regenerate
-  the static copies.
-- Do not edit `build/`, `.docusaurus/`, or transpiled JavaScript generated from
-  tracked TypeScript.
+- Edit `skills/<name>/SKILL.md`, not `static/SKILL.md` or `static/skills/**`.
+  `pnpm sync-skill` regenerates the static copies.
+- Do not edit `build/`, `.docusaurus/`, or JavaScript transpiled from tracked
+  TypeScript.
 - Generate `docs/reference/sql/functions/df-functions.md` with
-  `ruby src/misc/update_functions.rb`, then update the corresponding localized
-  file as described in `CONTRIBUTING.md`.
-- Define `VAR::<name>` values in the matching file under `variables/`. A
-  versioned document must not silently fall back to a value for another
-  release.
+  `ruby src/misc/update_functions.rb`, then update the matching localized file.
+- Define placeholders in the matching `variables/variables-<version>.ts`.
+  Never let a versioned page silently use another release's value.
 
-## Before opening or updating a PR
+## Checks before a PR
 
-1. Review the complete diff for unintended versions, locales, generated files,
-   and lockfile changes.
-2. Run `git diff --check`.
-3. Run `pnpm test` for code, plugin, or configuration changes.
-4. Run the applicable locale builds.
-5. Run both strict link checks for link, heading, route, version, localization,
-   or MDX changes.
-6. Manually inspect changed link destinations; do not rely only on build
-   success.
-7. Update navigation when documents are added, moved, or removed.
-8. Use a Conventional Commit-style PR title and complete
-   [`.github/pull_request_template.md`](.github/pull_request_template.md)
-   accurately, including version and localization scope.
+Always run `git diff --check` and inspect the diff manually.
+
+| Change | Required checks |
+| --- | --- |
+| Documentation text only | Build the affected locale |
+| Links, headings, routes, versions, or localization | Both strict link commands |
+| Components, plugins, theme, or configuration | `pnpm test`, `pnpm typecheck`, and affected builds |
+| Navigation | Build each affected locale and inspect the sidebar |
+
+CI also checks Markdown and spelling. Build success does not replace manual
+review of technical claims and link destinations.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,175 @@
+# AGENTS.md
+
+Guidance for coding agents (Claude Code, Codex, and others) and contributors
+working in this repository. `CLAUDE.md` is a symlink to this file. If
+`.local/AGENTS.md` or `.local/CLAUDE.md` exists, read it as well; it contains
+personal or machine-local overrides and is not tracked. Put local instructions
+there instead of editing this shared guide for one machine.
+
+This repository contains the Docusaurus sources for the GreptimeDB
+documentation published at <https://docs.greptime.com> and
+<https://docs.greptime.cn>.
+
+## Core commands
+
+| Task | Command |
+| --- | --- |
+| Install dependencies | `pnpm install` |
+| Preview English docs | `pnpm start` |
+| Preview Chinese docs | `pnpm start:zh` |
+| Build English docs | `pnpm build` |
+| Build Chinese docs | `DOC_LANG=zh pnpm build` |
+| Strict English link check | `DOC_LANG=en pnpm check:links` |
+| Strict Chinese link check | `DOC_LANG=zh pnpm check:links` |
+| Unit tests | `pnpm test` |
+| Type check | `pnpm typecheck` |
+| Preview a backport | `pnpm backport:dry` |
+| Backport the last commit | `pnpm backport` |
+
+Use pnpm; do not update `package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`
+unless the task changes dependencies. CI uses Node.js 22 and pnpm 8.6.0.
+
+## Repository map
+
+- `docs/`: English Nightly documentation for unreleased GreptimeDB changes.
+- `versioned_docs/version-<version>/`: English snapshots for released versions.
+- `i18n/zh/docusaurus-plugin-content-docs/current/`: Chinese Nightly docs.
+- `i18n/zh/docusaurus-plugin-content-docs/version-<version>/`: Chinese released
+  docs.
+- `sidebars.ts` and `versioned_sidebars/`: English navigation.
+- `i18n/zh/docusaurus-plugin-content-docs/*.json`: Chinese navigation labels.
+- `versions.json`: released documentation versions, newest first.
+- `variables/`: values used by `VAR::<name>` placeholders for Nightly and each
+  released version.
+- `src/components/`, `src/theme/`, and `src/plugins/`: Docusaurus components,
+  theme overrides, and build plugins.
+- `skills/`: source files for published GreptimeDB agent skills.
+- `static/`: images and other site assets. Some files here are generated.
+- `blog/`: release notes.
+
+## Read before changing docs
+
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) for document structure, links, images,
+  placeholders, and contribution flow.
+- [`docusaurus.config.ts`](docusaurus.config.ts) for locales, version routing,
+  excluded templates, and build behavior.
+- [`sidebars.ts`](sidebars.ts) when adding, moving, or deleting Nightly docs.
+- [`scripts/backport-docs.js`](scripts/backport-docs.js) before using the
+  backport command.
+
+For link and anchor work, also read:
+
+- [`src/components/AnchorAlias/index.tsx`](src/components/AnchorAlias/index.tsx)
+- [`src/theme/MDXComponents.js`](src/theme/MDXComponents.js)
+
+## Version and locale scope
+
+Decide the intended versions and locales before editing:
+
+- Put unreleased features in `docs/` and the Chinese `current/` tree.
+- Apply fixes to every released version where the same problem exists, but do
+  not backport behavior or options that the corresponding GreptimeDB release
+  does not support.
+- Keep English and Chinese documents aligned in meaning. Do not copy English
+  prose, headings, or anchors blindly into Chinese files.
+- Treat versioned docs as user-facing release documentation, not generated
+  files that can be overwritten without review.
+- When creating a released documentation version, keep `versions.json`,
+  `versioned_docs/`, `versioned_sidebars/`, the Chinese version directory and
+  sidebar JSON, and `variables/variables-<version>.ts` consistent.
+
+`pnpm backport` applies the last commit to the latest released English and
+localized docs. Run `pnpm backport:dry` first, then inspect the resulting diff;
+the script cannot decide whether a change is semantically valid for that
+release.
+
+## Writing and technical accuracy
+
+- Use plain, direct English. Avoid marketing filler and vague claims.
+- Write Chinese naturally for Chinese developers; avoid literal translation
+  and English sentence structure.
+- Keep commands, SQL, configuration keys, API names, and code examples exact
+  and copy-pasteable.
+- Verify version-sensitive behavior against the applicable GreptimeDB release,
+  source code, or authoritative reference. Do not infer it from a nearby page.
+- New documentation pages need suitable front matter, including `keywords` and
+  `description`, an H1 title, and the appropriate sidebar entry.
+
+## Links and anchors
+
+Always include the `.md` extension in links to documentation source files:
+
+```markdown
+[Ingest data](/user-guide/ingest-data/overview.md)
+```
+
+Root-relative documentation paths are resolved inside the reader's current
+documentation version. Prefer them for links that should remain within that
+version.
+
+Before changing a link, read both the source paragraph and the destination
+section. A link can intentionally land on an overview or option section that
+routes the reader to a more detailed page. Do not replace a valid target only
+because another page appears more direct. A passing checker proves that a
+target exists; it does not prove that the target is semantically correct.
+
+Heading slugs are public URLs. Renaming a heading or replacing an established
+anchor can break external links. Preserve stable anchors when the content still
+represents the same concept.
+
+Use the global `AnchorAlias` MDX component when a renamed or translated heading
+needs to retain an existing anchor:
+
+```mdx
+<AnchorAlias id="upload-a-pipeline" />
+
+## Upload the Pipeline
+```
+
+Rules for `AnchorAlias`:
+
+- Place it immediately before the heading for the exact section represented by
+  the alias.
+- Use the incoming legacy or cross-locale slug as `id`; keep IDs unique within
+  the page.
+- Do not import it in individual documents. It is registered globally in
+  `src/theme/MDXComponents.js`.
+- Use it instead of a raw `<span id="...">`; the component also registers the
+  anchor with Docusaurus's broken-link collector.
+- Do not add or move an alias merely to silence the checker. If the source link
+  intends a different section, fix the link instead.
+
+Strict link checks build Nightly and every released version from 1.0 onward.
+Run them for both locales after changing links, headings, routes, version
+configuration, or MDX anchor handling. Older 0.x docs are outside that strict
+CI scope unless the task explicitly includes them.
+
+## Generated files and placeholders
+
+- Edit `skills/<name>/SKILL.md`, not `static/SKILL.md` or
+  `static/skills/**`. `pnpm sync-skill`, `prestart`, and `prebuild` regenerate
+  the static copies.
+- Do not edit `build/`, `.docusaurus/`, or transpiled JavaScript generated from
+  tracked TypeScript.
+- Generate `docs/reference/sql/functions/df-functions.md` with
+  `ruby src/misc/update_functions.rb`, then update the corresponding localized
+  file as described in `CONTRIBUTING.md`.
+- Define `VAR::<name>` values in the matching file under `variables/`. A
+  versioned document must not silently fall back to a value for another
+  release.
+
+## Before opening or updating a PR
+
+1. Review the complete diff for unintended versions, locales, generated files,
+   and lockfile changes.
+2. Run `git diff --check`.
+3. Run `pnpm test` for code, plugin, or configuration changes.
+4. Run the applicable locale builds.
+5. Run both strict link checks for link, heading, route, version, localization,
+   or MDX changes.
+6. Manually inspect changed link destinations; do not rely only on build
+   success.
+7. Update navigation when documents are added, moved, or removed.
+8. Use a Conventional Commit-style PR title and complete
+   [`.github/pull_request_template.md`](.github/pull_request_template.md)
+   accurately, including version and localization scope.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,8 +55,9 @@ must not touch lockfiles.
   Chinese `current/` tree for unreleased features. Change a released version
   only when the content is valid for that GreptimeDB release.
 - Treat versioned docs as user-facing source files, not disposable generated
-  output. Keep English and Chinese aligned in meaning, but write each language
-  naturally.
+  output. When adding or expanding user-facing documentation, update the
+  corresponding Chinese page in the same PR. Keep English and Chinese aligned
+  in meaning, but write each language naturally.
 - Verify version-sensitive claims against the applicable release, source code,
   or an authoritative reference. Do not infer behavior from a nearby page or a
   newer documentation version.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,17 @@
 # AGENTS.md
 
-Guidance for coding agents and contributors working in this repository.
-`CLAUDE.md` is a symlink to this file. Also read `.local/AGENTS.md` or
-`.local/CLAUDE.md` when present; those files contain untracked local overrides.
+Guidance for coding agents working in this repository. `CLAUDE.md` imports this
+file. Also read `.local/AGENTS.md` or `.local/CLAUDE.md` when present; those
+files contain untracked, machine-local instructions.
 
-This is the short operating guide. [`CONTRIBUTING.md`](CONTRIBUTING.md) is the
-source of truth for document structure, links, images, placeholders, and the
-contribution flow.
+[`CONTRIBUTING.md`](CONTRIBUTING.md) is the source of truth for contribution
+workflow, document structure, links, images, placeholders, and reference
+snippets. Read it before editing.
 
 ## Setup and commands
 
-Use Node.js 20 or newer and pnpm 8.6.0. CI currently runs Node.js 22.
+Use Node.js 22 and pnpm 8.6.0 to match the main build CI. `package.json`
+currently allows Node.js 18 or newer.
 
 | Task | Command |
 | --- | --- |
@@ -26,9 +27,9 @@ Use Node.js 20 or newer and pnpm 8.6.0. CI currently runs Node.js 22.
 | Preview the latest-version backport | `pnpm backport:dry` |
 | Apply the latest-version backport | `pnpm backport` |
 
-`DOC_LANG` selects the locale. `prestart` and `prebuild` run
-`pnpm sync-skill`; do not bypass them when checking the site. The strict link
-commands build Nightly and every released version from 1.0 onward.
+`DOC_LANG` selects the locale. The repository enables pnpm pre/post scripts;
+`prestart` and `prebuild` run `pnpm sync-skill`. Use the package scripts so
+local and CI builds include the same generated skill content.
 
 Use pnpm. Dependency changes should update `pnpm-lock.yaml`; docs-only changes
 must not touch lockfiles.
@@ -36,112 +37,53 @@ must not touch lockfiles.
 ## Repository map
 
 - `docs/`: English Nightly docs for unreleased changes.
-- `versioned_docs/version-<version>/`: English docs for released versions.
+- `versioned_docs/version-<version>/`: English released docs.
 - `i18n/zh/docusaurus-plugin-content-docs/current/`: Chinese Nightly docs.
 - `i18n/zh/docusaurus-plugin-content-docs/version-<version>/`: Chinese released
   docs.
 - `sidebars.ts`, `versioned_sidebars/`, and the JSON files under
   `i18n/zh/docusaurus-plugin-content-docs/`: navigation.
-- `versions.json`: released doc versions, newest first.
-- `variables/`: values for `VAR::<name>` placeholders.
-- `src/components/`, `src/theme/`, and `src/plugins/`: Docusaurus code.
-- `skills/`: sources for published GreptimeDB agent skills.
+- `variables/`: version-specific `VAR::<name>` values.
+- `src/`: Docusaurus components, theme overrides, plugins, and scripts.
+- `skills/`: source files for published agent skills.
 - `static/`: site assets and generated skill copies.
 - `blog/`: release notes.
 
-High-signal files are `docusaurus.config.ts`, `package.json`, `sidebars.ts`,
-`.github/pull_request_template.md`, and the files linked from the relevant
-section of `CONTRIBUTING.md`.
+## Rules agents must follow
 
-## Contribution workflow
+- Decide the version and language scope before editing. Use `docs/` and the
+  Chinese `current/` tree for unreleased features. Change a released version
+  only when the content is valid for that GreptimeDB release.
+- Treat versioned docs as user-facing source files, not disposable generated
+  output. Keep English and Chinese aligned in meaning, but write each language
+  naturally.
+- Verify version-sensitive claims against the applicable release, source code,
+  or an authoritative reference. Do not infer behavior from a nearby page or a
+  newer documentation version.
+- Read the source paragraph and destination section before changing a link. A
+  green link checker proves that the target exists, not that it is the intended
+  target.
+- Preserve established heading URLs when the section still represents the
+  same concept. Use the global `AnchorAlias` component for a legacy or
+  cross-locale slug; a raw `<span id="...">` is not registered with
+  Docusaurus's broken-link collector. Place the alias immediately before the
+  exact heading it represents, and never move one merely to silence the
+  checker.
+- Edit `skills/<name>/SKILL.md`, not generated files under `static/skills/` or
+  `static/SKILL.md`. Do not edit `build/`, `.docusaurus/`, or JavaScript
+  transpiled from tracked TypeScript.
+- Run `pnpm backport:dry` before `pnpm backport` and inspect the result. The
+  script cannot decide whether a change is valid for a released version.
 
-1. Read `CONTRIBUTING.md` and the existing pages around the change.
-2. Decide the version and locale scope before editing.
-3. Make the smallest consistent change. Add front matter, an H1, and navigation
-   entries for a new page.
-4. Preview or build the affected locale.
-5. Run the checks required by the change.
-6. Review the complete diff for unintended versions, locales, generated files,
-   and lockfile changes.
-7. Open a PR with a Conventional Commit-style title and complete
-   `.github/pull_request_template.md` accurately.
-
-Use `docs/` and the Chinese `current/` tree for unreleased features. Apply a fix
-to released versions only where the same problem exists and the documented
-behavior is valid for that GreptimeDB release. Keep English and Chinese aligned
-in meaning, but do not copy English headings or prose blindly into Chinese.
-
-Versioned docs are user-facing sources, not disposable generated files. When
-creating a version, keep `versions.json`, `versioned_docs/`,
-`versioned_sidebars/`, the matching Chinese directory and sidebar JSON, and
-`variables/variables-<version>.ts` consistent.
-
-`pnpm backport` applies the last commit to the latest released English and
-Chinese docs. Run `pnpm backport:dry` first and review the result. The script
-cannot determine whether a change is valid for that release.
-
-## Writing and accuracy
-
-- Use plain, direct English. Avoid marketing filler and vague claims.
-- Write Chinese naturally for Chinese developers; avoid literal translation.
-- Keep commands, SQL, configuration keys, API names, and examples exact and
-  copy-pasteable.
-- Verify version-sensitive behavior against the applicable GreptimeDB release,
-  source code, or an authoritative reference.
-- Do not infer behavior from a nearby page or a newer documentation version.
-
-## Links and anchors
-
-Include the `.md` extension in links to documentation source files:
-
-```markdown
-[Ingest data](/user-guide/ingest-data/overview.md)
-```
-
-Root-relative paths keep readers in their current documentation version.
-
-Read the source paragraph and the destination section before changing a link.
-A target can intentionally be an overview or option section that sends readers
-to a detailed page. A green link checker proves that the target exists, not
-that it is the right target.
-
-Heading slugs are public URLs. Preserve established anchors when a heading is
-renamed or translated and the section still represents the same concept.
-
-Use the global `AnchorAlias` component for a legacy or cross-locale slug:
-
-```mdx
-<AnchorAlias id="upload-a-pipeline" />
-
-## Upload the Pipeline
-```
-
-`AnchorAlias` is registered in `src/theme/MDXComponents.js`, so individual
-documents do not import it. It also registers the ID with Docusaurus's
-broken-link collector; a raw `<span id="...">` does not.
-
-Place an alias immediately before the exact heading it represents. Keep IDs
-unique within the page. Never add or move an alias only to silence the checker;
-fix the source link when it intends a different section.
-
-Run both strict link commands after changing links, headings, routes, version
-configuration, localization, or MDX anchor handling. The strict CI scope
-excludes 0.x docs unless the task includes them.
-
-## Generated files
-
-- Edit `skills/<name>/SKILL.md`, not `static/SKILL.md` or `static/skills/**`.
-  `pnpm sync-skill` regenerates the static copies.
-- Do not edit `build/`, `.docusaurus/`, or JavaScript transpiled from tracked
-  TypeScript.
-- Generate `docs/reference/sql/functions/df-functions.md` with
-  `ruby src/misc/update_functions.rb`, then update the matching localized file.
-- Define placeholders in the matching `variables/variables-<version>.ts`.
-  Never let a versioned page silently use another release's value.
+See the detailed guidance in
+[`CONTRIBUTING.md`](CONTRIBUTING.md#add-or-update-documentation),
+[`Links and anchors`](CONTRIBUTING.md#links-and-anchors), and
+[`Variables and generated files`](CONTRIBUTING.md#variables-and-generated-files).
 
 ## Checks before a PR
 
-Always run `git diff --check` and inspect the diff manually.
+Always run `git diff --check` and review the complete diff for unintended
+versions, languages, generated files, and lockfile changes.
 
 | Change | Required checks |
 | --- | --- |
@@ -150,5 +92,5 @@ Always run `git diff --check` and inspect the diff manually.
 | Components, plugins, theme, or configuration | `pnpm test`, `pnpm typecheck`, and affected builds |
 | Navigation | Build each affected locale and inspect the sidebar |
 
-CI also checks Markdown and spelling. Build success does not replace manual
-review of technical claims and link destinations.
+CI also checks Markdown, spelling, front matter, and the PR title. Build success
+does not replace manual review of technical claims and link destinations.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,260 +1,197 @@
 # Contributing to GreptimeDB Docs
 
-Thank you for your interest in contributing to the GreptimeDB Docs repository!
-We appreciate your involvement in this open-source project and welcome contributions from the community.
+Contributions to the GreptimeDB documentation are welcome. Use an issue to
+report incorrect, missing, or outdated documentation. Use a pull request for a
+concrete fix or new document.
 
-## How to contribute
+For GreptimeDB product bugs and feature requests, use the
+[GreptimeDB repository](https://github.com/GreptimeTeam/greptimedb/issues).
 
-We welcome contributions to the GreptimeDB Docs repository in the following ways:
+## Before you start
 
-- Submit an issue to report a problem or suggest an improvement.
-- Submit a pull request to add new documents.
+- Find the documentation version and language affected by the change.
+- Read the existing page and nearby pages before changing structure or links.
+- Verify technical claims against the applicable GreptimeDB release.
+- Keep a pull request focused on one logical change.
 
+## Set up the project
 
-## Project structure
-
-This project uses [Docusaurus](https://docusaurus.io/) as the documentation framework,
-following its architecture principles and guidelines.
-
-```
-docs/
-├── blog
-│   ├── release-0-9-1.md
-│   ├── release-0-9-2.md
-├── docs
-│   ├── getting-started
-│   │   ├── overview.md
-│   │   └── ...
-│   ├── user-guide
-│   └── ...
-├── versioned_docs
-│   ├── version-0.9
-│   └── ...
-├── sidebars.ts
-├── i18n
-│   └── zh
-│       └── docusaurus-plugin-content-docs
-│           ├── current
-│           ├── version-0.9
-│           ├── current.json
-│           ├── version-0.9.json
-│           └── ...
-├── src
-│   ├── css
-│   │   └── custom.css
-│   └── plugins
-│       └── variable-placeholder.ts
-├── variables
-│   ├── variables-0.9.ts
-│   ├── variables-nightly.ts
-│   └── ...
-├── static
-│   └── img
-├── docusaurus.config.ts
-├── package.json
-├── README.md
-└── pnpm-lock.yaml
-```
-### Key Directories and files
-
-- `/blog/` - Markdown files for release notes.
-- `/docs/` - Documentation files for the nightly version.
-- `sidebars.ts` - Configuration file for the navigation sidebar metadata for the nightly version of the documentation.
-- `/versioned_docs/` - Documentation files for older versions.
-- `/versioned_docs` - Markdown files for the documentation of old versions.
-- `/versioned_sidebars` - Configuration file for the navigation sidebar metadata of the documentation of old versions.
-- `/i18n/zh/docusaurus-plugin-content-docs` - Localized documentation Markdown files for the Chinese language.
-  - `/current/` - Nightly version of the localized documentation.
-  - `/version-<doc-version>` - Localized documentation for the specified version.
-  - `/current.json` - Navigation sidebar metadata for the nightly version of the localized documentation.
-  - `/version-<doc-version>.json` - Navigation sidebar metadata for the specified version of the localized documentation.
-- `/src/plugins/variable-placeholder.ts` - Custom plugin that replaces variables in the documentation.
-
-## Documentation Versioning
-
-Documentation versions align with GreptimeDB versions:
-
-- **Nightly version**: Unreleased features.
-- **Versioned docs**: Stable releases (e.g., v0.9, v0.10) that include all features up to the specified version.
-
-
-## Adding a new document
-
-### English documents
-
-- Add new documents to the `./docs` directory for the nightly version.
-- Ensure the document's H1 header is the title, which will be used in the sidebar.
-- Update `sidebars.ts` to include the new document:
-
-```ts
-{
-  type: 'category',
-  label: '<Navigation name>',
-  items: [
-    'user-guide/manage-data/overview',
-    '<your file path>',
-    '...',
-  ],
-},
-```
-
-### Localized documents
-
-* Add new localized documents under ./i18n/<locale>/docusaurus-plugin-content-docs/current.
-* Follow the same guidelines as for English documents, that the H1 header is the title, which will be used in the sidebar.
-* If adding a new directory, update current.json for translations:
-
-```
-"sidebar.docs.category.<category-label>": {
-  "message": "<The localized label for the category, for example, 管理数据>",
-  "description": "Description"
-},
-```
-
-## Adding a new release note
-
-Add a new Markdown file to the `/blog` dictionary.
-The content structure should remain consistency as the previous release notes.
-
-## Modifying existing documents
-
-- English documents: Modify documents in `./docs` and ensure consistency across all relevant versions in `./versioned_docs`.
-- Localized documents: Modify localized documents in `./i18n/<locale>/docusaurus-plugin-content-docs/<version>` and ensure consistency across versions.
-
-### Updating `df-functions.md`
-
-Use the following command to generate `./docs/reference/sql/functions/df-functions.md`.
-
-```shell
-ruby src/misc/update_functions.rb
-```
-
-Then copy the English content to the corresponding localized file.
-
-## Deleting documents
-
-- English documents: Remove the document and update the `sidebars.ts` configuration.
-- Localized documents: Remove the document and update the corresponding json file of the sidebar configuration.
-
-## Images
-
-### Adding images
-
-Place images in the `./static/img` directory and reference them with a relative path:
-
-```markdown
-![image](/img/xxx.png)
-```
-
-### Image style
-
-Please use the [`example.drawio.svg`](static/img/example.drawio.svg) template for diagrams, maintaining consistency in colors and style.
-
-## Markdown links
-
-Relative path and absolute path are both supported in the markdown links.
-The absolute file paths are resolved relative to the content root, usually `docs/` or localized ones like `i18n/<localize>/plugin-content-docs/current`.
-
-For example, link to the `Ingest Data` document in the `./docs` directory:
-
-```markdown
-[Ingest Data](/user-guide/ingest-data/overview.md)
-```
-
-Always use the `.md` extension when linking to other documentation files.
-This ensures that the files are correctly linked to the corresponding version.
-For example, use `[Ingest Data](/user-guide/ingest-data/overview.md)` instead of `[Ingest Data](/user-guide/ingest-data/overview)`.
-
-## Using tabs
-
-You can the `Tabs` component to display different content in the same position.
-Please refer to the [Docusaurus documentation](https://docusaurus.io/docs/markdown-features/tabs) for more information.
-
-## Variable Placeholders
-
-You can utilize variable placeholders in the documentation to replace the variables with actual values.
-These placeholders are defined in the `./variables` directory.
-The variable file name must match the version name in the `versioned_docs` directory.
-For instance, `version-0.9` should have a corresponding `variables-0.9.ts` file.
-
-To use a variable placeholder in the documentation, follow this syntax:
-
-```markdown
-VAR::<variableName>
-```
-
-Add the variable name to the corresponding variable file:
-
-```ts
-export const variables = {
-  // ...
-  variableName: 'name',
-  // ...
-};
-```
-
-For a practical example, please refer to the [GreptimeDB Standalone installation document](docs/getting-started/installation/greptimedb-standalone.md#linux-and-macos).
-
-## Include other Markdown files
-
-You can include other Markdown files in the current Markdown file.
-For example, if you want to include the `shared-content.md` file in the current file, you can use the following code:
-
-```markdown
-import IncludesharedContent from './shared-content.md'
-<IncludesharedContent/>
-```
-
-## Document templates
-
-Document templates can help you reuse the same outlines and structures in multiple documents. For example, you can create a template file for all SDK documents and only write the SDK-specific content in each individual SDK document.
-
-For an example, please refer to the [gRPC-SDK dictionary](docs/user-guide/ingest-data/for-iot/grpc-sdks).
-
-## Build and preview the docs locally
-
-We highly encourage you to preview your changes locally before submitting a pull request.
-This project requires Node.js version 20.x or higher.
-Use `npm install -g pnpm` to install package manager, and start a local server with the following commands:
+Use Node.js 20 or newer and pnpm 8.6.0. CI currently uses Node.js 22.
 
 ```shell
 pnpm install
-pnpm run start
 ```
 
-You can also use `pnpm run build` to check dead links.
+Common commands:
 
-### Preview the localized documentation
+| Task | Command |
+| --- | --- |
+| Preview English | `pnpm start` |
+| Preview Chinese | `pnpm start:zh` |
+| Build English | `pnpm build` |
+| Build Chinese | `DOC_LANG=zh pnpm build` |
+| Check English links and anchors | `DOC_LANG=en pnpm check:links` |
+| Check Chinese links and anchors | `DOC_LANG=zh pnpm check:links` |
+| Run unit tests | `pnpm test` |
+| Run TypeScript checks | `pnpm typecheck` |
 
-To preview the documentation in a specific language, use command `pnpm run start --locale <localize language>`.
-For example:
+`DOC_LANG` selects the locale. Normal start and build commands run
+`pnpm sync-skill` first. The strict link commands build Nightly and every
+released documentation version from 1.0 onward.
 
-```cmd
-DOC_LANG=zh pnpm start
+Use pnpm. Dependency changes should update `pnpm-lock.yaml`; documentation-only
+changes must not touch lockfiles.
+
+## Repository layout
+
+- `docs/`: English Nightly docs for unreleased changes.
+- `versioned_docs/version-<version>/`: English docs for released versions.
+- `i18n/zh/docusaurus-plugin-content-docs/current/`: Chinese Nightly docs.
+- `i18n/zh/docusaurus-plugin-content-docs/version-<version>/`: Chinese released
+  docs.
+- `sidebars.ts`, `versioned_sidebars/`, and
+  `i18n/zh/docusaurus-plugin-content-docs/*.json`: navigation.
+- `variables/`: version-specific values for `VAR::<name>` placeholders.
+- `src/`: Docusaurus components, theme overrides, plugins, and scripts.
+- `skills/`: sources for published GreptimeDB agent skills.
+- `static/`: images, downloads, and generated skill copies.
+- `blog/`: release notes.
+
+`versions.json` lists released documentation versions with the newest first.
+
+## Add or update documentation
+
+Use `docs/` and the Chinese `current/` tree for unreleased features. Update a
+released version only when the change is valid for that GreptimeDB release.
+Keep English and Chinese aligned in meaning, but write each language naturally.
+
+New pages require front matter and an H1:
+
+```markdown
+---
+keywords: [GreptimeDB, documentation]
+description: A short description of the page.
+---
+
+# Page title
 ```
 
-## PR title check
+Add English Nightly pages to `sidebars.ts`. Update the corresponding
+versioned sidebar or Chinese sidebar JSON when the same structural change
+applies there.
 
-We use [action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request) to ensure that PR titles follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+When moving or deleting a page:
 
-## Backport nightly changes to versioned docs
+- Update every sidebar that references it.
+- Update inbound links in the affected versions and languages.
+- Preserve established routes or anchors when external links may depend on
+  them.
 
-Some doc modifications on latest nightly (current) are required to backport to
-released docs. We created a script to simplify this process.
+Versioned docs are user-facing sources, not disposable generated files. When
+creating a version, keep `versions.json`, `versioned_docs/`,
+`versioned_sidebars/`, the matching Chinese directory and sidebar JSON, and
+`variables/variables-<version>.ts` consistent.
 
-To backport the changes, first commit your changes on nightly docs. Then execute
+## Writing guidelines
 
-```sh
-pnpm run backport
+- Use plain, direct English without marketing filler.
+- Write Chinese naturally for Chinese developers; avoid literal translation.
+- Keep commands, SQL, configuration keys, API names, and examples exact and
+  copy-pasteable.
+- State which release a version-specific feature or option applies to.
+- Follow the terminology already used by the surrounding documentation.
+
+## Links and anchors
+
+Include the `.md` extension in links to documentation source files:
+
+```markdown
+[Ingest data](/user-guide/ingest-data/overview.md)
 ```
 
-This command will apply all the changes from git `HEAD~1` to last release
-versioned docs. Then are several options to customize this behavior
+Root-relative documentation paths keep readers in their current documentation
+version.
 
-```sh
-pnpm run backport --help
+Read the source paragraph and destination section before changing a link. A
+link can intentionally land on an overview or option section that sends readers
+to a detailed page. A green link checker proves that the target exists, not
+that it is the right target.
+
+Heading slugs are public URLs. When a heading is renamed or translated but the
+section still represents the same concept, preserve the established anchor
+with the global `AnchorAlias` component:
+
+```mdx
+<AnchorAlias id="upload-a-pipeline" />
+
+## Upload the Pipeline
 ```
 
-Note that we cannot guarantee success of this command because sometimes there
-are more changes to versioned docs that blocks us from apply it. You will need
-to resolve the conflicts manually.
+Place the alias immediately before the exact heading it represents. Keep IDs
+unique within the page. Do not import `AnchorAlias` in a document; it is
+registered globally. Do not add or move an alias only to silence the checker.
+
+Run both strict link commands after changing links, headings, routes, versions,
+localization, or MDX anchor handling.
+
+## Images and shared content
+
+Put site assets under `static/` and reference them from the site root:
+
+```markdown
+![Diagram](/img/example.drawio.svg)
+```
+
+Use [`static/img/example.drawio.svg`](static/img/example.drawio.svg) as the
+style reference for diagrams.
+
+Docusaurus MDX supports shared Markdown imports and tabs. Reuse the existing
+patterns near the page you are editing instead of introducing a second
+convention.
+
+## Variables and generated files
+
+Use `VAR::<name>` for version-specific values. Define the value in
+`variables/variables-nightly.ts` and in each applicable
+`variables/variables-<version>.ts`.
+
+Do not edit generated outputs:
+
+- Edit `skills/<name>/SKILL.md`, not `static/SKILL.md` or `static/skills/**`.
+  `pnpm sync-skill` regenerates the static copies.
+- Do not edit `build/`, `.docusaurus/`, or JavaScript transpiled from tracked
+  TypeScript.
+- Generate `docs/reference/sql/functions/df-functions.md` with
+  `ruby src/misc/update_functions.rb`, then update the matching localized file.
+
+## Backport Nightly changes
+
+The backport script applies the last commit from the English and Chinese
+Nightly trees to the latest released documentation version.
+
+```shell
+pnpm backport:dry
+pnpm backport
+```
+
+Run the dry run first and inspect the result. The script cannot determine
+whether a change is valid for the target release. Use `pnpm backport --help`
+for additional options.
+
+## Before opening a pull request
+
+1. Review the complete diff for unintended versions, languages, generated
+   files, and lockfile changes.
+2. Run `git diff --check`.
+3. Build each affected language.
+4. Run both strict link commands for link, heading, route, version,
+   localization, or MDX changes.
+5. Run `pnpm test` and `pnpm typecheck` for components, plugins, theme, or
+   configuration changes.
+6. Check the rendered sidebar after navigation changes.
+7. Use a [Conventional Commit](https://www.conventionalcommits.org/) style PR
+   title and fill in the pull request template.
+
+CI checks the build, unit tests, Markdown, spelling, front matter for
+documentation pages, and the PR title. Build success does not replace manual
+review of technical claims and link destinations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,9 @@ changes must not touch lockfiles.
 
 Use `docs/` and the Chinese `current/` tree for unreleased features. Update a
 released version only when the change is valid for that GreptimeDB release.
-Keep English and Chinese aligned in meaning, but write each language naturally.
+When adding or expanding user-facing documentation, update the corresponding
+Chinese page in the same pull request. Keep English and Chinese aligned in
+meaning, but write each language naturally.
 
 New pages require front matter and an H1:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,8 @@ For GreptimeDB product bugs and feature requests, use the
 
 ## Set up the project
 
-Use Node.js 20 or newer and pnpm 8.6.0. CI currently uses Node.js 22.
+Use Node.js 22 and pnpm 8.6.0 to match the main build CI. `package.json`
+currently allows Node.js 18 or newer.
 
 ```shell
 pnpm install
@@ -35,9 +36,10 @@ Common commands:
 | Run unit tests | `pnpm test` |
 | Run TypeScript checks | `pnpm typecheck` |
 
-`DOC_LANG` selects the locale. Normal start and build commands run
-`pnpm sync-skill` first. The strict link commands build Nightly and every
-released documentation version from 1.0 onward.
+`DOC_LANG` selects the locale. The repository enables pnpm pre/post scripts, so
+normal start and build commands run `pnpm sync-skill` first. The strict link
+commands build Nightly and every released documentation version from 1.0
+onward.
 
 Use pnpm. Dependency changes should update `pnpm-lock.yaml`; documentation-only
 changes must not touch lockfiles.
@@ -91,6 +93,47 @@ Versioned docs are user-facing sources, not disposable generated files. When
 creating a version, keep `versions.json`, `versioned_docs/`,
 `versioned_sidebars/`, the matching Chinese directory and sidebar JSON, and
 `variables/variables-<version>.ts` consistent.
+
+## Reference snippets
+
+Add an English Nightly category to `sidebars.ts`:
+
+```typescript
+{
+  type: 'category',
+  label: 'Category name',
+  items: ['path/to/page'],
+}
+```
+
+For Chinese navigation, add a matching translation to
+`i18n/zh/docusaurus-plugin-content-docs/current.json`. The key must use the
+English category label from `sidebars.ts`:
+
+```json
+{
+  "sidebar.docs.category.Category name": {
+    "message": "Translated category name",
+    "description": "The label for category Category name in sidebar docs"
+  }
+}
+```
+
+Reuse Markdown content through an MDX import:
+
+```mdx
+import SharedContent from './shared-content.md'
+
+<SharedContent />
+```
+
+Version variable filenames must match their documentation directories. For
+example, pages under `versioned_docs/version-1.2/` use
+`variables/variables-1.2.ts`; Nightly pages use
+`variables/variables-nightly.ts`.
+
+Add release notes under `blog/`. Follow the filename, front matter, and section
+structure of the newest release note.
 
 ## Writing guidelines
 
@@ -151,9 +194,8 @@ convention.
 
 ## Variables and generated files
 
-Use `VAR::<name>` for version-specific values. Define the value in
-`variables/variables-nightly.ts` and in each applicable
-`variables/variables-<version>.ts`.
+Use `VAR::<name>` for version-specific values. Define the value in the matching
+file under `variables/`.
 
 Do not edit generated outputs:
 


### PR DESCRIPTION
## What changed

- add a concise `AGENTS.md` for coding agents and a portable `CLAUDE.md` import
- ignore `.local/` for machine-local agent instructions
- update `CONTRIBUTING.md` with current setup, version, localization, link, anchor, generated-file, backport, sidebar, shared-content, variable, and release-note guidance
- simplify the pull request template around scope and verification
- add documentation problem and documentation request issue forms

This PR depends on #2669 for the documented `AnchorAlias` component, `pnpm check:links` command, and package lifecycle behavior. Merge it after #2669.

## Scope

- Documentation versions: repository-wide contributor guidance; no versioned page content changed
- Languages: English contributor guidance; no localized page content changed

## Verification

- `npx --yes markdownlint-cli@0.45.0 --config .markdownlint.yaml AGENTS.md CLAUDE.md CONTRIBUTING.md .github/pull_request_template.md`
- `typos AGENTS.md CLAUDE.md CONTRIBUTING.md .github/pull_request_template.md .github/ISSUE_TEMPLATE/*.yml`
- `git diff --check`
- parsed all issue-template YAML files
- verified referenced repository paths, package scripts, labels, and that `CLAUDE.md` is a regular file importing `AGENTS.md`

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] I updated navigation when the document structure changed.