### PR TITLE
docs: document Kafka WAL create_index option

### DIFF
--- a/docs/user-guide/deployments-administration/wal/remote-wal/configuration.md
+++ b/docs/user-guide/deployments-administration/wal/remote-wal/configuration.md
@@ -77,6 +77,7 @@ The Datanode side is mainly used to write the data to the Kafka topics and read 
 provider = "kafka"
 broker_endpoints = ["kafka.kafka-cluster.svc:9092"]
 max_batch_bytes = "1MB"
+create_index = false
 overwrite_entry_start_id = true
 connect_timeout = "3s"
 timeout = "3s"
@@ -89,6 +90,7 @@ timeout = "3s"
 | `provider`                 | Set to "kafka" to enable Remote WAL via Kafka.                                                                                |
 | `broker_endpoints`         | List of Kafka broker addresses.                                                                                               |
 | `max_batch_bytes`          | Maximum size for each Kafka producer batch.                                                                                   |
+| `create_index`             | Whether to create per-region Kafka WAL indexes. The default is `false`, and the option only takes effect in distributed mode. Enable it when many regions share a Kafka topic to reduce Kafka reads and speed up WAL replay during recovery. |
 | `overwrite_entry_start_id` | If true, the Datanode will skip over missing entries during WAL replay. Prevents out-of-range errors, but may hide data loss. |
 | `connect_timeout`          | The connect timeout for Kafka client. Default is `"3s"`.                                                                      |
 | `timeout`                  | The timeout for Kafka client operations. Default is `"3s"`.                                                                   |

--- a/docs/user-guide/deployments-administration/wal/remote-wal/configuration.md
+++ b/docs/user-guide/deployments-administration/wal/remote-wal/configuration.md
@@ -90,7 +90,7 @@ timeout = "3s"
 | `provider`                 | Set to "kafka" to enable Remote WAL via Kafka.                                                                                |
 | `broker_endpoints`         | List of Kafka broker addresses.                                                                                               |
 | `max_batch_bytes`          | Maximum size for each Kafka producer batch.                                                                                   |
-| `create_index`             | Whether to create per-region Kafka WAL indexes. The default is `false`, and the option only takes effect in distributed mode. Enable it when many regions share a Kafka topic to reduce Kafka reads and speed up WAL replay during recovery. |
+| `create_index`             | Whether to create per-region Kafka WAL indexes. The default is `false`, and the option only takes effect in distributed mode. The index can reduce Kafka reads during recovery, but enable it only after confirming significant read amplification during single-region recovery. The Datanode persists the index to object storage every `dump_index_interval` (`"60s"` by default), adding continuous object-store I/O. |
 | `overwrite_entry_start_id` | If true, the Datanode will skip over missing entries during WAL replay. Prevents out-of-range errors, but may hide data loss. |
 | `connect_timeout`          | The connect timeout for Kafka client. Default is `"3s"`.                                                                      |
 | `timeout`                  | The timeout for Kafka client operations. Default is `"3s"`.                                                                   |

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/wal/remote-wal/configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/wal/remote-wal/configuration.md
@@ -87,7 +87,7 @@ timeout = "3s"
 | `provider`                 | 设置为 `"kafka"` 以启用 Remote WAL。                                                         |
 | `broker_endpoints`         | Kafka broker 的地址列表。                                                                    |
 | `max_batch_bytes`          | 每个写入批次的最大大小，默认不能超过 Kafka 配置的单条消息上限（通常为 1MB）。                |
-| `create_index`             | 是否为各个 Region 创建 Kafka WAL 索引，默认值为 `false`，且仅在分布式模式下生效。当多个 Region 共享一个 Kafka topic 时，可以启用该配置，以减少 Kafka 读取量并加快恢复期间的 WAL 回放。 |
+| `create_index`             | 是否为各个 Region 创建 Kafka WAL 索引，默认值为 `false`，且仅在分布式模式下生效。索引可以减少恢复期间的 Kafka 读取量，但仅建议在确认单个 Region 恢复存在明显读取放大后启用。Datanode 每隔 `dump_index_interval`（默认值为 `"60s"`）将索引持久化到对象存储，这会产生持续的对象存储 I/O。 |
 | `overwrite_entry_start_id` | 若设为 `true`，在 WAL 回放时跳过缺失的 entry，避免 out-of-range 错误（但可能掩盖数据丢失）。 |
 | `connect_timeout`          | Kafka 客户端的连接超时时间，默认值为 `"3s"`。                                                 |
 | `timeout`                  | Kafka 客户端操作的超时时间，默认值为 `"3s"`。                                                 |

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/wal/remote-wal/configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/wal/remote-wal/configuration.md
@@ -74,6 +74,7 @@ Datanode 负责将数据写入 Kafka 并从中读取数据。
 provider = "kafka"
 broker_endpoints = ["kafka.kafka-cluster.svc.cluster.local:9092"]
 max_batch_bytes = "1MB"
