### PR TITLE
docs: document runtime.compact_rt_max_blocking_threads

### DIFF
--- a/docs/user-guide/deployments-administration/configuration.md
+++ b/docs/user-guide/deployments-administration/configuration.md
@@ -126,11 +126,11 @@ These options are valid in all subcommands (`standalone`, `datanode`, `frontend`
 # Defaults to the number of CPU cores.
 global_rt_size = 8
 
-# The number of threads to execute compact operations.
+# The number of threads to execute compaction operations.
 # Defaults to max(num_cpus / 2, 1).
 compact_rt_size = 4
 
-# The maximum number of blocking threads for compact operations.
+# The maximum number of blocking threads for compaction operations.
 # Compaction picker CPU work runs on the compact runtime's blocking thread pool,
 # so this limit prevents bursts of compaction planning from consuming all available CPUs.
 # Defaults to max(num_cpus / 2, 1). An explicit 0 is clamped to 1.
@@ -140,8 +140,8 @@ compact_rt_max_blocking_threads = 4
 | Option                               | Type    | Default                  | Description                                                                                                                                                                            |
 | ------------------------------------ | ------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `runtime.global_rt_size`             | Integer | The number of CPU cores  | The number of threads to execute the runtime for global read operations.                                                                                                                |
-| `runtime.compact_rt_size`            | Integer | `max(num_cpus / 2, 1)`   | The number of threads to execute compact operations.                                                                                                                                    |
-| `runtime.compact_rt_max_blocking_threads` | Integer | `max(num_cpus / 2, 1)` | The maximum number of blocking threads for compact operations. Compaction picker CPU work runs on this blocking thread pool. An explicit `0` is clamped to `1`.                          |
+| `runtime.compact_rt_size`            | Integer | `max(num_cpus / 2, 1)`   | The number of threads to execute compaction operations.                                                                                                                                    |
+| `runtime.compact_rt_max_blocking_threads` | Integer | `max(num_cpus / 2, 1)` | The maximum number of blocking threads for compaction operations. Compaction picker CPU work runs on this blocking thread pool. An explicit `0` is clamped to `1`.                          |
 
 ### Write memory limiter options
 

--- a/docs/user-guide/deployments-administration/configuration.md
+++ b/docs/user-guide/deployments-administration/configuration.md
@@ -115,6 +115,34 @@ GREPTIMEDB_METASRV__META_CLIENT__METASRV_ADDRS=127.0.0.1:3001,127.0.0.1:3002,127
 In this section, we will introduce some main configuration options.
 For all options, refer to the [Configuration Reference](https://github.com/GreptimeTeam/greptimedb/blob/VAR::greptimedbVersion/config/config.md) on Github.
 
+### Runtime options
+
+GreptimeDB executes background work on several dedicated Tokio runtimes.
+These options are valid in all subcommands (`standalone`, `datanode`, `frontend`, and `metasrv`).
+
+```toml
+[runtime]
+# The number of threads to execute the runtime for global read operations.
+# Defaults to the number of CPU cores.
+global_rt_size = 8
+
+# The number of threads to execute compact operations.
+# Defaults to max(num_cpus / 2, 1).
+compact_rt_size = 4
+
+# The maximum number of blocking threads for compact operations.
+# Compaction picker CPU work runs on the compact runtime's blocking thread pool,
+# so this limit prevents bursts of compaction planning from consuming all available CPUs.
+# Defaults to max(num_cpus / 2, 1). An explicit 0 is clamped to 1.
+compact_rt_max_blocking_threads = 4
+```
+
+| Option                               | Type    | Default                  | Description                                                                                                                                                                            |
+| ------------------------------------ | ------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `runtime.global_rt_size`             | Integer | The number of CPU cores  | The number of threads to execute the runtime for global read operations.                                                                                                                |
+| `runtime.compact_rt_size`            | Integer | `max(num_cpus / 2, 1)`   | The number of threads to execute compact operations.                                                                                                                                    |
+| `runtime.compact_rt_max_blocking_threads` | Integer | `max(num_cpus / 2, 1)` | The maximum number of blocking threads for compact operations. Compaction picker CPU work runs on this blocking thread pool. An explicit `0` is clamped to `1`.                          |
+
 ### Write memory limiter options
 
 Memory limiter options control the total memory used by concurrent write requests across all protocols (HTTP, gRPC, and Arrow Flight).
@@ -1007,6 +1035,8 @@ ingest_rt_size = 8
 | grpc.runtime_size | Integer | The number of gRPC server worker threads, 8 by default.                                                                                                                                                                                                                         |
 | runtime.query_rt_size | Integer | The number of threads to execute datanode query operations. Defaults to `max(num_cpus - 1, 1)`. |
 | runtime.ingest_rt_size | Integer | The number of threads to execute datanode ingestion operations. Defaults to the number of CPU cores. |
+
+For the common runtime options shared by all components, see [Runtime options](#runtime-options).
 
 ### Frontend-only configuration
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/configuration.md
@@ -113,6 +113,34 @@ GREPTIMEDB_METASRV__META_CLIENT__METASRV_ADDRS=127.0.0.1:3001,127.0.0.1:3002,127
 
 本节将介绍主要的配置项，请前往 GitHub 查看[所有配置项](https://github.com/GreptimeTeam/greptimedb/blob/VAR::greptimedbVersion/config/config.md)。
 
+### 运行时选项
+
+GreptimeDB 在多个专用的 Tokio 运行时上执行后台任务。
+这些选项适用于所有子命令（`standalone`、`datanode`、`frontend` 和 `metasrv`）。
+
+```toml
+[runtime]
+# 执行全局读操作的运行时线程数。
+# 默认为 CPU 核心数。
+global_rt_size = 8
+
+# 执行 compaction 操作的线程数。
+# 默认为 max(num_cpus / 2, 1)。
+compact_rt_size = 4
+
+# compaction 操作的最大阻塞线程数。
+# compaction picker 的 CPU 工作运行在 compact 运行时的阻塞线程池中，
+# 该限制可防止 compaction 规划的突发负载耗尽所有可用 CPU。
+# 默认为 max(num_cpus / 2, 1)。显式设置为 0 时会被调整为 1。
+compact_rt_max_blocking_threads = 4
+```
+
+| 配置项                                  | 类型   | 默认值                   | 描述                                                                                                                                   |
+| --------------------------------------- | ------ | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `runtime.global_rt_size`                | 整数   | CPU 核心数               | 执行全局读操作的运行时线程数。                                                                                                          |
+| `runtime.compact_rt_size`               | 整数   | `max(num_cpus / 2, 1)`   | 执行 compaction 操作的线程数。                                                                                                          |
+| `runtime.compact_rt_max_blocking_threads` | 整数 | `max(num_cpus / 2, 1)`   | compaction 操作的最大阻塞线程数。compaction picker 的 CPU 工作运行在该阻塞线程池中。显式设置为 `0` 时会被调整为 `1`。                    |
+
 ### 写入内存限制选项
 
 内存限制选项控制所有协议（HTTP、gRPC 和 Arrow Flight）并发写入请求使用的总内存。
@@ -994,6 +1022,8 @@ ingest_rt_size = 8
 | grpc.runtime_size | 整数   | gRPC 服务器工作线程数，默认为 8。           |
 | runtime.query_rt_size | 整数   | 执行 datanode 查询操作的运行时线程数。默认值为 `max(num_cpus - 1, 1)`。 |
 | runtime.ingest_rt_size | 整数   | 执行 datanode 写入操作的运行时线程数。默认值为 CPU 核心数。 |
+
+所有组件共享的通用运行时选项，请参阅[运行时选项](#运行时选项)。
 
 ### 仅限于 `Frontend` 的配置
 


### PR DESCRIPTION
## What's changed

Adds a **Runtime options** section to the configuration guide (`docs/user-guide/deployments-administration/configuration.md` and the Chinese `current/` page) covering the common `[runtime]` options:

- `runtime.global_rt_size`
- `runtime.compact_rt_size`
- `runtime.compact_rt_max_blocking_threads` (new, introduced in [GreptimeTeam/greptimedb#8704](https://github.com/GreptimeTeam/greptimedb/pull/8704))

The new option bounds the blocking thread pool of the compact runtime where compaction picker CPU work runs. Default is `max(num_cpus / 2, 1)`; an explicit `0` is clamped to `1`. Also adds a cross-reference from the Datanode-only runtime options to the new section.

Scope: Nightly only (`docs/` + zh `current/`), since the option is not in any released version.

## Checks

- [x] `git diff --check`
- [x] `DOC_LANG=en pnpm check:links`
- [x] `DOC_LANG=zh pnpm check:links`

Closes #2674