### PR TITLE
docs: add Events reference for 1.2

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2.json
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2.json
@@ -246,5 +246,9 @@
   "sidebar.docs.category.Management Console": {
     "message": "管理控制台",
     "description": "The label for category Management Console in sidebar docs"
+  },
+  "sidebar.docs.category.Events": {
+    "message": "事件",
+    "description": "The label for category Events in sidebar docs"
   }
 }

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/sql/greptime-private/events.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/sql/greptime-private/events.md
@@ -1,0 +1,22 @@
+---
+keywords: [事件, greptime private, 系统表]
+description: greptime_private 数据库中的 events 表。
+---
+
+# events
+
+`events` 表保存 GreptimeDB 运行期间产生的事件。单机部署记录受支持的本地 DDL Procedure 事件；带有 Metasrv 的分布式部署还可以记录运维事件。事件会异步写入，写入失败不会影响原操作的执行结果。因此，不能以事件是否出现作为操作成功的依据。
+
+该表会在首次记录事件时自动创建。如果还没有事件记录，或已禁用事件记录，查询会提示表不存在。配置方法请参阅[生命周期事件记录器](/user-guide/deployments-administration/configuration.md#生命周期事件记录器)。
+
+```sql
+USE greptime_private;
+
+SELECT timestamp, type
+FROM events
+WHERE timestamp >= now() - INTERVAL '1' hour
+ORDER BY timestamp DESC
+LIMIT 20;
+```
+
+字段定义请参阅[事件数据模型](/user-guide/deployments-administration/monitoring/events/event-data-model.md)。DDL Procedure 查询示例请参阅[DDL 事件](/user-guide/deployments-administration/monitoring/events/ddl-events.md)。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/sql/greptime-private/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/sql/greptime-private/overview.md
@@ -11,5 +11,6 @@ GreptimeDB 将一些重要的内部信息以系统表的形式存储在 `greptim
 
 | 表名                                | 描述                                                     |
 | ----------------------------------- | -------------------------------------------------------- |
+| [`events`](./events.md)             | 保存 GreptimeDB 运行期间产生的事件记录。                 |
 | [`slow_queries`](./slow_queries.md) | 包含 GreptimeDB 的慢查询信息，包括查询语句、执行时间等。 |
 | [`pipelines`](./pipelines.md)       | 包含 GreptimeDB 的 Pipeline 信息。                       |

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/configuration.md
@@ -535,6 +535,8 @@ drop_table, undrop_table, purge_dropped_table, truncate_table,
 create_view, drop_view
 ```
 
+`undrop_table` 和 `purge_dropped_table` 仅 GreptimeDB 企业版支持。
+
 Metasrv 支持以下事件类型：
 
 ```text
@@ -547,6 +549,8 @@ create_view, drop_view,
 repartition, repartition_group,
 batch_gc, wal_prune
 ```
+
+`undrop_table` 和 `purge_dropped_table` 仅 GreptimeDB 企业版支持。
 
 <AnchorAlias id="region-engine-options" />
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/monitoring/events/ddl-events.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/monitoring/events/ddl-events.md
@@ -1,0 +1,204 @@
+---
+keywords: [GreptimeDB 事件, DDL 事件]
+description: 查看 GreptimeDB 记录的 DDL 事件。
+---
+
+# DDL 事件
+
+公共字段和 Procedure 状态请参阅[事件数据模型](/user-guide/deployments-administration/monitoring/events/event-data-model.md)。
+
+## 数据库事件
+
+```sql
+SELECT timestamp, type, procedure_state,
+       json_get_string(procedure_trigger, 'type') AS trigger_type,
+       json_to_string(payload) AS payload
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+  AND schema_name = '<database_name>'
+  AND type = '<event_type>'
+ORDER BY timestamp;
+```
+
+数据库事件类型包括 `create_database`、`alter_database` 和 `drop_database`。
+事件记录保留 `schema_name`。本查询用该列筛选，但不在结果中显示它。
+
+**`create_database`**
+
+```sql
++-------------------------------+-----------------+-----------------+--------------+----------------------------------------------------------------------------------+
+| timestamp                     | type            | procedure_state | trigger_type | payload                                                                          |
++-------------------------------+-----------------+-----------------+--------------+----------------------------------------------------------------------------------+
+| 2026-08-10 11:39:18.014737397 | create_database | Running | Submitted    | {"create_if_not_exists":true,"options":[{"key":"ttl","value":"1h"}],"version":1} |
+| 2026-08-10 11:39:18.052757527 | create_database | Done    | Succeeded    | null                                                                             |
++-------------------------------+-----------------+-----------------+--------------+----------------------------------------------------------------------------------+
+```
+
+**`alter_database`**
+
+```sql
++-------------------------------+----------------+-----------------+--------------+---------------------------------------------------------------------+
+| timestamp                     | type           | procedure_state | trigger_type | payload                                                             |
++-------------------------------+----------------+-----------------+--------------+---------------------------------------------------------------------+
+| 2026-08-10 11:39:18.060198497 | alter_database | Running | Submitted    | {"action":"set","options":[{"key":"ttl","value":"2h"}],"version":1} |
+| 2026-08-10 11:39:18.107764363 | alter_database | Done    | Succeeded    | null                                                                |
++-------------------------------+----------------+-----------------+--------------+---------------------------------------------------------------------+
+```
+
+**`drop_database`**
+
+```sql
++-------------------------------+---------------+-----------------+--------------+-------------------------------------+
+| timestamp                     | type          | procedure_state | trigger_type | payload                             |
++-------------------------------+---------------+-----------------+--------------+-------------------------------------+
+| 2026-08-10 11:39:18.113713574 | drop_database | Running | Submitted    | {"drop_if_exists":true,"version":1} |
+| 2026-08-10 11:39:18.197868233 | drop_database | Done    | Succeeded    | null                                |
++-------------------------------+---------------+-----------------+--------------+-------------------------------------+
+```
+
+## 表事件
+
+```sql
+SELECT timestamp, type, procedure_state,
+       json_get_string(procedure_trigger, 'type') AS trigger_type,
+       table_name, table_id, json_to_string(payload) AS payload
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+  AND schema_name = '<database_name>'
+  AND type = '<event_type>'
+ORDER BY timestamp;
+```
+
+该查询返回过去一小时内、指定数据库中指定类型的表事件。若只查询某张表，
+请在 `WHERE` 子句中添加 `AND table_name = '<table_name>'`。
+
+同一张表的事件记录会保留 `table_name`。`create_table` 和
+`create_logical_tables` 成功后，只有 Procedure 返回分配的 ID，记录中才会包含
+`table_id`。`alter_table`、`truncate_table` 和 `drop_table` 在提交时已经知道
+表 ID，因此它们的事件记录会包含 `table_id`。
+
+GreptimeDB 还会记录 `create_logical_tables` 和 `alter_logical_tables` 事件。两者会为每张逻辑表的每个生命周期触发类型各写入一行，因此按 `procedure_id` 查询时，同一触发类型可能返回多行。`undrop_table` 和 `purge_dropped_table` 仅 GreptimeDB 企业版支持。
+
+**`create_table`**
+
+```sql
++-------------------------------+--------------+-----------------+--------------+----------------+----------+------------------------------------------------------------+
+| timestamp                     | type         | procedure_state | trigger_type | table_name     | table_id | payload                                                    |
++-------------------------------+--------------+-----------------+--------------+----------------+----------+------------------------------------------------------------+
+| 2026-08-10 11:39:53.544351589 | create_table | Running         | Submitted    | ddl_source     |     NULL | {"create_if_not_exists":false,"engine":"mito","version":1} |
+| 2026-08-10 11:39:53.620080844 | create_table | Done            | Succeeded    | ddl_source     |     1449 | null                                                       |
++-------------------------------+--------------+-----------------+--------------+----------------+----------+------------------------------------------------------------+
+```
+
+**`alter_table`**
+
+```sql
++-------------------------------+-------------+-----------------+--------------+------------+----------+------------------------------------+
+| timestamp                     | type        | procedure_state | trigger_type | table_name | table_id | payload                            |
++-------------------------------+-------------+-----------------+--------------+------------+----------+------------------------------------+
+| 2026-08-10 11:40:23.445906161 | alter_table | Running         | Submitted    | ddl_source |     1449 | {"kind":"add_columns","version":1} |
+| 2026-08-10 11:40:23.539710789 | alter_table | Done            | Succeeded    | ddl_source |     1449 | null                               |
++-------------------------------+-------------+-----------------+--------------+------------+----------+------------------------------------+
+```
+
+**`truncate_table`**
+
+```sql
++-------------------------------+----------------+-----------------+--------------+----------------+----------+------------------------------------+
+| timestamp                     | type           | procedure_state | trigger_type | table_name     | table_id | payload                            |
++-------------------------------+----------------+-----------------+--------------+----------------+----------+------------------------------------+
+| 2026-08-10 11:40:51.949349425 | truncate_table | Running         | Submitted    | ddl_drop_probe |     1451 | {"time_range_count":0,"version":1} |
+| 2026-08-10 11:40:51.982366731 | truncate_table | Done            | Succeeded    | ddl_drop_probe |     1451 | null                               |
++-------------------------------+----------------+-----------------+--------------+----------------+----------+------------------------------------+
+```
+
+**`drop_table`**
+
+```sql
++-------------------------------+------------+-----------------+--------------+----------------+----------+--------------------------------------+
+| timestamp                     | type       | procedure_state | trigger_type | table_name     | table_id | payload                              |
++-------------------------------+------------+-----------------+--------------+----------------+----------+--------------------------------------+
+| 2026-08-10 11:40:51.986072827 | drop_table | Running         | Submitted    | ddl_drop_probe |     1451 | {"drop_if_exists":false,"version":1} |
+| 2026-08-10 11:40:52.061732144 | drop_table | Done            | Succeeded    | ddl_drop_probe |     1451 | null                                 |
++-------------------------------+------------+-----------------+--------------+----------------+----------+--------------------------------------+
+```
+
+## Flow 事件
+
+Flow 行保留 `catalog_name` 和 `flow_name`。Flow 的 `schema_name` 是 SQL `NULL`，
+但 `flow_name` 仍会保留。`create_flow` 在可用时新增 `flow_id`，`drop_flow` 保留已知的 ID。
+
+```sql
+SELECT timestamp, type, procedure_state,
+       json_get_string(procedure_trigger, 'type') AS trigger_type,
+       catalog_name, schema_name, flow_name, flow_id,
+       json_to_string(payload) AS payload
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+  AND flow_name = '<flow_name>'
+  AND type = '<event_type>'
+ORDER BY timestamp;
+```
+
+**`create_flow`**
+
+```sql
++-------------------------------+-------------+-----------------+--------------+--------------+-------------+-----------+---------+-----------------------------------------------------------------------------------------------------------+
+| timestamp                     | type        | procedure_state | trigger_type | catalog_name | schema_name | flow_name | flow_id | payload                                                                                                   |
++-------------------------------+-------------+-----------------+--------------+--------------+-------------+-----------+---------+-----------------------------------------------------------------------------------------------------------+
+| 2026-08-10 11:41:47.833758897 | create_flow | Running         | Submitted    | greptime     | NULL        | ddl_flow  |    NULL | {"create_if_not_exists":false,"eval_interval_secs":10,"expire_after":null,"or_replace":false,"version":1} |
+| 2026-08-10 11:41:47.857319802 | create_flow | Done            | Succeeded    | greptime     | NULL        | ddl_flow  |    1025 | null                                                                                                      |
++-------------------------------+-------------+-----------------+--------------+--------------+-------------+-----------+---------+-----------------------------------------------------------------------------------------------------------+
+```
+
+**`drop_flow`**
+
+```sql
++-------------------------------+-----------+-----------------+--------------+--------------+-------------+-----------+---------+--------------------------------------+
+| timestamp                     | type      | procedure_state | trigger_type | catalog_name | schema_name | flow_name | flow_id | payload                              |
++-------------------------------+-----------+-----------------+--------------+--------------+-------------+-----------+---------+--------------------------------------+
+| 2026-08-10 11:41:47.864231473 | drop_flow | Running         | Submitted    | greptime     | NULL        | ddl_flow  |    1025 | {"drop_if_exists":false,"version":1} |
+| 2026-08-10 11:41:47.926665304 | drop_flow | Done            | Succeeded    | greptime     | NULL        | ddl_flow  |    1025 | null                                 |
++-------------------------------+-----------+-----------------+--------------+--------------+-------------+-----------+---------+--------------------------------------+
+```
+
+## View 事件
+
+View 行保留稳定的 `view_name`。`create_view` 只有在可用时才新增 `view_id`，
+`drop_view` 保留已知的 ID。
+
+```sql
+SELECT timestamp, type, procedure_state,
+       json_get_string(procedure_trigger, 'type') AS trigger_type,
+       view_name, view_id, json_to_string(payload) AS payload
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+  AND schema_name = '<database_name>'
+  AND view_name = '<view_name>'
+  AND type = '<event_type>'
+ORDER BY timestamp;
+```
+
+本查询使用 `schema_name` 筛选，但不在结果中显示它。
+
+**`create_view`**
+
+```sql
++-------------------------------+-------------+-----------------+--------------+-----------+---------+-----------------------------------------------------------------------------------------------------------+
+| timestamp                     | type        | procedure_state | trigger_type | view_name | view_id | payload                                                                                                   |
++-------------------------------+-------------+-----------------+--------------+-----------+---------+-----------------------------------------------------------------------------------------------------------+
+| 2026-08-10 11:41:18.483028192 | create_view | Running         | Submitted    | ddl_view  |    NULL | {"column_count":0,"create_if_not_exists":false,"or_replace":false,"referenced_table_count":1,"version":1} |
+| 2026-08-10 11:41:18.513571854 | create_view | Done            | Succeeded    | ddl_view  |    1452 | null                                                                                                      |
++-------------------------------+-------------+-----------------+--------------+-----------+---------+-----------------------------------------------------------------------------------------------------------+
+```
+
+**`drop_view`**
+
+```sql
++-------------------------------+-----------+-----------------+--------------+-----------+---------+--------------------------------------+
+| timestamp                     | type      | procedure_state | trigger_type | view_name | view_id | payload                              |
++-------------------------------+-----------+-----------------+--------------+-----------+---------+--------------------------------------+
+| 2026-08-10 11:41:18.520281932 | drop_view | Running         | Submitted    | ddl_view  |    1452 | {"drop_if_exists":false,"version":1} |
+| 2026-08-10 11:41:18.572632167 | drop_view | Done            | Succeeded    | ddl_view  |    1452 | null                                 |
++-------------------------------+-----------+-----------------+--------------+-----------+---------+--------------------------------------+
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/monitoring/events/event-data-model.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/monitoring/events/event-data-model.md
@@ -1,0 +1,126 @@
+---
+keywords: [GreptimeDB 事件, 事件数据模型]
+description: 了解 GreptimeDB events 表的数据模型。
+---
+
+# 事件数据模型
+
+`greptime_private.events` 有以下公共列。
+
+| 列              | 含义                                                  |
+| --------------- | ----------------------------------------------------- |
+| `type`          | 事件类型，例如 `create_table` 或 `region_migration`。 |
+| `timestamp`     | 记录该行的时间。                                      |
+| `payload`       | 与事件类型相关的 JSON 数据。                          |
+| `event_context` | 有上下文时，用于描述事件触发原因的 JSON。             |
+
+## Procedure 事件列
+
+Procedure 事件还有以下列：
+
+| 列                  | 含义                                                                                                                                                             |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `procedure_id`      | Procedure 的唯一 ID。                                                                                                                                            |
+| `procedure_state`   | 记录事件时的 Procedure 状态。取值为 `Running`、`Done`、`Retrying`、`PrepareRollback`、`RollingBack`、`Failed` 和 `Poisoned`。                                    |
+| `procedure_trigger` | Procedure 事件触发信息，采用 JSON 格式。`type` 可为 `Submitted`、`Recovered`、`ChildSubmitted`、`Retrying`、`RollingBack`、`Succeeded`、`Failed` 或 `Poisoned`。 |
+| `procedure_error`   | Procedure 出错时的 Debug 格式错误信息；其他情况为空字符串。                                                                                                      |
+
+触发类型为 `Submitted` 的事件状态通常为 `Running`。Procedure 成功完成后，完成记录的状态为
+`Done`，触发类型为 `Succeeded`。完成记录根据 Procedure 完成时的状态生成，因此字段可能
+与提交时的记录不同。事件会异步写入，写入失败不会影响 Procedure 的执行结果。
+
+`event_context` 只写入 `Submitted` 记录。存在该字段时，其中稳定的 `reason` 值可以是
+`manual`、`auto_create`、`auto_alter`、`auto_repartition`、`auto_rebalance`、
+`region_failover`、`scheduled_gc` 或 `unknown`。例如，通过 MySQL 提交的事件可能包含
+`{"protocol":"mysql","reason":"manual"}`。
+
+除 `Submitted` 和 `Succeeded` 外，Procedure 还可能在适用时产生以下触发类型。
+并非每个 Procedure 都会产生所有触发类型，记录顺序也不保证与下表一致：
+
+| `type`           | 含义和字段                                                                                                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Recovered`      | 根 Procedure 从持久化状态恢复。                                                                                                                                     |
+| `ChildSubmitted` | 尝试提交子 Procedure。`procedure_trigger` 包含子 Procedure 的 `procedure_id` 和提交 `outcome`（`Accepted`、`AlreadyAccepted`、`ManagerStopped` 或 `SpawnFailed`）。 |
+| `Retrying`       | 正在重试 Procedure 的执行或回滚。`procedure_trigger` 包含重试 `phase`（`Execute` 或 `Rollback`）和 `attempt`。                                                      |
+| `RollingBack`    | 开始回滚 Procedure。                                                                                                                                                |
+| `Failed`         | Procedure 到达失败终态。请检查 `procedure_error` 中的失败详情。                                                                                                     |
+| `Poisoned`       | Procedure 无法继续。请检查 `procedure_error` 中的失败详情。                                                                                                         |
+
+## 查询 JSON 字段
+
+详细信息请参阅 [JSON 函数](/reference/sql/functions/json.md)。在事件查询中，
+`json_to_string` 将 JSON 值转换为可读文本，`json_get_string` 按路径提取值，
+`json_path_match` 计算 JSON 谓词，`json_is_null` 检查值是否为 JSON `null`。如需检查
+SQL `NULL`，应单独使用 `IS NULL`。
+
+例如，以下查询从包含 `event_context` 的 `create_table` 行中提取相关字段：
+
+```sql
+SELECT procedure_state,
+       json_get_string(procedure_trigger, 'type') AS trigger_type,
+       json_path_match(procedure_trigger, '$.type == "Submitted"') AS is_submitted,
+       json_get_string(event_context, 'reason') AS reason
+FROM greptime_private.events
+WHERE type = 'create_table'
+  AND timestamp >= now() - INTERVAL '1' hour
+  AND schema_name = '<database_name>'
+  AND table_name = '<table_name>'
+  AND event_context IS NOT NULL
+ORDER BY timestamp;
+```
+
+```sql
++-----------------+--------------+--------------+--------+
+| procedure_state | trigger_type | is_submitted | reason |
++-----------------+--------------+--------------+--------+
+| Running         | Submitted    |            1 | manual |
++-----------------+--------------+--------------+--------+
+```
+
+## JSON `null` 和 SQL `NULL`
+
+在 `create_table` 示例以及 DDL/repartition Procedure 完成后产生的事件中，终态 `payload` 可能是
+JSON `null`，而不是 SQL `NULL`：
+
+```sql
+SELECT procedure_state, json_to_string(payload) AS payload,
+       payload IS NULL AS payload_is_sql_null,
+       json_is_null(payload) AS payload_is_json_null,
+       json_get_string(procedure_trigger, 'type') AS trigger_type
+FROM greptime_private.events
+WHERE type = 'create_table'
+  AND timestamp >= now() - INTERVAL '1' hour
+  AND schema_name = '<database_name>'
+  AND table_name = '<table_name>'
+ORDER BY timestamp;
+```
+
+```sql
++-----------------+------------------------------------------------------------+---------------------+----------------------+--------------+
+| procedure_state | payload                                                    | payload_is_sql_null | payload_is_json_null | trigger_type |
++-----------------+------------------------------------------------------------+---------------------+----------------------+--------------+
+| Running         | {"create_if_not_exists":false,"engine":"mito","version":1} | 0                   | 0                    | Submitted    |
+| Done            | null                                                       | 0                   | 1                    | Succeeded    |
++-----------------+------------------------------------------------------------+---------------------+----------------------+--------------+
+```
+
+## Procedure 事件的专用列
+
+以下列只会在对应事件类型中填充；不适用时为 SQL `NULL`。
+
+- **数据库、表和视图事件：** `catalog_name`、`schema_name` 以及适用的表或视图名称和
+  ID 列用于标识对象。Flow 事件使用 `catalog_name` 和 `flow_name`；其 `schema_name` 为
+  SQL `NULL`。`physical_table_id` 仅适用于 `create_logical_tables` 和
+  `alter_logical_tables`。详见 [DDL 事件](/user-guide/deployments-administration/monitoring/events/ddl-events.md)。
+- **Region 迁移：** `region_id`、`region_number` 标识 Region；
+  `region_migration_trigger_reason`、`region_migration_src_node_id`、
+  `region_migration_src_peer_addr`、`region_migration_dst_node_id` 和
+  `region_migration_dst_peer_addr` 记录迁移原因、源端和目标端。
+- **Repartition：** `catalog_name`、`schema_name`、`table_name` 和 `table_id` 标识受影响的表。
+  `parent_procedure_id` 关联父 Procedure，`repartition_group_id` 标识分组操作。
+  `source_region_id`、`source_region_number`、`source_partition_expr`、
+  `target_region_id`、`target_region_number` 和 `target_partition_expr` 描述源和目标
+  Region 及其分区表达式。
+- **批量 GC：** `region_id`、`region_number` 和 `gc_report` 记录处理的 Region 及 GC 结果。
+- **WAL 清理：** `topic_name`、`prunable_entry_id` 和 `latest_offset` 分别表示 topic、
+  请求的清理边界和排他的最新 offset。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/monitoring/events/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/monitoring/events/overview.md
@@ -1,0 +1,36 @@
+---
+keywords: [GreptimeDB 事件, Procedure 事件, 运维事件, greptime_private]
+description: 查询 greptime_private.events 中的事件记录。
+---
+
+# 事件
+
+`greptime_private.events` 表保存 GreptimeDB 运行期间产生的事件记录，帮助运维人员检查 DDL 变更和后台 Procedure，而不必依赖服务日志。
+
+GreptimeDB 会异步写入事件记录，通常每 5 秒刷新一次。刚完成的操作可能不会立即出现在表中；写入失败不会影响原操作的执行结果，因此不能以事件是否出现作为操作成功的依据。
+
+## 配置事件记录
+
+单机部署可以在本地配置事件记录器，分布式部署则可以在 Metasrv 上配置。配置选项和支持的事件类型请参阅[生命周期事件记录器](/user-guide/deployments-administration/configuration.md#生命周期事件记录器)。
+
+单机部署会记录受支持的本地 DDL Procedure 事件。带有 Metasrv 的分布式部署还可以记录更多运维事件。
+
+## 查询事件
+
+事件表会在首次记录事件时创建。尚未记录任何事件，或已禁用事件记录时，下面的查询会报表不存在。
+
+排查最近的操作时，可以先查询最近一小时的事件，并将结果限制为 20 条：
+
+```sql
+SELECT timestamp, type
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+ORDER BY timestamp DESC
+LIMIT 20;
+```
+
+以下页面分别介绍查询方法和事件详情：
+
+- [查询事件](/user-guide/deployments-administration/monitoring/events/query-events.md)
+- [事件数据模型](/user-guide/deployments-administration/monitoring/events/event-data-model.md)
+- [DDL 事件](/user-guide/deployments-administration/monitoring/events/ddl-events.md)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/monitoring/events/query-events.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/monitoring/events/query-events.md
@@ -1,0 +1,229 @@
+---
+keywords: [GreptimeDB 事件, 查询事件]
+description: 查询 GreptimeDB 事件记录。
+---
+
+# 查询事件
+
+查询 `greptime_private.events` 系统表可以排查最近事件。事件异步写入，刚提交的操作可能不会立即出现。
+有关事件列，请参阅[事件数据模型](/user-guide/deployments-administration/monitoring/events/event-data-model.md)。
+
+## 查看最近事件
+
+以下查询会返回完整的事件记录：
+
+```sql
+SELECT *
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+ORDER BY timestamp DESC
+LIMIT 20;
+```
+
+该查询适合初步探索，但会返回所有列。日常排查时，建议只选择所需列：
+
+```sql
+SELECT timestamp, type, json_to_string(payload) AS payload
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+ORDER BY timestamp DESC
+LIMIT 20;
+```
+
+这样只返回排查所需的时间、事件类型和 payload，结果会更容易阅读。
+
+## 查看并筛选事件类型
+
+先列出集群中实际存在的类型，再选择筛选条件：
+
+```sql
+SELECT type, COUNT(*) AS event_rows
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+GROUP BY type
+ORDER BY type;
+```
+
+该结果仅反映最近一小时内实际出现的事件类型，不能作为已配置或受支持类型的完整清单。
+支持的本地 DDL 事件类型请参阅 [DDL 事件](/user-guide/deployments-administration/monitoring/events/ddl-events.md)。
+
+将事件类型、数据库和对象名称组合，可以避免混入无关事件：
+
+```sql
+SELECT timestamp, type, procedure_state,
+       json_get_string(procedure_trigger, 'type') AS trigger_type
+FROM greptime_private.events
+WHERE type = 'create_table'
+  AND timestamp >= now() - INTERVAL '1' hour
+  AND schema_name = '<database_name>'
+  AND table_name = '<table_name>'
+ORDER BY timestamp;
+```
+
+示例输出：
+
+```sql
++-------------------------------+--------------+-----------------+--------------+
+| timestamp                     | type         | procedure_state | trigger_type |
++-------------------------------+--------------+-----------------+--------------+
+| 2026-08-10 11:28:40.590240203 | create_table | Running         | Submitted    |
+| 2026-08-10 11:28:40.659064297 | create_table | Done            | Succeeded    |
++-------------------------------+--------------+-----------------+--------------+
+```
+
+## 查询对象的最新事件
+
+将占位符替换为对象名称；需要时再填入数据库。每个查询只返回匹配结果中最新的一条事件。
+
+### 数据库
+
+```sql
+SELECT timestamp, type, schema_name, procedure_state,
+       json_get_string(procedure_trigger, 'type') AS trigger_type
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+  AND schema_name = '<database_name>'
+  AND type IN ('create_database', 'alter_database', 'drop_database')
+ORDER BY timestamp DESC
+LIMIT 1;
+```
+
+### 表
+
+```sql
+SELECT timestamp, type, schema_name, table_name, table_id, procedure_state
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+  AND schema_name = '<database_name>'
+  AND table_name = '<table_name>'
+ORDER BY timestamp DESC
+LIMIT 1;
+```
+
+### Flow
+
+```sql
+SELECT timestamp, type, flow_name, flow_id, procedure_state
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+  AND flow_name = '<flow_name>'
+ORDER BY timestamp DESC
+LIMIT 1;
+```
+
+### 视图
+
+```sql
+SELECT timestamp, type, schema_name, view_name, view_id, procedure_state
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+  AND schema_name = '<database_name>'
+  AND view_name = '<view_name>'
+ORDER BY timestamp DESC
+LIMIT 1;
+```
+
+### Region
+
+涉及 Region 的运维事件是全局事件，不按数据库隔离。下面的查询返回某个
+Region 最近的一条事件。`region_migration`、`batch_gc` 和
+`repartition_group` 都至少需要有一条记录：events 表会在首次记录某类事件时，
+加入该类事件的列。每条记录只填写该事件类型适用的列，其余选出的列为 SQL `NULL`。
+
+```sql
+SELECT timestamp, type, procedure_state,
+       region_id, source_region_id, target_region_id,
+       region_migration_trigger_reason,
+       region_migration_src_node_id, region_migration_dst_node_id
+FROM greptime_private.events
+WHERE type IN ('region_migration', 'batch_gc', 'repartition_group')
+  AND timestamp >= now() - INTERVAL '1' hour
+  AND (region_id = <region_id>
+       OR source_region_id = <region_id>
+       OR target_region_id = <region_id>)
+ORDER BY timestamp DESC
+LIMIT 1;
+```
+
+## 查询 Procedure 事件
+
+Procedure 事件共享 `procedure_id`。
+
+### 获取 Procedure ID
+
+对于创建表的 Procedure，按数据库和表筛选，再将 `procedure_trigger` 的类型筛为
+`Submitted`，即可找到提交行：
+
+```sql
+SELECT procedure_id
+FROM greptime_private.events
+WHERE type = 'create_table'
+  AND timestamp >= now() - INTERVAL '1' hour
+  AND schema_name = '<database_name>'
+  AND table_name = '<table_name>'
+  AND json_path_match(procedure_trigger, '$.type == "Submitted"')
+ORDER BY timestamp DESC
+LIMIT 1;
+```
+
+示例结果：
+
+```sql
++--------------------------------------+
+| procedure_id                         |
++--------------------------------------+
+| a5788f51-5726-4db7-a85e-e9afc36da557 |
++--------------------------------------+
+```
+
+在后续查询中使用返回的 ID 查看该 Procedure 的事件记录。定位条件可以避免选中名称相似但属于其他对象的 Procedure。
+
+### 查询一个 Procedure
+
+需要探索所有可用列时，使用完整记录查询：
+
+```sql
+SELECT *
+FROM greptime_private.events
+WHERE procedure_id = '<procedure_id>'
+  AND timestamp >= now() - INTERVAL '1' hour
+ORDER BY timestamp ASC;
+```
+
+日常排查时，使用只选择所需列的投影：
+
+```sql
+SELECT timestamp, type, procedure_state,
+       json_get_string(procedure_trigger, 'type') AS trigger_type,
+       procedure_error, json_to_string(payload) AS payload
+FROM greptime_private.events
+WHERE procedure_id = '<procedure_id>'
+  AND timestamp >= now() - INTERVAL '1' hour
+ORDER BY timestamp;
+```
+
+以下是一次 MySQL 操作的示例输出：
+
+```sql
++-------------------------------+--------------+-----------------+--------------+-----------------+------------------------------------------------------------+
+| timestamp                     | type         | procedure_state | trigger_type | procedure_error | payload                                                    |
++-------------------------------+--------------+-----------------+--------------+-----------------+------------------------------------------------------------+
+| 2026-08-10 11:23:14.388632208 | create_table | Running         | Submitted    |                 | {"create_if_not_exists":false,"engine":"mito","version":1} |
+| 2026-08-10 11:23:14.463992155 | create_table | Done            | Succeeded    |                 | null                                                       |
++-------------------------------+--------------+-----------------+--------------+-----------------+------------------------------------------------------------+
+```
+
+### 查询失败的 Procedure
+
+查询最近失败的 Procedure：
+
+```sql
+SELECT timestamp, type, procedure_id, procedure_state,
+       json_get_string(procedure_trigger, 'type') AS trigger_type,
+       procedure_error
+FROM greptime_private.events
+WHERE procedure_state IN ('Failed', 'Poisoned')
+  AND timestamp >= now() - INTERVAL '1' hour
+ORDER BY timestamp DESC
+LIMIT 20;
+```

--- a/versioned_docs/version-1.2/reference/sql/greptime-private/events.md
+++ b/versioned_docs/version-1.2/reference/sql/greptime-private/events.md
@@ -1,0 +1,29 @@
+---
+keywords: [events, greptime private, system tables]
+description: The events table in the `greptime_private` database.
+---
+
+# events
+
+The `events` table stores events recorded while GreptimeDB runs. Standalone
+deployments record supported local DDL Procedure events. Distributed deployments
+with Metasrv can additionally record operational event types. Event recording is
+asynchronous and best-effort, so rows are not an acknowledgement that an
+operation succeeded.
+
+The table is created when the first event is recorded. If no event has been
+recorded, or event recording is disabled, querying it returns a table-not-found
+error. Configure recording in [Lifecycle event recorder](/user-guide/deployments-administration/configuration.md#lifecycle-event-recorder).
+
+```sql
+USE greptime_private;
+
+SELECT timestamp, type
+FROM events
+WHERE timestamp >= now() - INTERVAL '1' hour
+ORDER BY timestamp DESC
+LIMIT 20;
+```
+
+For column definitions, see [Event data model](/user-guide/deployments-administration/monitoring/events/event-data-model.md).
+For DDL Procedure query examples, see [DDL events](/user-guide/deployments-administration/monitoring/events/ddl-events.md).

--- a/versioned_docs/version-1.2/reference/sql/greptime-private/overview.md
+++ b/versioned_docs/version-1.2/reference/sql/greptime-private/overview.md
@@ -11,5 +11,6 @@ GreptimeDB stores some important internal information as system tables in the `g
 
 | Table Name                          | Description                                                                                   |
 | ----------------------------------- | --------------------------------------------------------------------------------------------- |
+| [`events`](./events.md)             | Stores events recorded while GreptimeDB runs.                                                 |
 | [`slow_queries`](./slow_queries.md) | Contains GreptimeDB slow query information, including query statements, execution times, etc. |
 | [`pipelines`](./pipelines.md)       | Contains GreptimeDB Pipeline information.                                                     |

--- a/versioned_docs/version-1.2/user-guide/deployments-administration/configuration.md
+++ b/versioned_docs/version-1.2/user-guide/deployments-administration/configuration.md
@@ -533,6 +533,8 @@ drop_table, undrop_table, purge_dropped_table, truncate_table,
 create_view, drop_view
 ```
 
+`undrop_table` and `purge_dropped_table` require GreptimeDB Enterprise.
+
 Metasrv supports the following event types:
 
 ```text
@@ -545,6 +547,8 @@ create_view, drop_view,
 repartition, repartition_group,
 batch_gc, wal_prune
 ```
+
+`undrop_table` and `purge_dropped_table` require GreptimeDB Enterprise.
 
 ### Region engine options
 

--- a/versioned_docs/version-1.2/user-guide/deployments-administration/monitoring/events/ddl-events.md
+++ b/versioned_docs/version-1.2/user-guide/deployments-administration/monitoring/events/ddl-events.md
@@ -1,0 +1,211 @@
+---
+keywords: [GreptimeDB events, DDL events]
+description: Inspect DDL events recorded by GreptimeDB.
+---
+
+# DDL events
+
+See [Event data model](/user-guide/deployments-administration/monitoring/events/event-data-model.md)
+for shared columns and Procedure states.
+
+## Database events
+
+```sql
+SELECT timestamp, type, procedure_state,
+       json_get_string(procedure_trigger, 'type') AS trigger_type,
+       json_to_string(payload) AS payload
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+  AND schema_name = '<database_name>'
+  AND type = '<event_type>'
+ORDER BY timestamp;
+```
+
+Database event types are `create_database`, `alter_database`, and `drop_database`.
+Event rows retain `schema_name`, which this query uses as a filter but does not
+include in the result.
+
+**`create_database`**
+
+```sql
++-------------------------------+-----------------+-----------------+--------------+----------------------------------------------------------------------------------+
+| timestamp                     | type            | procedure_state | trigger_type | payload                                                                          |
++-------------------------------+-----------------+-----------------+--------------+----------------------------------------------------------------------------------+
+| 2026-08-10 11:39:18.014737397 | create_database | Running | Submitted    | {"create_if_not_exists":true,"options":[{"key":"ttl","value":"1h"}],"version":1} |
+| 2026-08-10 11:39:18.052757527 | create_database | Done    | Succeeded    | null                                                                             |
++-------------------------------+-----------------+-----------------+--------------+----------------------------------------------------------------------------------+
+```
+
+**`alter_database`**
+
+```sql
++-------------------------------+----------------+-----------------+--------------+---------------------------------------------------------------------+
+| timestamp                     | type           | procedure_state | trigger_type | payload                                                             |
++-------------------------------+----------------+-----------------+--------------+---------------------------------------------------------------------+
+| 2026-08-10 11:39:18.060198497 | alter_database | Running | Submitted    | {"action":"set","options":[{"key":"ttl","value":"2h"}],"version":1} |
+| 2026-08-10 11:39:18.107764363 | alter_database | Done    | Succeeded    | null                                                                |
++-------------------------------+----------------+-----------------+--------------+---------------------------------------------------------------------+
+```
+
+**`drop_database`**
+
+```sql
++-------------------------------+---------------+-----------------+--------------+-------------------------------------+
+| timestamp                     | type          | procedure_state | trigger_type | payload                             |
++-------------------------------+---------------+-----------------+--------------+-------------------------------------+
+| 2026-08-10 11:39:18.113713574 | drop_database | Running | Submitted    | {"drop_if_exists":true,"version":1} |
+| 2026-08-10 11:39:18.197868233 | drop_database | Done    | Succeeded    | null                                |
++-------------------------------+---------------+-----------------+--------------+-------------------------------------+
+```
+
+## Table events
+
+```sql
+SELECT timestamp, type, procedure_state,
+       json_get_string(procedure_trigger, 'type') AS trigger_type,
+       table_name, table_id, json_to_string(payload) AS payload
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+  AND schema_name = '<database_name>'
+  AND type = '<event_type>'
+ORDER BY timestamp;
+```
+
+This query returns table events of the selected type from the specified database
+in the last hour. To query one table, add
+`AND table_name = '<table_name>'` to the `WHERE` clause.
+
+Rows for the same table retain `table_name`. A successful `create_table` or
+`create_logical_tables` event includes `table_id` only when the Procedure returns
+the allocated ID. `alter_table`, `truncate_table`, and `drop_table` already know
+the table ID when they are submitted, so their event rows include it.
+
+GreptimeDB also records `create_logical_tables` and `alter_logical_tables` events.
+Each emits one row per logical table for each lifecycle trigger type, so a query
+by `procedure_id` can return multiple rows for the same trigger type. `undrop_table`
+and `purge_dropped_table` are Enterprise-only.
+
+**`create_table`**
+
+```sql
++-------------------------------+--------------+-----------------+--------------+----------------+----------+------------------------------------------------------------+
+| timestamp                     | type         | procedure_state | trigger_type | table_name     | table_id | payload                                                    |
++-------------------------------+--------------+-----------------+--------------+----------------+----------+------------------------------------------------------------+
+| 2026-08-10 11:39:53.544351589 | create_table | Running         | Submitted    | ddl_source     |     NULL | {"create_if_not_exists":false,"engine":"mito","version":1} |
+| 2026-08-10 11:39:53.620080844 | create_table | Done            | Succeeded    | ddl_source     |     1449 | null                                                       |
++-------------------------------+--------------+-----------------+--------------+----------------+----------+------------------------------------------------------------+
+```
+
+**`alter_table`**
+
+```sql
++-------------------------------+-------------+-----------------+--------------+------------+----------+------------------------------------+
+| timestamp                     | type        | procedure_state | trigger_type | table_name | table_id | payload                            |
++-------------------------------+-------------+-----------------+--------------+------------+----------+------------------------------------+
+| 2026-08-10 11:40:23.445906161 | alter_table | Running         | Submitted    | ddl_source |     1449 | {"kind":"add_columns","version":1} |
+| 2026-08-10 11:40:23.539710789 | alter_table | Done            | Succeeded    | ddl_source |     1449 | null                               |
++-------------------------------+-------------+-----------------+--------------+------------+----------+------------------------------------+
+```
+
+**`truncate_table`**
+
+```sql
++-------------------------------+----------------+-----------------+--------------+----------------+----------+------------------------------------+
+| timestamp                     | type           | procedure_state | trigger_type | table_name     | table_id | payload                            |
++-------------------------------+----------------+-----------------+--------------+----------------+----------+------------------------------------+
+| 2026-08-10 11:40:51.949349425 | truncate_table | Running         | Submitted    | ddl_drop_probe |     1451 | {"time_range_count":0,"version":1} |
+| 2026-08-10 11:40:51.982366731 | truncate_table | Done            | Succeeded    | ddl_drop_probe |     1451 | null                               |
++-------------------------------+----------------+-----------------+--------------+----------------+----------+------------------------------------+
+```
+
+**`drop_table`**
+
+```sql
++-------------------------------+------------+-----------------+--------------+----------------+----------+--------------------------------------+
+| timestamp                     | type       | procedure_state | trigger_type | table_name     | table_id | payload                              |
++-------------------------------+------------+-----------------+--------------+----------------+----------+--------------------------------------+
+| 2026-08-10 11:40:51.986072827 | drop_table | Running         | Submitted    | ddl_drop_probe |     1451 | {"drop_if_exists":false,"version":1} |
+| 2026-08-10 11:40:52.061732144 | drop_table | Done            | Succeeded    | ddl_drop_probe |     1451 | null                                 |
++-------------------------------+------------+-----------------+--------------+----------------+----------+--------------------------------------+
+```
+
+## Flow events
+
+Flow rows retain `catalog_name` and `flow_name`. `schema_name` is SQL `NULL` for
+Flow events, while `flow_name` remains available. `create_flow` adds `flow_id` when
+available, and `drop_flow` retains the known ID.
+
+```sql
+SELECT timestamp, type, procedure_state,
+       json_get_string(procedure_trigger, 'type') AS trigger_type,
+       catalog_name, schema_name, flow_name, flow_id,
+       json_to_string(payload) AS payload
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+  AND flow_name = '<flow_name>'
+  AND type = '<event_type>'
+ORDER BY timestamp;
+```
+
+**`create_flow`**
+
+```sql
++-------------------------------+-------------+-----------------+--------------+--------------+-------------+-----------+---------+-----------------------------------------------------------------------------------------------------------+
+| timestamp                     | type        | procedure_state | trigger_type | catalog_name | schema_name | flow_name | flow_id | payload                                                                                                   |
++-------------------------------+-------------+-----------------+--------------+--------------+-------------+-----------+---------+-----------------------------------------------------------------------------------------------------------+
+| 2026-08-10 11:41:47.833758897 | create_flow | Running         | Submitted    | greptime     | NULL        | ddl_flow  |    NULL | {"create_if_not_exists":false,"eval_interval_secs":10,"expire_after":null,"or_replace":false,"version":1} |
+| 2026-08-10 11:41:47.857319802 | create_flow | Done            | Succeeded    | greptime     | NULL        | ddl_flow  |    1025 | null                                                                                                      |
++-------------------------------+-------------+-----------------+--------------+--------------+-------------+-----------+---------+-----------------------------------------------------------------------------------------------------------+
+```
+
+**`drop_flow`**
+
+```sql
++-------------------------------+-----------+-----------------+--------------+--------------+-------------+-----------+---------+--------------------------------------+
+| timestamp                     | type      | procedure_state | trigger_type | catalog_name | schema_name | flow_name | flow_id | payload                              |
++-------------------------------+-----------+-----------------+--------------+--------------+-------------+-----------+---------+--------------------------------------+
+| 2026-08-10 11:41:47.864231473 | drop_flow | Running         | Submitted    | greptime     | NULL        | ddl_flow  |    1025 | {"drop_if_exists":false,"version":1} |
+| 2026-08-10 11:41:47.926665304 | drop_flow | Done            | Succeeded    | greptime     | NULL        | ddl_flow  |    1025 | null                                 |
++-------------------------------+-----------+-----------------+--------------+--------------+-------------+-----------+---------+--------------------------------------+
+```
+
+## View events
+
+View rows retain stable `view_name` values. `create_view` adds `view_id` only
+when available, and `drop_view` retains the known ID.
+
+```sql
+SELECT timestamp, type, procedure_state,
+       json_get_string(procedure_trigger, 'type') AS trigger_type,
+       view_name, view_id, json_to_string(payload) AS payload
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+  AND schema_name = '<database_name>'
+  AND view_name = '<view_name>'
+  AND type = '<event_type>'
+ORDER BY timestamp;
+```
+
+The query uses `schema_name` as a filter and does not include it in the result.
+
+**`create_view`**
+
+```sql
++-------------------------------+-------------+-----------------+--------------+-----------+---------+-----------------------------------------------------------------------------------------------------------+
+| timestamp                     | type        | procedure_state | trigger_type | view_name | view_id | payload                                                                                                   |
++-------------------------------+-------------+-----------------+--------------+-----------+---------+-----------------------------------------------------------------------------------------------------------+
+| 2026-08-10 11:41:18.483028192 | create_view | Running         | Submitted    | ddl_view  |    NULL | {"column_count":0,"create_if_not_exists":false,"or_replace":false,"referenced_table_count":1,"version":1} |
+| 2026-08-10 11:41:18.513571854 | create_view | Done            | Succeeded    | ddl_view  |    1452 | null                                                                                                      |
++-------------------------------+-------------+-----------------+--------------+-----------+---------+-----------------------------------------------------------------------------------------------------------+
+```
+
+**`drop_view`**
+
+```sql
++-------------------------------+-----------+-----------------+--------------+-----------+---------+--------------------------------------+
+| timestamp                     | type      | procedure_state | trigger_type | view_name | view_id | payload                              |
++-------------------------------+-----------+-----------------+--------------+-----------+---------+--------------------------------------+
+| 2026-08-10 11:41:18.520281932 | drop_view | Running         | Submitted    | ddl_view  |    1452 | {"drop_if_exists":false,"version":1} |
+| 2026-08-10 11:41:18.572632167 | drop_view | Done            | Succeeded    | ddl_view  |    1452 | null                                 |
++-------------------------------+-----------+-----------------+--------------+-----------+---------+--------------------------------------+
+```

--- a/versioned_docs/version-1.2/user-guide/deployments-administration/monitoring/events/event-data-model.md
+++ b/versioned_docs/version-1.2/user-guide/deployments-administration/monitoring/events/event-data-model.md
@@ -1,0 +1,136 @@
+---
+keywords: [GreptimeDB events, event data model]
+description: Understand the GreptimeDB events table data model.
+---
+
+# Event data model
+
+`greptime_private.events` has the following common columns.
+
+| Column          | Meaning                                                     |
+| --------------- | ----------------------------------------------------------- |
+| `type`          | Event type, such as `create_table` or `region_migration`.   |
+| `timestamp`     | Time at which the row was recorded.                         |
+| `payload`       | JSON data for the event type.                               |
+| `event_context` | JSON describing why the event was triggered when available. |
+
+## Procedure event columns
+
+Procedure events also have the following columns:
+
+| Column              | Meaning                                                                                                                                                     |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `procedure_id`      | Unique Procedure ID.                                                                                                                                        |
+| `procedure_state`   | Procedure state when the event was recorded. Values are `Running`, `Done`, `Retrying`, `PrepareRollback`, `RollingBack`, `Failed`, and `Poisoned`.          |
+| `procedure_trigger` | Procedure event trigger in JSON. Its `type` is `Submitted`, `Recovered`, `ChildSubmitted`, `Retrying`, `RollingBack`, `Succeeded`, `Failed`, or `Poisoned`. |
+| `procedure_error`   | Debug-formatted error when the Procedure fails; an empty string otherwise.                                                                                  |
+
+Rows with trigger type `Submitted` normally have state `Running`. When a Procedure
+succeeds, the completed event has state `Done` and trigger type `Succeeded`. The completed
+row is generated from the Procedure's final state, so its fields can differ from
+the submitted row. Events are recorded asynchronously; a recording failure does
+not change the Procedure result.
+
+`event_context` is written only on `Submitted` rows. When it is available, its
+stable `reason` value is one of
+`manual`, `auto_create`, `auto_alter`, `auto_repartition`, `auto_rebalance`,
+`region_failover`, `scheduled_gc`, or `unknown`. For example, a MySQL-submitted
+event can contain `{"protocol":"mysql","reason":"manual"}`.
+
+In addition to `Submitted` and `Succeeded`, a Procedure can emit the following
+trigger types when applicable. Not every Procedure emits every trigger type, and rows are
+not guaranteed to appear in the order shown:
+
+| `type`           | Meaning and fields                                                                                                                                                                       |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Recovered`      | The root Procedure was recovered from persisted state.                                                                                                                                   |
+| `ChildSubmitted` | A child Procedure submission was attempted. `procedure_trigger` includes the child `procedure_id` and its `outcome` (`Accepted`, `AlreadyAccepted`, `ManagerStopped`, or `SpawnFailed`). |
+| `Retrying`       | Procedure execution or rollback is being retried. `procedure_trigger` includes the retry `phase` (`Execute` or `Rollback`) and `attempt`.                                                |
+| `RollingBack`    | Procedure rollback is starting.                                                                                                                                                          |
+| `Failed`         | The Procedure reached a failed terminal state. Inspect `procedure_error` for failure details.                                                                                            |
+| `Poisoned`       | The Procedure cannot proceed. Inspect `procedure_error` for the failure details.                                                                                                         |
+
+## Query JSON fields
+
+See the [JSON functions](/reference/sql/functions/json.md) reference for
+details. In event queries, `json_to_string` converts a JSON value to readable
+text, `json_get_string` extracts a value by path, `json_path_match` evaluates a
+JSON predicate, and `json_is_null` checks whether a value is the JSON `null`
+value. Use `IS NULL` separately to check for SQL `NULL`.
+
+For example, this query extracts fields from a `create_table` row that contains
+`event_context`:
+
+```sql
+SELECT procedure_state,
+       json_get_string(procedure_trigger, 'type') AS trigger_type,
+       json_path_match(procedure_trigger, '$.type == "Submitted"') AS is_submitted,
+       json_get_string(event_context, 'reason') AS reason
+FROM greptime_private.events
+WHERE type = 'create_table'
+  AND timestamp >= now() - INTERVAL '1' hour
+  AND schema_name = '<database_name>'
+  AND table_name = '<table_name>'
+  AND event_context IS NOT NULL
+ORDER BY timestamp;
+```
+
+```sql
++-----------------+--------------+--------------+--------+
+| procedure_state | trigger_type | is_submitted | reason |
++-----------------+--------------+--------------+--------+
+| Running         | Submitted    |            1 | manual |
++-----------------+--------------+--------------+--------+
+```
+
+## JSON `null` and SQL `NULL`
+
+In the `create_table` example and DDL/repartition events after a Procedure completes, a terminal
+`payload` can be JSON `null` rather than SQL `NULL`:
+
+```sql
+SELECT procedure_state, json_to_string(payload) AS payload,
+       payload IS NULL AS payload_is_sql_null,
+       json_is_null(payload) AS payload_is_json_null,
+       json_get_string(procedure_trigger, 'type') AS trigger_type
+FROM greptime_private.events
+WHERE type = 'create_table'
+  AND timestamp >= now() - INTERVAL '1' hour
+  AND schema_name = '<database_name>'
+  AND table_name = '<table_name>'
+ORDER BY timestamp;
+```
+
+```sql
++-----------------+------------------------------------------------------------+---------------------+----------------------+--------------+
+| procedure_state | payload                                                    | payload_is_sql_null | payload_is_json_null | trigger_type |
++-----------------+------------------------------------------------------------+---------------------+----------------------+--------------+
+| Running         | {"create_if_not_exists":false,"engine":"mito","version":1} | 0                   | 0                    | Submitted    |
+| Done            | null                                                       | 0                   | 1                    | Succeeded    |
++-----------------+------------------------------------------------------------+---------------------+----------------------+--------------+
+```
+
+## Procedure event type-specific columns
+
+The following columns are populated only by the listed event types. An SQL `NULL`
+value in one of these columns is normal when it does not apply.
+
+- **Database, table, and view events:** `catalog_name`, `schema_name`, and the
+  applicable table or view name and ID columns identify the affected object.
+  Flow events use `catalog_name` and `flow_name`; their `schema_name` is SQL
+  `NULL`. `physical_table_id` applies only to `create_logical_tables` and
+  `alter_logical_tables`. See [DDL events](/user-guide/deployments-administration/monitoring/events/ddl-events.md).
+- **Region migration:** `region_id` and `region_number` identify the Region.
+  `region_migration_trigger_reason`, `region_migration_src_node_id`,
+  `region_migration_src_peer_addr`, `region_migration_dst_node_id`, and
+  `region_migration_dst_peer_addr` describe why and where it moved.
+- **Repartition:** `catalog_name`, `schema_name`, `table_name`, and `table_id`
+  identify the affected table. `parent_procedure_id` links a child procedure to
+  its parent; `repartition_group_id` identifies a group operation. `source_region_id`,
+  `source_region_number`, `source_partition_expr`, `target_region_id`,
+  `target_region_number`, and `target_partition_expr` describe the affected
+  Regions and partition expressions.
+- **Batch GC:** `region_id`, `region_number`, and `gc_report` describe the
+  Regions processed and their GC result.
+- **WAL pruning:** `topic_name`, `prunable_entry_id`, and `latest_offset`
+  identify the topic, requested prune boundary, and exclusive latest offset.

--- a/versioned_docs/version-1.2/user-guide/deployments-administration/monitoring/events/overview.md
+++ b/versioned_docs/version-1.2/user-guide/deployments-administration/monitoring/events/overview.md
@@ -1,0 +1,41 @@
+---
+keywords: [GreptimeDB events, Procedure events, operational events, greptime_private]
+description: Query event records in greptime_private.events.
+---
+
+# Events
+
+The `greptime_private.events` table stores events recorded while GreptimeDB runs. It helps operators inspect DDL changes and background procedures without searching service logs.
+
+GreptimeDB writes event records asynchronously on a best-effort basis. Records are
+normally flushed every five seconds, so a recent operation might not be visible
+immediately. Event recording should not be treated as the operation's success
+acknowledgement.
+
+## Configure event recording
+
+The event recorder can be configured in standalone deployments or on Metasrv in distributed deployments. See [Lifecycle event recorder](/user-guide/deployments-administration/configuration.md#lifecycle-event-recorder) for configuration options and the supported type list.
+
+Standalone deployments record supported local DDL Procedure events. Distributed deployments with Metasrv can additionally record operational event types.
+
+## Query events
+
+The table is created when the first event is recorded. If no event has been
+recorded yet, or event recording is disabled, this query returns a table-not-found
+error.
+
+Start with a bounded query while investigating a recent operation:
+
+```sql
+SELECT timestamp, type
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+ORDER BY timestamp DESC
+LIMIT 20;
+```
+
+Use the following pages for focused queries and event details:
+
+- [Query events](/user-guide/deployments-administration/monitoring/events/query-events.md)
+- [Event data model](/user-guide/deployments-administration/monitoring/events/event-data-model.md)
+- [DDL events](/user-guide/deployments-administration/monitoring/events/ddl-events.md)

--- a/versioned_docs/version-1.2/user-guide/deployments-administration/monitoring/events/query-events.md
+++ b/versioned_docs/version-1.2/user-guide/deployments-administration/monitoring/events/query-events.md
@@ -1,0 +1,241 @@
+---
+keywords: [GreptimeDB events, query events]
+description: Query GreptimeDB event records.
+---
+
+# Query events
+
+Query the `greptime_private.events` system table to investigate recent events.
+Events are written asynchronously, so a newly submitted operation might not be
+visible immediately. See [Event data model](/user-guide/deployments-administration/monitoring/events/event-data-model.md)
+for event columns.
+
+## Start with recent events
+
+The following query returns all columns for up to 20 events recorded during the
+last hour:
+
+```sql
+SELECT *
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+ORDER BY timestamp DESC
+LIMIT 20;
+```
+
+This is useful for exploration, but it returns every column. For routine checks,
+select only the columns you need:
+
+```sql
+SELECT timestamp, type, json_to_string(payload) AS payload
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+ORDER BY timestamp DESC
+LIMIT 20;
+```
+
+The compact result keeps the time, type, and payload visible without pasting the
+full output.
+
+## Discover and filter event types
+
+List types actually present in the cluster before choosing a filter:
+
+```sql
+SELECT type, COUNT(*) AS event_rows
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+GROUP BY type
+ORDER BY type;
+```
+
+The result is a point-in-time view of the event types currently present in the
+cluster. It varies with workload and does not define the configured or
+source-supported types. See [DDL events](/user-guide/deployments-administration/monitoring/events/ddl-events.md)
+for the supported local DDL event types.
+
+Combine an event type with a database and object name to avoid unrelated rows:
+
+```sql
+SELECT timestamp, type, procedure_state,
+       json_get_string(procedure_trigger, 'type') AS trigger_type
+FROM greptime_private.events
+WHERE type = 'create_table'
+  AND timestamp >= now() - INTERVAL '1' hour
+  AND schema_name = '<database_name>'
+  AND table_name = '<table_name>'
+ORDER BY timestamp;
+```
+
+Example output:
+
+```sql
++-------------------------------+--------------+-----------------+--------------+
+| timestamp                     | type         | procedure_state | trigger_type |
++-------------------------------+--------------+-----------------+--------------+
+| 2026-08-10 11:28:40.590240203 | create_table | Running         | Submitted    |
+| 2026-08-10 11:28:40.659064297 | create_table | Done            | Succeeded    |
++-------------------------------+--------------+-----------------+--------------+
+```
+
+## Find the latest event for an object
+
+Replace the placeholders with the object name and, where needed, the database.
+Each query returns the newest matching event.
+
+### Database
+
+```sql
+SELECT timestamp, type, schema_name, procedure_state,
+       json_get_string(procedure_trigger, 'type') AS trigger_type
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+  AND schema_name = '<database_name>'
+  AND type IN ('create_database', 'alter_database', 'drop_database')
+ORDER BY timestamp DESC
+LIMIT 1;
+```
+
+### Table
+
+```sql
+SELECT timestamp, type, schema_name, table_name, table_id, procedure_state
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+  AND schema_name = '<database_name>'
+  AND table_name = '<table_name>'
+ORDER BY timestamp DESC
+LIMIT 1;
+```
+
+### Flow
+
+```sql
+SELECT timestamp, type, flow_name, flow_id, procedure_state
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+  AND flow_name = '<flow_name>'
+ORDER BY timestamp DESC
+LIMIT 1;
+```
+
+### View
+
+```sql
+SELECT timestamp, type, schema_name, view_name, view_id, procedure_state
+FROM greptime_private.events
+WHERE timestamp >= now() - INTERVAL '1' hour
+  AND schema_name = '<database_name>'
+  AND view_name = '<view_name>'
+ORDER BY timestamp DESC
+LIMIT 1;
+```
+
+### Region
+
+Operational events that reference a Region are global, not tied to a database.
+Use this query to find the latest event for a Region. It requires
+`region_migration`, `batch_gc`, and `repartition_group` to have each recorded at
+least one event: the table adds an event type's columns when it first records
+that type. A row fills only the fields for its event type; the other selected
+fields are SQL `NULL`.
+
+```sql
+SELECT timestamp, type, procedure_state,
+       region_id, source_region_id, target_region_id,
+       region_migration_trigger_reason,
+       region_migration_src_node_id, region_migration_dst_node_id
+FROM greptime_private.events
+WHERE type IN ('region_migration', 'batch_gc', 'repartition_group')
+  AND timestamp >= now() - INTERVAL '1' hour
+  AND (region_id = <region_id>
+       OR source_region_id = <region_id>
+       OR target_region_id = <region_id>)
+ORDER BY timestamp DESC
+LIMIT 1;
+```
+
+## Query Procedure events
+
+Procedure events share a `procedure_id`.
+
+### Get a procedure ID
+
+For a table-creation procedure, find the row whose trigger type is `Submitted`
+for the given database and table:
+
+```sql
+SELECT procedure_id
+FROM greptime_private.events
+WHERE type = 'create_table'
+  AND timestamp >= now() - INTERVAL '1' hour
+  AND schema_name = '<database_name>'
+  AND table_name = '<table_name>'
+  AND json_path_match(procedure_trigger, '$.type == "Submitted"')
+ORDER BY timestamp DESC
+LIMIT 1;
+```
+
+Example result:
+
+```sql
++--------------------------------------+
+| procedure_id                         |
++--------------------------------------+
+| a5788f51-5726-4db7-a85e-e9afc36da557 |
++--------------------------------------+
+```
+
+Use the returned ID to query the Procedure's event rows. Filtering by
+`schema_name` and `table_name` avoids selecting a procedure for another object
+with a similar name.
+
+### Query a Procedure
+
+Use the full-row query when you need to explore every available column:
+
+```sql
+SELECT *
+FROM greptime_private.events
+WHERE procedure_id = '<procedure_id>'
+  AND timestamp >= now() - INTERVAL '1' hour
+ORDER BY timestamp ASC;
+```
+
+For routine checks, use a focused projection:
+
+```sql
+SELECT timestamp, type, procedure_state,
+       json_get_string(procedure_trigger, 'type') AS trigger_type,
+       procedure_error, json_to_string(payload) AS payload
+FROM greptime_private.events
+WHERE procedure_id = '<procedure_id>'
+  AND timestamp >= now() - INTERVAL '1' hour
+ORDER BY timestamp;
+```
+
+Example output from a MySQL operation:
+
+```sql
++-------------------------------+--------------+-----------------+--------------+-----------------+------------------------------------------------------------+
+| timestamp                     | type         | procedure_state | trigger_type | procedure_error | payload                                                    |
++-------------------------------+--------------+-----------------+--------------+-----------------+------------------------------------------------------------+
+| 2026-08-10 11:23:14.388632208 | create_table | Running         | Submitted    |                 | {"create_if_not_exists":false,"engine":"mito","version":1} |
+| 2026-08-10 11:23:14.463992155 | create_table | Done            | Succeeded    |                 | null                                                       |
++-------------------------------+--------------+-----------------+--------------+-----------------+------------------------------------------------------------+
+```
+
+### Find failed Procedures
+
+To list recent failed Procedures:
+
+```sql
+SELECT timestamp, type, procedure_id, procedure_state,
+       json_get_string(procedure_trigger, 'type') AS trigger_type,
+       procedure_error
+FROM greptime_private.events
+WHERE procedure_state IN ('Failed', 'Poisoned')
+  AND timestamp >= now() - INTERVAL '1' hour
+ORDER BY timestamp DESC
+LIMIT 20;
+```

--- a/versioned_sidebars/version-1.2-sidebars.json
+++ b/versioned_sidebars/version-1.2-sidebars.json
@@ -352,6 +352,20 @@
                 "user-guide/deployments-administration/monitoring/key-logs",
                 "user-guide/deployments-administration/monitoring/tracing",
                 "user-guide/deployments-administration/monitoring/slow-query",
+                {
+                  "type": "category",
+                  "label": "Events",
+                  "items": [
+                    {
+                      "type": "doc",
+                      "id": "user-guide/deployments-administration/monitoring/events/overview",
+                      "label": "Overview"
+                    },
+                    "user-guide/deployments-administration/monitoring/events/query-events",
+                    "user-guide/deployments-administration/monitoring/events/event-data-model",
+                    "user-guide/deployments-administration/monitoring/events/ddl-events"
+                  ]
+                },
                 "user-guide/deployments-administration/monitoring/runtime-info"
               ]
             },
@@ -647,6 +661,7 @@
                   "id": "reference/sql/greptime-private/overview",
                   "label": "Overview"
                 },
+                "reference/sql/greptime-private/events",
                 "reference/sql/greptime-private/slow_queries",
                 "reference/sql/greptime-private/pipelines"
               ]


### PR DESCRIPTION
## What changed

Backport the Events documentation to 1.2. This adds the English and Chinese Events guides, `greptime_private.events` reference page, navigation entries, and lifecycle event recorder notes for Enterprise-only event types.

Related issue: #2723

## Scope

- Documentation versions: 1.2
- Languages: English, Chinese

## Verification

- `pnpm exec prettier --write <changed files>`
- `DOC_LANG=en pnpm check:links`
- `DOC_LANG=zh pnpm check:links`
- `git diff --check`
- Validated the documented SQL examples and their result columns against local MySQL on port 4002.

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] I updated navigation when the document structure changed.