+create_index = false
 overwrite_entry_start_id = true
 connect_timeout = "3s"
 timeout = "3s"
@@ -86,6 +87,7 @@ timeout = "3s"
 | `provider`                 | 设置为 `"kafka"` 以启用 Remote WAL。                                                         |
 | `broker_endpoints`         | Kafka broker 的地址列表。                                                                    |
 | `max_batch_bytes`          | 每个写入批次的最大大小，默认不能超过 Kafka 配置的单条消息上限（通常为 1MB）。                |
+| `create_index`             | 是否为各个 Region 创建 Kafka WAL 索引，默认值为 `false`，且仅在分布式模式下生效。当多个 Region 共享一个 Kafka topic 时，可以启用该配置，以减少 Kafka 读取量并加快恢复期间的 WAL 回放。 |
 | `overwrite_entry_start_id` | 若设为 `true`，在 WAL 回放时跳过缺失的 entry，避免 out-of-range 错误（但可能掩盖数据丢失）。 |
 | `connect_timeout`          | Kafka 客户端的连接超时时间，默认值为 `"3s"`。                                                 |
 | `timeout`                  | Kafka 客户端操作的超时时间，默认值为 `"3s"`。                                                 |

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/wal/remote-wal/configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/wal/remote-wal/configuration.md
@@ -87,7 +87,7 @@ timeout = "3s"
 | `provider`                 | 设置为 `"kafka"` 以启用 Remote WAL。                                                         |
 | `broker_endpoints`         | Kafka broker 的地址列表。                                                                    |
 | `max_batch_bytes`          | 每个写入批次的最大大小，默认不能超过 Kafka 配置的单条消息上限（通常为 1MB）。                |
-| `create_index`             | 是否为各个 Region 创建 Kafka WAL 索引，默认值为 `false`，且仅在分布式模式下生效。当多个 Region 共享一个 Kafka topic 时，可以启用该配置，以减少 Kafka 读取量并加快恢复期间的 WAL 回放。 |
+| `create_index`             | 是否为各个 Region 创建 Kafka WAL 索引，默认值为 `false`，且仅在分布式模式下生效。索引可以减少恢复期间的 Kafka 读取量，但仅建议在确认单个 Region 恢复存在明显读取放大后启用。Datanode 每隔 `dump_index_interval`（默认值为 `"60s"`）将索引持久化到对象存储，这会产生持续的对象存储 I/O。 |
 | `overwrite_entry_start_id` | 若设为 `true`，在 WAL 回放时跳过缺失的 entry，避免 out-of-range 错误（但可能掩盖数据丢失）。 |
 | `connect_timeout`          | Kafka 客户端的连接超时时间，默认值为 `"3s"`。                                                 |
 | `timeout`                  | Kafka 客户端操作的超时时间，默认值为 `"3s"`。                                                 |

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/wal/remote-wal/configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/wal/remote-wal/configuration.md
@@ -74,6 +74,7 @@ Datanode 负责将数据写入 Kafka 并从中读取数据。
 provider = "kafka"
 broker_endpoints = ["kafka.kafka-cluster.svc.cluster.local:9092"]
 max_batch_bytes = "1MB"
+create_index = false
 overwrite_entry_start_id = true
 connect_timeout = "3s"
 timeout = "3s"
@@ -86,6 +87,7 @@ timeout = "3s"
 | `provider`                 | 设置为 `"kafka"` 以启用 Remote WAL。                                                         |
 | `broker_endpoints`         | Kafka broker 的地址列表。                                                                    |
 | `max_batch_bytes`          | 每个写入批次的最大大小，默认不能超过 Kafka 配置的单条消息上限（通常为 1MB）。                |
