### PR TITLE
docs: move soft-drop docs to enterprise section

### DIFF
--- a/docs/enterprise/overview.md
+++ b/docs/enterprise/overview.md
@@ -32,6 +32,8 @@ which are described in detail in the documentation in this section:
   user activity with detailed audit logs.
 - [Query Guard](./deployments-administration/query-guard.md): Ban `DROP TABLE` / `DROP DATABASE`
   statements for all users and reject cross-catalog access.
+- [Soft-Drop Tables](./soft-drop.md): Protect tables from accidental `DROP TABLE`
+  operations and restore them from the recycle bin within the retention period.
 - [Automatic region load balance](./autopilot/region-balancer.md): Auto balance
   datanodes workload by moving regions between them.
 - [Scheduled Compaction](./deployments-administration/scheduled-compaction.md): Periodically submit regular compaction requests for all physical Regions, with HTTP endpoints for manual triggers and job queries.

--- a/docs/enterprise/soft-drop.md
+++ b/docs/enterprise/soft-drop.md
@@ -1,6 +1,6 @@
 ---
-keywords: [soft drop, recycle bin, drop table, undrop table, purge table, data recovery]
-description: How to enable and use soft-drop tables in GreptimeDB.
+keywords: [soft drop, recycle bin, drop table, undrop table, purge table, data recovery, GreptimeDB Enterprise]
+description: How to enable and use soft-drop tables in GreptimeDB Enterprise.
 ---
 
 # Soft-Drop Tables
@@ -30,7 +30,7 @@ The options are:
 | `gc.experimental_soft_drop.enable` | Enables soft-drop for supported tables in distributed mode. |
 | `gc.experimental_soft_drop.retention` | How long a soft-dropped table can stay in the recycle bin before Metasrv GC automatically purges it. The value must be at least `1ms`. |
 
-Restart Metasrv after changing these options. For ordinary file GC, keep Metasrv and Datanode GC settings consistent as described in [Garbage Collection](./gc.md).
+Restart Metasrv after changing these options. For ordinary file GC, keep Metasrv and Datanode GC settings consistent as described in [Garbage Collection](/user-guide/deployments-administration/manage-data/gc.md).
 
 ## Drop a table
 

--- a/docs/reference/sql/admin.md
+++ b/docs/reference/sql/admin.md
@@ -28,7 +28,7 @@ GreptimeDB provides some administration functions to manage the database and dat
 * `reconcile_catalog()` to reconcile the metadata inconsistency of all tables in the entire cluster, read [table reconciliation](/user-guide/deployments-administration/maintenance/table-reconciliation.md) for more details.
 * `gc_table(table_name, [full_file_listing])` to garbage collect orphaned SST files in object storage for a dropped table. Returns the number of processed regions. The optional `full_file_listing` boolean (default `false`) enables a thorough scan of all files when set to `true`.
 * `gc_regions(region_id1, ..., region_idN, [full_file_listing])` to garbage collect orphaned SST files in object storage for one or more specific regions by their region ids. Returns the number of processed regions. The optional `full_file_listing` boolean (default `false`) enables a thorough scan of all files when set to `true`.
