### PR TITLE
docs: add Apache Spark connector guide

### DIFF
--- a/docs/user-guide/ingest-data/overview.md
+++ b/docs/user-guide/ingest-data/overview.md
@@ -14,7 +14,8 @@ GreptimeDB supports schemaless writing, automatically creating tables and adding
 This capability ensures that you do not need to manually define schemas beforehand, making it easier to manage and integrate diverse data sources seamlessly.
 <!-- TODO: add links to protocols and integrations -->
 This feature is supported for all protocols and integrations, except
-[SQL](./for-iot/sql.md) and [Apache Flink](/user-guide/integrations/flink.md).
+[SQL](./for-iot/sql.md), [Apache Flink](/user-guide/integrations/flink.md), and
+[Apache Spark](/user-guide/integrations/spark.md).
 
 ## Recommended Data Ingestion Methods
 
@@ -23,6 +24,7 @@ GreptimeDB supports various data ingestion methods for specific scenarios, ensur
 - [For Observability Scenarios](./for-observability/overview.md): Suitable for real-time monitoring and alerting.
 - [For IoT Scenarios](./for-iot/overview.md): Suitable for real-time data and complex IoT infrastructures.
 - [Apache Flink](/user-guide/integrations/flink.md): Use Flink SQL, the Table API, or the DataStream API to write insert-only records to GreptimeDB.
+- [Apache Spark](/user-guide/integrations/spark.md): Write batch DataFrames and Structured Streaming micro-batches to GreptimeDB.
 
 ## Next Steps
 