+| `create_index`             | 是否为各个 Region 创建 Kafka WAL 索引，默认值为 `false`，且仅在分布式模式下生效。当多个 Region 共享一个 Kafka topic 时，可以启用该配置，以减少 Kafka 读取量并加快恢复期间的 WAL 回放。 |
 | `overwrite_entry_start_id` | 若设为 `true`，在 WAL 回放时跳过缺失的 entry，避免 out-of-range 错误（但可能掩盖数据丢失）。 |
 | `connect_timeout`          | Kafka 客户端的连接超时时间，默认值为 `"3s"`。                                                 |
 | `timeout`                  | Kafka 客户端操作的超时时间，默认值为 `"3s"`。                                                 |

--- a/versioned_docs/version-1.2/user-guide/deployments-administration/wal/remote-wal/configuration.md
+++ b/versioned_docs/version-1.2/user-guide/deployments-administration/wal/remote-wal/configuration.md
@@ -77,6 +77,7 @@ The Datanode side is mainly used to write the data to the Kafka topics and read 
 provider = "kafka"
 broker_endpoints = ["kafka.kafka-cluster.svc:9092"]
 max_batch_bytes = "1MB"
+create_index = false
 overwrite_entry_start_id = true
 connect_timeout = "3s"
 timeout = "3s"
@@ -89,6 +90,7 @@ timeout = "3s"
 | `provider`                 | Set to "kafka" to enable Remote WAL via Kafka.                                                                                |
 | `broker_endpoints`         | List of Kafka broker addresses.                                                                                               |
 | `max_batch_bytes`          | Maximum size for each Kafka producer batch.                                                                                   |
+| `create_index`             | Whether to create per-region Kafka WAL indexes. The default is `false`, and the option only takes effect in distributed mode. Enable it when many regions share a Kafka topic to reduce Kafka reads and speed up WAL replay during recovery. |
 | `overwrite_entry_start_id` | If true, the Datanode will skip over missing entries during WAL replay. Prevents out-of-range errors, but may hide data loss. |
 | `connect_timeout`          | The connect timeout for Kafka client. Default is `"3s"`.                                                                      |
 | `timeout`                  | The timeout for Kafka client operations. Default is `"3s"`.                                                                   |

--- a/versioned_docs/version-1.2/user-guide/deployments-administration/wal/remote-wal/configuration.md
+++ b/versioned_docs/version-1.2/user-guide/deployments-administration/wal/remote-wal/configuration.md
@@ -90,7 +90,7 @@ timeout = "3s"
 | `provider`                 | Set to "kafka" to enable Remote WAL via Kafka.                                                                                |
 | `broker_endpoints`         | List of Kafka broker addresses.                                                                                               |
 | `max_batch_bytes`          | Maximum size for each Kafka producer batch.                                                                                   |
-| `create_index`             | Whether to create per-region Kafka WAL indexes. The default is `false`, and the option only takes effect in distributed mode. Enable it when many regions share a Kafka topic to reduce Kafka reads and speed up WAL replay during recovery. |
+| `create_index`             | Whether to create per-region Kafka WAL indexes. The default is `false`, and the option only takes effect in distributed mode. The index can reduce Kafka reads during recovery, but enable it only after confirming significant read amplification during single-region recovery. The Datanode persists the index to object storage every `dump_index_interval` (`"60s"` by default), adding continuous object-store I/O. |
 | `overwrite_entry_start_id` | If true, the Datanode will skip over missing entries during WAL replay. Prevents out-of-range errors, but may hide data loss. |
 | `connect_timeout`          | The connect timeout for Kafka client. Default is `"3s"`.                                                                      |
 | `timeout`                  | The timeout for Kafka client operations. Default is `"3s"`.                                                                   |


### PR DESCRIPTION
## What changed

Document the Datanode Kafka WAL `create_index` option in the Nightly and v1.2 Remote WAL configuration pages. The update describes its default value of `false`, its distributed-mode limitation, and when enabling it can reduce Kafka reads and speed up WAL replay.

Closes #2724.

## Scope

- Documentation versions: Nightly, 1.2
- Languages: English, Chinese

## Verification

- `pnpm build`
- `DOC_LANG=zh pnpm build`
- `DOC_LANG=en pnpm check:links`
- `DOC_LANG=zh pnpm check:links`
- `git diff --check`

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] I updated navigation when the document structure changed.