-* `purge_table(table_name)` to permanently purge a [soft-dropped table](/user-guide/deployments-administration/manage-data/soft-drop.md). The table name can be unqualified, schema-qualified, or fully qualified. This function is only available through the `ADMIN` statement.
+* `purge_table(table_name)` to permanently purge a [soft-dropped table](/enterprise/soft-drop.md). The table name can be unqualified, schema-qualified, or fully qualified. This function is only available in the GreptimeDB Enterprise database through the `ADMIN` statement.
 
 For example:
 ```sql

--- a/docs/reference/sql/drop.md
+++ b/docs/reference/sql/drop.md
@@ -41,7 +41,7 @@ DROP DATABASE test;
 
 ## DROP TABLE
 
-`DROP TABLE` removes tables from the database. By default, it removes the table definition and all table data, indexes, rules, and constraints for that table. If [soft-drop](/enterprise/soft-drop.md) is enabled in a distributed cluster, supported tables are moved to the recycle bin and can be restored before the retention deadline.
+`DROP TABLE` removes tables from the database. By default, it removes the table definition and all table data, indexes, rules, and constraints for that table. If [soft-drop](/enterprise/soft-drop.md) (GreptimeDB Enterprise only) is enabled in a distributed cluster, supported tables are moved to the recycle bin and can be restored before the retention deadline.
 
 :::danger Danger
 

--- a/docs/reference/sql/drop.md
+++ b/docs/reference/sql/drop.md
@@ -41,7 +41,7 @@ DROP DATABASE test;
 
 ## DROP TABLE
 
-`DROP TABLE` removes tables from the database. By default, it removes the table definition and all table data, indexes, rules, and constraints for that table. If [soft-drop](/user-guide/deployments-administration/manage-data/soft-drop.md) is enabled in a distributed cluster, supported tables are moved to the recycle bin and can be restored before the retention deadline.
+`DROP TABLE` removes tables from the database. By default, it removes the table definition and all table data, indexes, rules, and constraints for that table. If [soft-drop](/enterprise/soft-drop.md) is enabled in a distributed cluster, supported tables are moved to the recycle bin and can be restored before the retention deadline.
 
 :::danger Danger
 
@@ -68,6 +68,12 @@ DROP TABLE monitor;
 ```
 
 ## UNDROP TABLE
+
+:::tip NOTE
+
+This feature is only available in the GreptimeDB Enterprise database.
+
+:::
 
 `UNDROP TABLE` restores a soft-dropped table from the recycle bin.
 

--- a/docs/reference/sql/information-schema/recycle-bin.md
+++ b/docs/reference/sql/information-schema/recycle-bin.md
@@ -5,6 +5,12 @@ description: Describes the RECYCLE_BIN table in INFORMATION_SCHEMA.
 
 # RECYCLE_BIN
 
+:::tip NOTE
+
+This feature is only available in the GreptimeDB Enterprise database.
+
+:::
+
 The `RECYCLE_BIN` table lists soft-dropped tables that are still eligible for restore.
 
 ```sql

--- a/docs/user-guide/deployments-administration/manage-data/basic-table-operations.md
+++ b/docs/user-guide/deployments-administration/manage-data/basic-table-operations.md
@@ -300,7 +300,7 @@ The `ALTER TABLE` statement also supports adding, removing, and renaming columns
 ## Drop a table
 
 :::danger danger
-Without [soft-drop](./soft-drop.md), `DROP TABLE` cannot be undone. Use it with care!
+Without [soft-drop](/enterprise/soft-drop.md) (GreptimeDB Enterprise only), `DROP TABLE` cannot be undone. Use it with care!
 :::
 
 `DROP TABLE [db.]table` is used to drop the table in `db` or the current database in-use.Drop the table `monitor` in the current database:

--- a/docs/user-guide/deployments-administration/manage-data/gc.md
+++ b/docs/user-guide/deployments-administration/manage-data/gc.md
@@ -27,7 +27,7 @@ enable = true              # Enable meta GC scheduler. default to be false; must
 gc_cooldown_period = "5m"   # Minimum gap before the same region is GCed again.
 
 [gc.experimental_soft_drop]
-enable = false             # Enable soft-drop tables. Requires gc.enable = true.
+enable = false             # Enable soft-drop tables (GreptimeDB Enterprise only). Requires gc.enable = true.
 retention = "7d"            # How long soft-dropped tables are retained before purge.
 ```
 
@@ -37,7 +37,7 @@ retention = "7d"            # How long soft-dropped tables are retained before p
 | --- | --- |
 | `enable` | Enable the meta GC scheduler. Must match datanode GC enablement. |
 | `gc_cooldown_period` | Minimum interval before the same region is scheduled for GC again; keep datanode `lingering_time` longer than this. |
