### PR TITLE
docs: document datanode client gRPC limits

### DIFF
--- a/docs/user-guide/deployments-administration/configuration.md
+++ b/docs/user-guide/deployments-administration/configuration.md
@@ -651,6 +651,9 @@ refer to the [Time Zone](/user-guide/timezone.md#impact-of-time-zone-on-sql-stat
 
 ### Metasrv-only configuration
 
+The `datanode.client` options configure outbound gRPC connections from Metasrv to Datanodes.
+The client message size limits are independent of the `[grpc]` server message size limits.
+
 ```toml
 # The working home directory.
 data_home = "./greptimedb_data"
@@ -800,6 +803,12 @@ connect_timeout = "10s"
 ## `TCP_NODELAY` option for accepted connections.
 tcp_nodelay = true
 
+## The maximum receive message size for the gRPC client.
+max_recv_message_size = "512MB"
+
+## The maximum send message size for the gRPC client.
+max_send_message_size = "512MB"
+
 [wal]
 # Available wal providers:
 # - `raft_engine` (default): there're none raft-engine wal config since metasrv only involves in remote wal currently.
@@ -912,6 +921,8 @@ timeout = "3s"
 | `datanode.client.timeout`                     | String  | `10s`                        | Operation timeout.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | `datanode.client.connect_timeout`             | String  | `10s`                        | Connect server timeout.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `datanode.client.tcp_nodelay`                 | Bool    | `true`                       | `TCP_NODELAY` option for accepted connections.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `datanode.client.max_recv_message_size`       | String  | `512MB`                      | The maximum receive message size for the gRPC client.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `datanode.client.max_send_message_size`       | String  | `512MB`                      | The maximum send message size for the gRPC client.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | `wal`                                         | --      | --                           | --                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | `wal.provider`                                | String  | `raft_engine`                | --                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | `wal.broker_endpoints`                        | Array   | --                           | The broker endpoints of the Kafka cluster.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
@@ -959,16 +970,23 @@ ingest_rt_size = 8
 
 ### Frontend-only configuration
 
+The `datanode.client` options configure outbound gRPC connections from Frontend to Datanodes.
+The client message size limits are independent of the `[grpc]` server message size limits.
+
 ```toml
 [datanode]
 [datanode.client]
 connect_timeout = "1s"
 tcp_nodelay = true
+max_recv_message_size = "512MB"
+max_send_message_size = "512MB"
 ```
 
-| Key                               | Type   | Default | Description                                    |
-| --------------------------------- | ------ | ------- | ---------------------------------------------- |
-| `datanode`                        | --     | --      | Datanode options.                              |
-| `datanode.client`                 | --     | --      | Datanode client options.                       |
-| `datanode.client.connect_timeout` | String | `1s`    | Connect server timeout.                        |
-| `datanode.client.tcp_nodelay`     | Bool   | `true`  | `TCP_NODELAY` option for accepted connections. |
+| Key                                             | Type   | Default | Description                                            |
+| ----------------------------------------------- | ------ | ------- | ------------------------------------------------------ |
+| `datanode`                                      | --     | --      | Datanode options.                                      |
+| `datanode.client`                               | --     | --      | Datanode client options.                               |
+| `datanode.client.connect_timeout`               | String | `1s`    | Connect server timeout.                                |
+| `datanode.client.tcp_nodelay`                   | Bool   | `true`  | `TCP_NODELAY` option for accepted connections.         |
+| `datanode.client.max_recv_message_size`         | String | `512MB` | The maximum receive message size for the gRPC client.  |
+| `datanode.client.max_send_message_size`         | String | `512MB` | The maximum send message size for the gRPC client.     |

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/configuration.md
@@ -655,6 +655,9 @@ default_timezone = "UTC"
 
 ### 仅限于 Metasrv 的配置
 
+`datanode.client` 选项用于配置从 Metasrv 到 Datanode 的出站 gRPC 连接。
+客户端的消息大小限制独立于 `[grpc]` 服务器的消息大小限制。
+
 ```toml
 # 工作主目录。
 data_home = "./greptimedb_data"
@@ -805,6 +808,12 @@ connect_timeout = "10s"
 ## 接受连接时的 `TCP_NODELAY` 选项，默认为 true。
 tcp_nodelay = true
 
+## gRPC 客户端可接收的最大消息大小。
+max_recv_message_size = "512MB"
+
+## gRPC 客户端可发送的最大消息大小。
+max_send_message_size = "512MB"
+
 [wal]
 # 可用的 WAL 提供者：
 # - `raft_engine`（默认）：由于 metasrv 目前仅涉及远程 WAL，因此没有 raft-engine WAL 配置。
@@ -898,6 +907,8 @@ timeout = "3s"
 | `datanode.client.timeout`                     | 字符串  | `10s`                | 操作超时。                                                                                                                           |
 | `datanode.client.connect_timeout`             | 字符串  | `10s`                | 连接服务器超时。                                                                                                                     |
 | `datanode.client.tcp_nodelay`                 | 布尔值  | `true`               | 接受连接的 `TCP_NODELAY` 选项。                                                                                                      |
+| `datanode.client.max_recv_message_size`       | 字符串  | `512MB`              | gRPC 客户端可接收的最大消息大小。                                                                                                    |
+| `datanode.client.max_send_message_size`       | 字符串  | `512MB`              | gRPC 客户端可发送的最大消息大小。                                                                                                    |
 | wal                                           | --      | --                   | --                                                                                                                                   |
 | wal.provider                                  | String  | `raft_engine` | --                                                                                                                                   |
 | wal.broker_endpoints                          | Array   | --                   | Kafka 集群的端点                                                                                                                     |
@@ -946,16 +957,23 @@ ingest_rt_size = 8
 
 ### 仅限于 `Frontend` 的配置
 
+`datanode.client` 选项用于配置从 Frontend 到 Datanode 的出站 gRPC 连接。
+客户端的消息大小限制独立于 `[grpc]` 服务器的消息大小限制。
+
 ```toml
 [datanode]
 [datanode.client]
 connect_timeout = "1s"
 tcp_nodelay = true
+max_recv_message_size = "512MB"
+max_send_message_size = "512MB"
 ```
 
-| Key                               | Type | Default | Description             |
-|-----------------------------------|------|---------|-------------------------|
-| `datanode`                        | --   | --      |                         |
-| `datanode.client`                 | --   | --      | Datanode 客户端选项。         |
-| `datanode.client.connect_timeout` | 字符串  | `1s`    | 连接服务器超时。                |
-| `datanode.client.tcp_nodelay`     | 布尔值  | `true`  | 接受连接的 `TCP_NODELAY` 选项。 |
+| Key                                             | Type   | Default | Description                              |
+| ----------------------------------------------- | ------ | ------- | ---------------------------------------- |
+| `datanode`                                      | --     | --      |                                          |
+| `datanode.client`                               | --     | --      | Datanode 客户端选项。                    |
+| `datanode.client.connect_timeout`               | 字符串 | `1s`    | 连接服务器超时。                         |
+| `datanode.client.tcp_nodelay`                   | 布尔值 | `true`  | 接受连接的 `TCP_NODELAY` 选项。          |
+| `datanode.client.max_recv_message_size`         | 字符串 | `512MB` | gRPC 客户端可接收的最大消息大小。        |
+| `datanode.client.max_send_message_size`         | 字符串 | `512MB` | gRPC 客户端可发送的最大消息大小。        |


### PR DESCRIPTION
## What changed

- Document `datanode.client.max_recv_message_size` and `datanode.client.max_send_message_size` for Frontend and Metasrv.
- Clarify that the outbound datanode client limits are independent of the inbound `[grpc]` server limits.
- Add aligned English and Chinese Nightly documentation using the existing 512 MB defaults from GreptimeDB.

Closes #2650.

## Scope

- Documentation versions: Nightly
- Languages: English and Chinese

## Verification

- `pnpm build`
- `DOC_LANG=zh pnpm build`
- `DOC_LANG=en pnpm check:links`
- `DOC_LANG=zh pnpm check:links`
- `git diff --check`
- Compared the options, defaults, and component behavior with GreptimeDB PR #8642.
- Confirmed that no navigation, released-version docs, generated files, or lockfiles changed.

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] I updated navigation when the document structure changed.
