### PR TITLE
docs: add lifecycle event recorder configuration

### DIFF
--- a/docs/user-guide/deployments-administration/configuration.md
+++ b/docs/user-guide/deployments-administration/configuration.md
@@ -469,6 +469,46 @@ default_ratio = 1.0
 
 How to use distributed tracing, please reference [Tracing](/user-guide/deployments-administration/monitoring/tracing.md#tutorial-use-jaeger-to-trace-greptimedb)
 
+### Lifecycle event recorder
+
+The lifecycle event recorder persists procedure lifecycle events in the `greptime_private.events` system table. Configure it in `standalone` mode or on Metasrv in a distributed deployment:
+
+```toml
+[event_recorder]
+# TTL of the events table. Defaults to 90 days.
+ttl = "90d"
+
+# Omit this option to record all current and future event types.
+# Use an empty array to disable event recording.
+event_types = ["create_table", "drop_table"]
+```
+
+- `ttl`: The TTL of the events table. The default is `90d`.
+- `event_types`: The event types to record. When omitted, all current and future event types are recorded. Set it to `[]` to disable event recording.
+
+Standalone supports the following event types:
+
+```text
+create_database, alter_database, drop_database,
+create_flow, drop_flow,
+create_table, create_logical_tables, alter_table, alter_logical_tables,
+drop_table, undrop_table, purge_dropped_table, truncate_table,
+create_view, drop_view
+```
+
+Metasrv supports the following event types:
+
+```text
+region_migration,
+create_database, alter_database, drop_database,
+create_flow, drop_flow,
+create_table, create_logical_tables, alter_table, alter_logical_tables,
+drop_table, undrop_table, purge_dropped_table, truncate_table,
+create_view, drop_view,
+repartition, repartition_group,
+batch_gc, wal_prune
+```
+
 ### Region engine options
 
 The parameters corresponding to different storage engines can be configured for `datanode` and `standalone` in the `[region_engine]` section. Currently, options for `mito` and `metric` region engines are available.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/configuration.md
@@ -471,6 +471,46 @@ default_ratio = 1.0
 
 如何使用分布式追踪，请参考 [Tracing](/user-guide/deployments-administration/monitoring/tracing.md#教程使用-jaeger-追踪-greptimedb-调用链路)
 
+### 生命周期事件记录器
+
+生命周期事件记录器会将 Procedure 的生命周期事件持久化到 `greptime_private.events` 系统表。在单机模式下使用 `standalone` 配置；在分布式部署中，在 Metasrv 上配置：
+
+```toml
+[event_recorder]
+# 事件表的 TTL，默认值为 90 天。
+ttl = "90d"
+
+# 省略此项以记录当前及未来的所有事件类型。
+# 使用空数组可禁用事件记录。
+event_types = ["create_table", "drop_table"]
+```
+
+- `ttl`：事件表的 TTL，默认值为 `90d`。
+- `event_types`：要记录的事件类型。省略时记录当前及未来的所有事件类型；设为 `[]` 可禁用事件记录。
+
+standalone 支持以下事件类型：
+
+```text
+create_database, alter_database, drop_database,
+create_flow, drop_flow,
+create_table, create_logical_tables, alter_table, alter_logical_tables,
+drop_table, undrop_table, purge_dropped_table, truncate_table,
+create_view, drop_view
+```
+
+Metasrv 支持以下事件类型：
+
+```text
+region_migration,
+create_database, alter_database, drop_database,
+create_flow, drop_flow,
+create_table, create_logical_tables, alter_table, alter_logical_tables,
+drop_table, undrop_table, purge_dropped_table, truncate_table,
+create_view, drop_view,
+repartition, repartition_group,
+batch_gc, wal_prune
+```
+
 <AnchorAlias id="region-engine-options" />
 
 ### Region 引擎选项


### PR DESCRIPTION
## What's Changed in this PR

Closes #2652, #2655, #2656, #2657, #2658, #2659, #2661, #2664, #2665, #2667.

Document the `[event_recorder]` configuration in the English and Chinese deployment configuration guides.

- Explain the `ttl` and `event_types` options, including the default all-event behavior and disabling recording with an empty array.
- List the event types supported by standalone and Metasrv separately.
- Document `batch_gc` and `wal_prune` as Metasrv-only event types.
- Keep the Chinese localized configuration page synchronized with the English page.

Validation:

- `git diff --check origin/main...HEAD`
- English/Chinese event-type list consistency check

`pnpm typecheck` was not completed because the checkout is missing `node_modules/@docusaurus/theme-classic` and `node_modules/@types/node`.

## Checklist

- [x] Please confirm that all corresponding versions of the documents have been revised.
- [x] Please ensure that the content in `sidebars.ts` matches the current document structure when you changed the document structure.
- [x] This change requires follow-up update in localized docs.