-| `experimental_soft_drop.enable` | Enable [soft-drop tables](./soft-drop.md). Requires `gc.enable = true`. |
+| `experimental_soft_drop.enable` | Enable [soft-drop tables](/enterprise/soft-drop.md) (GreptimeDB Enterprise only). Requires `gc.enable = true`. |
 | `experimental_soft_drop.retention` | How long soft-dropped tables are retained before automatic purge. |
 
 ## Datanode Configuration

--- a/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/overview.md
@@ -29,6 +29,7 @@ GreptimeDB Enterprise 包括以下高级功能，
 - [部署 GreptimeDB](./deployments-administration/overview.md)：设置认证信息及其他关键配置后，将 GreptimeDB 部署在 Kubernetes 上并监控关键指标。
 - [审计日志](./deployments-administration/monitoring/audit-logging.md)：记录数据库用户行为的日志。
 - [Query Guard](./deployments-administration/query-guard.md)：对所有用户（包括管理员）禁止 `DROP TABLE` / `DROP DATABASE` 语句，并拒绝跨 catalog 访问。
+- [Soft-Drop Table](./soft-drop.md)：防止误删表，可在保留期内从 recycle bin 中恢复表。
 - [自动分区平衡](./autopilot/region-balancer.md)：通过分区监控和迁移在 datanode 之间自动平衡负载。
 - [定时 Compaction](./deployments-administration/scheduled-compaction.md)：定期为所有物理 Region 提交 regular Compaction 请求，并提供用于人工触发和任务查询的 HTTP endpoints。
 - [Elasticsearch 查询兼容性](./elasticsearch-compatible/overview.md)：在 Kibana 中以 GreptimeDB 作为后端。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/soft-drop.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/soft-drop.md
@@ -1,6 +1,6 @@
 ---
-keywords: [soft drop, recycle bin, drop table, undrop table, purge table, 数据恢复]
-description: 介绍如何在 GreptimeDB 中开启和使用 soft-drop table。
+keywords: [soft drop, recycle bin, drop table, undrop table, purge table, 数据恢复, GreptimeDB 企业版]
+description: 介绍如何在 GreptimeDB 企业版中开启和使用 soft-drop table。
 ---
 
 # Soft-Drop Table
@@ -30,7 +30,7 @@ retention = "7d"
 | `gc.experimental_soft_drop.enable` | 在分布式模式中为支持的表启用 soft-drop。 |
 | `gc.experimental_soft_drop.retention` | Soft-dropped table 在 recycle bin 中保留多久后由 Metasrv GC 自动 purge。该值必须至少为 `1ms`。 |
 
-修改配置后请重启 Metasrv。普通文件 GC 仍需按照[垃圾回收（GC）](./gc.md)中的说明，保持 Metasrv 与 Datanode 的 GC 配置一致。
+修改配置后请重启 Metasrv。普通文件 GC 仍需按照[垃圾回收（GC）](/user-guide/deployments-administration/manage-data/gc.md)中的说明，保持 Metasrv 与 Datanode 的 GC 配置一致。
 
 ## 删除表
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/admin.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/admin.md
@@ -27,7 +27,7 @@ GreptimeDB 提供了一些管理函数来管理数据库和数据：
 * `reconcile_catalog()` 修复整个集群中所有表的元数据不一致问题，详细信息请阅读 [table reconciliation](/user-guide/deployments-administration/maintenance/table-reconciliation.md)。
 * `gc_table(table_name, [full_file_listing])` 对对象存储中已删除表的孤立 SST 文件进行垃圾回收，返回已处理的 Region 数量。可选参数 `full_file_listing`（默认为 `false`），设为 `true` 时启用全量文件扫描模式。
 * `gc_regions(region_id1, ..., region_idN, [full_file_listing])` 根据 Region ID 对对象存储中指定 Region 的孤立 SST 文件进行垃圾回收，返回已处理的 Region 数量。可选参数 `full_file_listing`（默认为 `false`），设为 `true` 时启用全量文件扫描模式。