--- a/docs/user-guide/integrations/spark.md
+++ b/docs/user-guide/integrations/spark.md
@@ -1,0 +1,149 @@
+---
+keywords: [Apache Spark, Spark connector, data ingestion, batch processing, Structured Streaming, DataSource V2]
+description: Write batch DataFrames and Structured Streaming micro-batches to GreptimeDB with the Apache Spark connector.
+---
+
+# Apache Spark
+
+The [GreptimeDB connector for Apache Spark](https://github.com/GreptimeTeam/spark-connector-greptimedb)
+is a DataSource V2 connector that writes batch DataFrames and Structured
+Streaming micro-batches to GreptimeDB.
+
+The connector requires Java 17 or later and the Scala 2.13 distribution of
+Apache Spark 4.2.0. It is write-only and requires an existing GreptimeDB table.
+
+## Install the connector
+
+### Download from Maven Central
+
+For a Maven-based Spark application, add the connector as a dependency:
+
+```xml
+<dependency>
+  <groupId>io.greptime</groupId>
+  <artifactId>spark-connector-greptimedb</artifactId>
+  <version>VAR::sparkConnectorVersion</version>
+</dependency>
+```
+
+To load the connector directly into a Spark runtime, download the shaded JAR
+from [Maven Central](https://central.sonatype.com/artifact/io.greptime/spark-connector-greptimedb/VAR::sparkConnectorVersion):
+
+```bash
+mvn dependency:copy \
+  -Dartifact=io.greptime:spark-connector-greptimedb:VAR::sparkConnectorVersion:jar:shaded \
+  -DoutputDirectory=/path/to/spark/jars
+```
+
+### Build from source
+
+Build the connector from source:
+
+```bash
+git clone https://github.com/GreptimeTeam/spark-connector-greptimedb.git
+cd spark-connector-greptimedb
+mvn package
+```
+
+The build creates a shaded JAR under `target/`. Add it when submitting your
+Spark application:
+
+```bash
+./bin/spark-submit \
+  --jars /path/to/spark-connector-greptimedb-*-shaded.jar \
+  /path/to/application.jar
+```
+
+## Write a batch DataFrame
+
+Create the destination table in GreptimeDB before writing data:
+
+```sql
+CREATE TABLE cpu_metrics (
+  ts TIMESTAMP(6) TIME INDEX,
+  host STRING,
+  usage DOUBLE,
+  PRIMARY KEY (host)
+);
+```
+
+Then write a DataFrame in append mode:
+
+```java
+Dataset<Row> metrics = ...;
+
+metrics.write()
+        .format("greptimedb")
+        .mode("append")
+        .option("endpoints", "127.0.0.1:4001")
+        .option("database", "public")
+        .option("table", "cpu_metrics")
+        .option("time-index", "ts")
+        .option("tags", "host")
+        .option("batch.max-rows", "1000")
+        .save();
+```
+
+`endpoints` uses the GreptimeDB gRPC endpoint, whose default port is `4001`.
+The `time-index` column must have the Spark SQL type `TIMESTAMP` or
+`TIMESTAMP_NTZ`, and its values must not be null. Columns listed in `tags`
+should match the primary key columns of the destination GreptimeDB table.
+
+## Write a Structured Streaming DataFrame
+
+Use the connector as a Structured Streaming sink in append output mode:
+
+```java
+StreamingQuery query = metrics.writeStream()
+        .format("greptimedb")
+        .outputMode("append")
+        .option("checkpointLocation", "/path/to/checkpoint")
+        .option("endpoints", "127.0.0.1:4001")
+        .option("database", "public")
+        .option("table", "cpu_metrics")
+        .option("time-index", "ts")
+        .option("tags", "host")
+        .start();
+```
+
+## Connector options
+
+| Option | Required | Default | Description |
+| --- | --- | --- | --- |
+| `endpoints` | Yes | - | Comma-separated GreptimeDB gRPC endpoints in `hostname:port` or `IPv4:port` format. |
+| `table` | Yes | - | Existing destination table. |
+| `time-index` | Yes | - | `TIMESTAMP` or `TIMESTAMP_NTZ` column used as the GreptimeDB time index. |
+| `database` | No | `public` | Destination database. |
+| `tags` | No | - | Comma-separated columns written as GreptimeDB tags. |
+| `username` | No | - | GreptimeDB username. Configure with `password`. |
+| `password` | No | - | GreptimeDB password. Configure with `username`. |
+| `batch.max-rows` | No | `1000` | Rows per ingester bulk message in each Spark task. |
+
+For advanced bulk-write options, see the
+[connector README](https://github.com/GreptimeTeam/spark-connector-greptimedb#options).
+
+## Supported data types
+
+| Spark SQL type | GreptimeDB type |
+| --- | --- |
+| `BOOLEAN` | `BOOLEAN` |
+| `TINYINT` | `INT8` |
+| `SMALLINT` | `INT16` |
+| `INT` | `INT32` |
+| `BIGINT` | `INT64` |
+| `FLOAT` | `FLOAT32` |
+| `DOUBLE` | `FLOAT64` |
+| `STRING`, `CHAR`, `VARCHAR` | `STRING` |
+| `BINARY` | `BINARY` |
+| `DATE` | `DATE` |
+| `TIMESTAMP`, `TIMESTAMP_NTZ` | `TIMESTAMP_MICROSECOND` |
+| `DECIMAL(p, s)` | `DECIMAL128(p, s)` |
+
+The connector rejects unsupported complex Spark SQL types before submitting
+the job. It does not validate the server-side schema, so the DataFrame columns
+and mapped types must match the destination table.
+
+Writes are insert-only and provide at-least-once delivery. Failed or retried
+Spark tasks and streaming epochs can produce duplicate rows. The connector
+does not support reads, overwrite, delete, upsert, automatic table creation,
+or exactly-once commits.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/overview.md
@@ -13,8 +13,9 @@ GreptimeDB 支持自动生成表结构和灵活的数据写入方法，
 GreptimeDB 支持无 schema 写入，即在数据写入时自动创建表格并添加必要的列。
 这种能力确保你无需事先手动定义 schema，从而更容易管理和集成各种数据源。
 <!-- TODO: 添加协议和集成的链接 -->
-此功能适用于所有协议和集成，除了 [SQL](./for-iot/sql.md) 和
-[Apache Flink](/user-guide/integrations/flink.md)。
+此功能适用于所有协议和集成，除了 [SQL](./for-iot/sql.md)、
+[Apache Flink](/user-guide/integrations/flink.md) 和
+[Apache Spark](/user-guide/integrations/spark.md)。
 
 ## 推荐的数据写入方法
 
@@ -23,6 +24,7 @@ GreptimeDB 支持针对特定场景的各种数据写入方法，以确保最佳
 - [可观测场景](./for-observability/overview.md)：适用于实时监控和警报。
 - [物联网场景](./for-iot/overview.md)：适用于实时数据和复杂的物联网基础设施。
 - [Apache Flink](/user-guide/integrations/flink.md)：使用 Flink SQL、Table API 或 DataStream API 将仅包含 insert 操作的数据写入 GreptimeDB。
+- [Apache Spark](/user-guide/integrations/spark.md)：将 batch DataFrame 和 Structured Streaming micro-batch 写入 GreptimeDB。
 
 ## 下一步
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/integrations/spark.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/integrations/spark.md
@@ -1,0 +1,146 @@
+---
+keywords: [Apache Spark, Spark connector, 数据写入, 批处理, Structured Streaming, DataSource V2]
+description: 使用 GreptimeDB 的 Apache Spark connector 写入 batch DataFrame 和 Structured Streaming micro-batch。
+---
+
+# Apache Spark
+
+[GreptimeDB Apache Spark connector](https://github.com/GreptimeTeam/spark-connector-greptimedb)
+是一个 DataSource V2 connector，支持将 batch DataFrame 和 Structured
+Streaming micro-batch 写入 GreptimeDB。
+
+Connector 要求使用 Java 17 或更高版本、Apache Spark 4.2.0 的 Scala 2.13
+发行版。它仅支持写入，并要求 GreptimeDB 中已经存在目标表。
+
+## 安装 connector
+
+### 从 Maven Central 下载
+
+对于基于 Maven 的 Spark 应用，将 connector 添加为依赖：
+
+```xml
+<dependency>
+  <groupId>io.greptime</groupId>
+  <artifactId>spark-connector-greptimedb</artifactId>
+  <version>VAR::sparkConnectorVersion</version>
+</dependency>
+```
+
+如需将 connector 直接加载到 Spark runtime，从
+[Maven Central](https://central.sonatype.com/artifact/io.greptime/spark-connector-greptimedb/VAR::sparkConnectorVersion)
+下载 shaded JAR：
+
+```bash
+mvn dependency:copy \
+  -Dartifact=io.greptime:spark-connector-greptimedb:VAR::sparkConnectorVersion:jar:shaded \
+  -DoutputDirectory=/path/to/spark/jars
+```
+
+### 从源码构建
+
+从源码构建 connector：
+
+```bash
+git clone https://github.com/GreptimeTeam/spark-connector-greptimedb.git
+cd spark-connector-greptimedb
+mvn package
+```
+
+构建会在 `target/` 目录下生成 shaded JAR。提交 Spark 应用时加载该文件：
+
+```bash
+./bin/spark-submit \
+  --jars /path/to/spark-connector-greptimedb-*-shaded.jar \
+  /path/to/application.jar
+```
+
+## 写入 batch DataFrame
+
+写入数据前，在 GreptimeDB 中创建目标表：
+
+```sql
+CREATE TABLE cpu_metrics (
+  ts TIMESTAMP(6) TIME INDEX,
+  host STRING,
+  usage DOUBLE,
+  PRIMARY KEY (host)
+);
+```
+
+然后以 append 模式写入 DataFrame：
+
+```java
+Dataset<Row> metrics = ...;
+
+metrics.write()
+        .format("greptimedb")
+        .mode("append")
+        .option("endpoints", "127.0.0.1:4001")
+        .option("database", "public")
+        .option("table", "cpu_metrics")
+        .option("time-index", "ts")
+        .option("tags", "host")
+        .option("batch.max-rows", "1000")
+        .save();
+```
+
+`endpoints` 使用 GreptimeDB gRPC endpoint，默认端口为 `4001`。
+`time-index` 列的 Spark SQL 类型必须为 `TIMESTAMP` 或 `TIMESTAMP_NTZ`，
+并且列值不能为 null。`tags` 中的列应与 GreptimeDB 目标表的主键列一致。
+
+## 写入 Structured Streaming DataFrame
+
+以 append output mode 将 connector 用作 Structured Streaming sink：
+
+```java
+StreamingQuery query = metrics.writeStream()
+        .format("greptimedb")
+        .outputMode("append")
+        .option("checkpointLocation", "/path/to/checkpoint")
+        .option("endpoints", "127.0.0.1:4001")
+        .option("database", "public")
+        .option("table", "cpu_metrics")
+        .option("time-index", "ts")
+        .option("tags", "host")
+        .start();
+```
+
+## Connector 配置
+
+| 配置项 | 必填 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `endpoints` | 是 | - | 以逗号分隔、格式为 `hostname:port` 或 `IPv4:port` 的 GreptimeDB gRPC endpoints。 |
+| `table` | 是 | - | 已存在的目标表。 |
+| `time-index` | 是 | - | 用作 GreptimeDB time index 的 `TIMESTAMP` 或 `TIMESTAMP_NTZ` 列。 |
+| `database` | 否 | `public` | 目标数据库。 |
+| `tags` | 否 | - | 以逗号分隔、写为 GreptimeDB tag 的列。 |
+| `username` | 否 | - | GreptimeDB 用户名，必须与 `password` 同时配置。 |
+| `password` | 否 | - | GreptimeDB 密码，必须与 `username` 同时配置。 |
+| `batch.max-rows` | 否 | `1000` | 每个 Spark task 的每条 ingester bulk message 包含的行数。 |
+
+高级 bulk-write 配置请参阅
+[connector README](https://github.com/GreptimeTeam/spark-connector-greptimedb#options)。
+
+## 支持的数据类型
+
+| Spark SQL 类型 | GreptimeDB 类型 |
+| --- | --- |
+| `BOOLEAN` | `BOOLEAN` |
+| `TINYINT` | `INT8` |
+| `SMALLINT` | `INT16` |
+| `INT` | `INT32` |
+| `BIGINT` | `INT64` |
+| `FLOAT` | `FLOAT32` |
+| `DOUBLE` | `FLOAT64` |
+| `STRING`, `CHAR`, `VARCHAR` | `STRING` |
+| `BINARY` | `BINARY` |
+| `DATE` | `DATE` |
+| `TIMESTAMP`, `TIMESTAMP_NTZ` | `TIMESTAMP_MICROSECOND` |
+| `DECIMAL(p, s)` | `DECIMAL128(p, s)` |
+
+Connector 会在提交 job 前拒绝不支持的复杂 Spark SQL 类型。它不会验证服务端
+schema，因此 DataFrame 列及其映射类型必须与目标表一致。
+
+写入仅支持 insert，提供 at-least-once 交付语义。失败或重试的 Spark task 和
+streaming epoch 可能产生重复数据。Connector 不支持读取、overwrite、delete、
+upsert、自动建表和 exactly-once commit。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/ingest-data/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/ingest-data/overview.md
@@ -13,8 +13,9 @@ GreptimeDB 支持自动生成表结构和灵活的数据写入方法，
 GreptimeDB 支持无 schema 写入，即在数据写入时自动创建表格并添加必要的列。
 这种能力确保你无需事先手动定义 schema，从而更容易管理和集成各种数据源。
 <!-- TODO: 添加协议和集成的链接 -->
-此功能适用于所有协议和集成，除了 [SQL](./for-iot/sql.md) 和
-[Apache Flink](/user-guide/integrations/flink.md)。
+此功能适用于所有协议和集成，除了 [SQL](./for-iot/sql.md)、
+[Apache Flink](/user-guide/integrations/flink.md) 和
+[Apache Spark](/user-guide/integrations/spark.md)。
 
 ## 推荐的数据写入方法
 
@@ -23,6 +24,7 @@ GreptimeDB 支持针对特定场景的各种数据写入方法，以确保最佳
 - [可观测场景](./for-observability/overview.md)：适用于实时监控和警报。
 - [物联网场景](./for-iot/overview.md)：适用于实时数据和复杂的物联网基础设施。
 - [Apache Flink](/user-guide/integrations/flink.md)：使用 Flink SQL、Table API 或 DataStream API 将仅包含 insert 操作的数据写入 GreptimeDB。
+- [Apache Spark](/user-guide/integrations/spark.md)：将 batch DataFrame 和 Structured Streaming micro-batch 写入 GreptimeDB。
 
 ## 下一步
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/integrations/spark.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/integrations/spark.md
@@ -1,0 +1,146 @@
+---
+keywords: [Apache Spark, Spark connector, 数据写入, 批处理, Structured Streaming, DataSource V2]
+description: 使用 GreptimeDB 的 Apache Spark connector 写入 batch DataFrame 和 Structured Streaming micro-batch。
+---
+
+# Apache Spark
+
+[GreptimeDB Apache Spark connector](https://github.com/GreptimeTeam/spark-connector-greptimedb)
+是一个 DataSource V2 connector，支持将 batch DataFrame 和 Structured
+Streaming micro-batch 写入 GreptimeDB。
+
+Connector 要求使用 Java 17 或更高版本、Apache Spark 4.2.0 的 Scala 2.13
+发行版。它仅支持写入，并要求 GreptimeDB 中已经存在目标表。
+
+## 安装 connector
+
+### 从 Maven Central 下载
+
+对于基于 Maven 的 Spark 应用，将 connector 添加为依赖：
+
+```xml
+<dependency>
+  <groupId>io.greptime</groupId>
+  <artifactId>spark-connector-greptimedb</artifactId>
+  <version>VAR::sparkConnectorVersion</version>
+</dependency>
+```
+
+如需将 connector 直接加载到 Spark runtime，从
+[Maven Central](https://central.sonatype.com/artifact/io.greptime/spark-connector-greptimedb/VAR::sparkConnectorVersion)
+下载 shaded JAR：
+
+```bash
+mvn dependency:copy \
+  -Dartifact=io.greptime:spark-connector-greptimedb:VAR::sparkConnectorVersion:jar:shaded \
+  -DoutputDirectory=/path/to/spark/jars
+```
+
+### 从源码构建
+
+从源码构建 connector：
+
+```bash
+git clone https://github.com/GreptimeTeam/spark-connector-greptimedb.git
+cd spark-connector-greptimedb
+mvn package
+```
+
+构建会在 `target/` 目录下生成 shaded JAR。提交 Spark 应用时加载该文件：
+
+```bash
+./bin/spark-submit \
+  --jars /path/to/spark-connector-greptimedb-*-shaded.jar \
+  /path/to/application.jar
+```
+
+## 写入 batch DataFrame
+
+写入数据前，在 GreptimeDB 中创建目标表：
+
+```sql
+CREATE TABLE cpu_metrics (
+  ts TIMESTAMP(6) TIME INDEX,
+  host STRING,
+  usage DOUBLE,
+  PRIMARY KEY (host)
+);
+```
+
+然后以 append 模式写入 DataFrame：
+
+```java
+Dataset<Row> metrics = ...;
+
+metrics.write()
+        .format("greptimedb")
+        .mode("append")
+        .option("endpoints", "127.0.0.1:4001")
+        .option("database", "public")
+        .option("table", "cpu_metrics")
+        .option("time-index", "ts")
+        .option("tags", "host")
+        .option("batch.max-rows", "1000")
+        .save();
+```
+
+`endpoints` 使用 GreptimeDB gRPC endpoint，默认端口为 `4001`。
+`time-index` 列的 Spark SQL 类型必须为 `TIMESTAMP` 或 `TIMESTAMP_NTZ`，
+并且列值不能为 null。`tags` 中的列应与 GreptimeDB 目标表的主键列一致。
+
+## 写入 Structured Streaming DataFrame
+
+以 append output mode 将 connector 用作 Structured Streaming sink：
+
+```java
+StreamingQuery query = metrics.writeStream()
+        .format("greptimedb")
+        .outputMode("append")
+        .option("checkpointLocation", "/path/to/checkpoint")
+        .option("endpoints", "127.0.0.1:4001")
+        .option("database", "public")
+        .option("table", "cpu_metrics")
+        .option("time-index", "ts")
+        .option("tags", "host")
+        .start();
+```
+
+## Connector 配置
+
+| 配置项 | 必填 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `endpoints` | 是 | - | 以逗号分隔、格式为 `hostname:port` 或 `IPv4:port` 的 GreptimeDB gRPC endpoints。 |
+| `table` | 是 | - | 已存在的目标表。 |
+| `time-index` | 是 | - | 用作 GreptimeDB time index 的 `TIMESTAMP` 或 `TIMESTAMP_NTZ` 列。 |
+| `database` | 否 | `public` | 目标数据库。 |
+| `tags` | 否 | - | 以逗号分隔、写为 GreptimeDB tag 的列。 |
+| `username` | 否 | - | GreptimeDB 用户名，必须与 `password` 同时配置。 |
+| `password` | 否 | - | GreptimeDB 密码，必须与 `username` 同时配置。 |
+| `batch.max-rows` | 否 | `1000` | 每个 Spark task 的每条 ingester bulk message 包含的行数。 |
+
+高级 bulk-write 配置请参阅
+[connector README](https://github.com/GreptimeTeam/spark-connector-greptimedb#options)。
+
+## 支持的数据类型
+
+| Spark SQL 类型 | GreptimeDB 类型 |
+| --- | --- |
+| `BOOLEAN` | `BOOLEAN` |
+| `TINYINT` | `INT8` |
+| `SMALLINT` | `INT16` |
+| `INT` | `INT32` |
+| `BIGINT` | `INT64` |
+| `FLOAT` | `FLOAT32` |
+| `DOUBLE` | `FLOAT64` |
+| `STRING`, `CHAR`, `VARCHAR` | `STRING` |
+| `BINARY` | `BINARY` |
+| `DATE` | `DATE` |
+| `TIMESTAMP`, `TIMESTAMP_NTZ` | `TIMESTAMP_MICROSECOND` |
+| `DECIMAL(p, s)` | `DECIMAL128(p, s)` |
+
+Connector 会在提交 job 前拒绝不支持的复杂 Spark SQL 类型。它不会验证服务端
+schema，因此 DataFrame 列及其映射类型必须与目标表一致。
+
+写入仅支持 insert，提供 at-least-once 交付语义。失败或重试的 Spark task 和
+streaming epoch 可能产生重复数据。Connector 不支持读取、overwrite、delete、
+upsert、自动建表和 exactly-once commit。

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -162,6 +162,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/integrations/vector',
             'user-guide/integrations/kafka',
             'user-guide/integrations/flink',
+            'user-guide/integrations/spark',
             'user-guide/integrations/telegraf',
             'user-guide/integrations/grafana',
             'user-guide/integrations/perses',

--- a/variables/variables-1.1.ts
+++ b/variables/variables-1.1.ts
@@ -5,6 +5,7 @@ export const variables = {
   goSdkVersion: 'v0.7.2',
   javaSdkVersion: '0.15.0',
   flinkConnectorVersion: '0.1.0',
+  sparkConnectorVersion: '0.1.0',
   debugPodVersion: '20250606-04e3c7d',
   etcdChartVersion: "12.0.8",
   etcdImageVersion: "3.6.1-debian-12-r3",

--- a/variables/variables-nightly.ts
+++ b/variables/variables-nightly.ts
@@ -5,6 +5,7 @@ export const variables = {
   goSdkVersion: 'v0.7.2',
   javaSdkVersion: '0.15.0',
   flinkConnectorVersion: '0.1.0',
+  sparkConnectorVersion: '0.1.0',
   debugPodVersion: '20250606-04e3c7d',
   etcdChartVersion: "12.0.8",
   etcdImageVersion: "3.6.1-debian-12-r3",

--- a/versioned_docs/version-1.1/user-guide/ingest-data/overview.md
+++ b/versioned_docs/version-1.1/user-guide/ingest-data/overview.md
@@ -14,7 +14,8 @@ GreptimeDB supports schemaless writing, automatically creating tables and adding
 This capability ensures that you do not need to manually define schemas beforehand, making it easier to manage and integrate diverse data sources seamlessly.
 <!-- TODO: add links to protocols and integrations -->
 This feature is supported for all protocols and integrations, except
-[SQL](./for-iot/sql.md) and [Apache Flink](/user-guide/integrations/flink.md).
+[SQL](./for-iot/sql.md), [Apache Flink](/user-guide/integrations/flink.md), and
+[Apache Spark](/user-guide/integrations/spark.md).
 
 ## Recommended Data Ingestion Methods
 
@@ -23,6 +24,7 @@ GreptimeDB supports various data ingestion methods for specific scenarios, ensur
 - [For Observability Scenarios](./for-observability/overview.md): Suitable for real-time monitoring and alerting.
 - [For IoT Scenarios](./for-iot/overview.md): Suitable for real-time data and complex IoT infrastructures.
 - [Apache Flink](/user-guide/integrations/flink.md): Use Flink SQL, the Table API, or the DataStream API to write insert-only records to GreptimeDB.
+- [Apache Spark](/user-guide/integrations/spark.md): Write batch DataFrames and Structured Streaming micro-batches to GreptimeDB.
 
 ## Next Steps
 

--- a/versioned_docs/version-1.1/user-guide/integrations/spark.md
+++ b/versioned_docs/version-1.1/user-guide/integrations/spark.md
@@ -1,0 +1,149 @@
+---
+keywords: [Apache Spark, Spark connector, data ingestion, batch processing, Structured Streaming, DataSource V2]
+description: Write batch DataFrames and Structured Streaming micro-batches to GreptimeDB with the Apache Spark connector.
+---
+
+# Apache Spark
+
+The [GreptimeDB connector for Apache Spark](https://github.com/GreptimeTeam/spark-connector-greptimedb)
+is a DataSource V2 connector that writes batch DataFrames and Structured
+Streaming micro-batches to GreptimeDB.
+
+The connector requires Java 17 or later and the Scala 2.13 distribution of
+Apache Spark 4.2.0. It is write-only and requires an existing GreptimeDB table.
+
+## Install the connector
+
+### Download from Maven Central
+
+For a Maven-based Spark application, add the connector as a dependency:
+
+```xml
+<dependency>
+  <groupId>io.greptime</groupId>
+  <artifactId>spark-connector-greptimedb</artifactId>
+  <version>VAR::sparkConnectorVersion</version>
+</dependency>
+```
+
+To load the connector directly into a Spark runtime, download the shaded JAR
+from [Maven Central](https://central.sonatype.com/artifact/io.greptime/spark-connector-greptimedb/VAR::sparkConnectorVersion):
+
+```bash
+mvn dependency:copy \
+  -Dartifact=io.greptime:spark-connector-greptimedb:VAR::sparkConnectorVersion:jar:shaded \
+  -DoutputDirectory=/path/to/spark/jars
+```
+
+### Build from source
+
+Build the connector from source:
+
+```bash
+git clone https://github.com/GreptimeTeam/spark-connector-greptimedb.git
+cd spark-connector-greptimedb
+mvn package
+```
+
+The build creates a shaded JAR under `target/`. Add it when submitting your
+Spark application:
+
+```bash
+./bin/spark-submit \
+  --jars /path/to/spark-connector-greptimedb-*-shaded.jar \
+  /path/to/application.jar
+```
+
+## Write a batch DataFrame
+
+Create the destination table in GreptimeDB before writing data:
+
+```sql
+CREATE TABLE cpu_metrics (
+  ts TIMESTAMP(6) TIME INDEX,
+  host STRING,
+  usage DOUBLE,
+  PRIMARY KEY (host)
+);
+```
+
+Then write a DataFrame in append mode:
+
+```java
+Dataset<Row> metrics = ...;
+
+metrics.write()
+        .format("greptimedb")
+        .mode("append")
+        .option("endpoints", "127.0.0.1:4001")
+        .option("database", "public")
+        .option("table", "cpu_metrics")
+        .option("time-index", "ts")
+        .option("tags", "host")
+        .option("batch.max-rows", "1000")
+        .save();
+```
+
+`endpoints` uses the GreptimeDB gRPC endpoint, whose default port is `4001`.
+The `time-index` column must have the Spark SQL type `TIMESTAMP` or
+`TIMESTAMP_NTZ`, and its values must not be null. Columns listed in `tags`
+should match the primary key columns of the destination GreptimeDB table.
+
+## Write a Structured Streaming DataFrame
+
+Use the connector as a Structured Streaming sink in append output mode:
+
+```java
+StreamingQuery query = metrics.writeStream()
+        .format("greptimedb")
+        .outputMode("append")
+        .option("checkpointLocation", "/path/to/checkpoint")
+        .option("endpoints", "127.0.0.1:4001")
+        .option("database", "public")
+        .option("table", "cpu_metrics")
+        .option("time-index", "ts")
+        .option("tags", "host")
+        .start();
+```
+
+## Connector options
+
+| Option | Required | Default | Description |
+| --- | --- | --- | --- |
+| `endpoints` | Yes | - | Comma-separated GreptimeDB gRPC endpoints in `hostname:port` or `IPv4:port` format. |
+| `table` | Yes | - | Existing destination table. |
+| `time-index` | Yes | - | `TIMESTAMP` or `TIMESTAMP_NTZ` column used as the GreptimeDB time index. |
+| `database` | No | `public` | Destination database. |
+| `tags` | No | - | Comma-separated columns written as GreptimeDB tags. |
+| `username` | No | - | GreptimeDB username. Configure with `password`. |
+| `password` | No | - | GreptimeDB password. Configure with `username`. |
+| `batch.max-rows` | No | `1000` | Rows per ingester bulk message in each Spark task. |
+
+For advanced bulk-write options, see the
+[connector README](https://github.com/GreptimeTeam/spark-connector-greptimedb#options).
+
+## Supported data types
+
+| Spark SQL type | GreptimeDB type |
+| --- | --- |
+| `BOOLEAN` | `BOOLEAN` |
+| `TINYINT` | `INT8` |
+| `SMALLINT` | `INT16` |
+| `INT` | `INT32` |
+| `BIGINT` | `INT64` |
+| `FLOAT` | `FLOAT32` |
+| `DOUBLE` | `FLOAT64` |
+| `STRING`, `CHAR`, `VARCHAR` | `STRING` |
+| `BINARY` | `BINARY` |
+| `DATE` | `DATE` |
+| `TIMESTAMP`, `TIMESTAMP_NTZ` | `TIMESTAMP_MICROSECOND` |
+| `DECIMAL(p, s)` | `DECIMAL128(p, s)` |
+
+The connector rejects unsupported complex Spark SQL types before submitting
+the job. It does not validate the server-side schema, so the DataFrame columns
+and mapped types must match the destination table.
+
+Writes are insert-only and provide at-least-once delivery. Failed or retried
+Spark tasks and streaming epochs can produce duplicate rows. The connector
+does not support reads, overwrite, delete, upsert, automatic table creation,
+or exactly-once commits.

--- a/versioned_sidebars/version-1.1-sidebars.json
+++ b/versioned_sidebars/version-1.1-sidebars.json
@@ -163,6 +163,7 @@
             "user-guide/integrations/vector",
             "user-guide/integrations/kafka",
             "user-guide/integrations/flink",
+            "user-guide/integrations/spark",
             "user-guide/integrations/telegraf",
             "user-guide/integrations/grafana",
             "user-guide/integrations/superset",


### PR DESCRIPTION
## What changed

- Add English and Chinese Apache Spark connector guides for Nightly and v1.1.
- Document Maven Central and source installation, batch and Structured Streaming writes, connector options, type mappings, and delivery semantics.
- Add the guides to navigation and data ingestion overviews.
- Define the Spark connector version for Nightly and v1.1.

## Why

GreptimeDB users need a first-party guide for writing Spark batch DataFrames and Structured Streaming micro-batches through the new DataSource V2 connector.

## Validation

- `git diff --cached --check`
- Builds and strict link checks were not run because the repository declares pnpm 8.6.0 while the current lockfile uses format v9, which pnpm 8.6.0 rejects. The lockfile was left unchanged.