-* `purge_table(table_name)` 永久 purge 一个 [soft-dropped table](/user-guide/deployments-administration/manage-data/soft-drop.md)。表名可以是未限定、schema 限定或完整限定名称。该函数只能通过 `ADMIN` 语句调用。
+* `purge_table(table_name)` 永久 purge 一个 [soft-dropped table](/enterprise/soft-drop.md)。表名可以是未限定、schema 限定或完整限定名称。该函数仅在 GreptimeDB 企业版中可用，且只能通过 `ADMIN` 语句调用。
 
 例如：
 ```sql

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/drop.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/drop.md
@@ -40,7 +40,7 @@ DROP DATABASE test;
 
 ## DROP TABLE
 
-`DROP TABLE` 从数据库中删除表。默认情况下，它会删除该表的表定义和所有表数据、索引、规则和约束。如果在分布式集群中开启了 [soft-drop](/enterprise/soft-drop.md)，支持的表会进入 recycle bin，并且可以在 retention deadline 前恢复。
+`DROP TABLE` 从数据库中删除表。默认情况下，它会删除该表的表定义和所有表数据、索引、规则和约束。如果在分布式集群中开启了 [soft-drop](/enterprise/soft-drop.md)（仅 GreptimeDB 企业版），支持的表会进入 recycle bin，并且可以在 retention deadline 前恢复。
 
 :::danger 危险操作
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/drop.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/drop.md
@@ -40,7 +40,7 @@ DROP DATABASE test;
 
 ## DROP TABLE
 
-`DROP TABLE` 从数据库中删除表。默认情况下，它会删除该表的表定义和所有表数据、索引、规则和约束。如果在分布式集群中开启了 [soft-drop](/user-guide/deployments-administration/manage-data/soft-drop.md)，支持的表会进入 recycle bin，并且可以在 retention deadline 前恢复。
+`DROP TABLE` 从数据库中删除表。默认情况下，它会删除该表的表定义和所有表数据、索引、规则和约束。如果在分布式集群中开启了 [soft-drop](/enterprise/soft-drop.md)，支持的表会进入 recycle bin，并且可以在 retention deadline 前恢复。
 
 :::danger 危险操作
 
@@ -66,6 +66,12 @@ DROP TABLE monitor;
 ```
 
 ## UNDROP TABLE
+
+:::tip 注意
+
+本功能仅在 GreptimeDB 企业版中可用。
+
+:::
 
 `UNDROP TABLE` 用于从 recycle bin 中恢复 soft-dropped table。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/information-schema/recycle-bin.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/information-schema/recycle-bin.md
@@ -5,6 +5,12 @@ description: 介绍 INFORMATION_SCHEMA 中的 RECYCLE_BIN 表。
 
 # RECYCLE_BIN
 
+:::tip 注意
+
+本功能仅在 GreptimeDB 企业版中可用。
+
+:::
+
 `RECYCLE_BIN` 表列出仍可恢复的 soft-dropped table。
 
 ```sql

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/manage-data/basic-table-operations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/manage-data/basic-table-operations.md
@@ -298,7 +298,7 @@ Query OK, 0 rows affected (0.03 sec)
 ## 删除表
 
 :::danger 危险操作
-未开启 [soft-drop](./soft-drop.md) 时，表删除后不可撤销！请谨慎操作！
+未开启 [soft-drop](/enterprise/soft-drop.md)（仅 GreptimeDB 企业版）时，表删除后不可撤销！请谨慎操作！
 :::
 
 `DROP TABLE [db.]table` 用于删除 `db` 或当前正在使用的数据库中的表。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/manage-data/gc.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/manage-data/gc.md
@@ -27,7 +27,7 @@ enable = true              # 开启 meta GC 调度器，默认值为 false；必
 gc_cooldown_period = "5m"   # 同一 region 再次 GC 的最小间隔。
 
 [gc.experimental_soft_drop]
-enable = false             # 开启 soft-drop table。要求 gc.enable = true。
+enable = false             # 开启 soft-drop table（仅 GreptimeDB 企业版）。要求 gc.enable = true。
 retention = "7d"            # Soft-dropped table 被 purge 前的保留时长。
 ```
 
@@ -37,7 +37,7 @@ retention = "7d"            # Soft-dropped table 被 purge 前的保留时长。
 | --- | --- |
 | `enable` | 启用 meta GC 调度器，必须与 datanode 的 GC 开关一致。 |
 | `gc_cooldown_period` | 同一 region 再次被调度 GC 的最小间隔；请保证 datanode 的 `lingering_time` 大于该值。 |
-| `experimental_soft_drop.enable` | 启用 [soft-drop table](./soft-drop.md)。要求 `gc.enable = true`。 |
+| `experimental_soft_drop.enable` | 启用 [soft-drop table](/enterprise/soft-drop.md)（仅 GreptimeDB 企业版）。要求 `gc.enable = true`。 |
 | `experimental_soft_drop.retention` | Soft-dropped table 自动 purge 前的保留时长。 |
 
 ## Datanode 配置

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/manage-data/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/manage-data/overview.md
@@ -14,4 +14,3 @@ description: 提供 GreptimeDB 数据管理的概述，包括存储位置说明�
 * [Region Migration](region-migration.md): 为负载均衡迁移 Region
 * [Region Failover](/user-guide/deployments-administration/manage-data/region-failover.md)
 * [Compaction](compaction.md)
-* [Soft-Drop Table](soft-drop.md): 防止误删表并在保留期内恢复

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -370,7 +370,6 @@ const sidebars: SidebarsConfig = {
                 'user-guide/deployments-administration/manage-data/repartition',
                 'user-guide/deployments-administration/manage-data/compaction',
                 'user-guide/deployments-administration/manage-data/gc',
-                'user-guide/deployments-administration/manage-data/soft-drop',
               ],
             },
             {
@@ -526,6 +525,7 @@ const sidebars: SidebarsConfig = {
           ],
         },
         'enterprise/trigger',
+        'enterprise/soft-drop',
         'enterprise/user',
         {
           type: 'category',


### PR DESCRIPTION
## What changed

GreptimeDB PR [GreptimeTeam/greptimedb#8747](https://github.com/GreptimeTeam/greptimedb/pull/8747) gates soft-drop tables behind the `enterprise` cargo feature, covering the config entrance (`gc.experimental_soft_drop`), the SQL surface (`UNDROP TABLE`, `ADMIN purge_table()`, `information_schema.recycle_bin`), and the purge/GC procedures.

This PR moves all soft-drop related documentation into the Enterprise section, following the same convention as the trigger docs (#2045):

- Moved the soft-drop user guide from `user-guide/deployments-administration/manage-data/` to `enterprise/soft-drop.md` (English and Chinese), and updated `sidebars.ts` accordingly.
- Added the "only available in GreptimeDB Enterprise" tip to the SQL reference pages: `UNDROP TABLE` in `reference/sql/drop.md` and `reference/sql/information-schema/recycle-bin.md`.
- Marked `ADMIN purge_table()` in `reference/sql/admin.md` as enterprise-only.
- Marked the `gc.experimental_soft_drop` options in `user-guide/deployments-administration/manage-data/gc.md` as enterprise-only (ordinary file GC remains documented as-is).
- Added Soft-Drop to the feature list in `enterprise/overview.md` (English and Chinese); removed it from the Chinese manage-data overview list.
- Updated all inbound links to point to `/enterprise/soft-drop.md`.

## Scope

- Documentation versions: Nightly (soft-drop does not exist in any released versioned docs)
- Languages: English, Chinese

## Verification

- `git diff --check`
- `DOC_LANG=en pnpm check:links` — passed
- `DOC_LANG=zh pnpm check:links` — passed
- Reviewed the full diff for unintended versions/languages/generated files; no lockfile changes.

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] I updated navigation when the document structure changed.