### PR TITLE
docs: update query guard banned operations config

### DIFF
--- a/docs/enterprise/deployments-administration/query-guard.md
+++ b/docs/enterprise/deployments-administration/query-guard.md
@@ -1,6 +1,6 @@
 ---
-keywords: [query guard, ban drop table, ban drop database, data protection, security, configuration]
-description: Guide to configuring the Query Guard plugin in GreptimeDB Enterprise to ban DROP TABLE / DROP DATABASE statements for all users and disallow cross-catalog queries.
+keywords: [query guard, ban drop table, ban drop database, ban truncate table, data protection, security, configuration]
+description: Guide to configuring the Query Guard plugin in GreptimeDB Enterprise to ban DROP TABLE, DROP DATABASE, and TRUNCATE TABLE operations for all users and disallow cross-catalog queries.
 ---
 
 # Query Guard
@@ -11,6 +11,7 @@ It provides the following protections:
 
 - **Ban `DROP TABLE`**: reject all `DROP TABLE` statements.
 - **Ban `DROP DATABASE`**: reject all `DROP DATABASE` statements.
+- **Ban `TRUNCATE TABLE`**: reject all `TRUNCATE TABLE` statements.
 - **Reject `COPY` statements**: reject all `COPY` statements.
 - **Disallow cross-catalog access**: reject queries that reference tables across
   different catalogs, cross-catalog gRPC DDL requests, and Flight bulk inserts
@@ -18,21 +19,20 @@ It provides the following protections:
 
 ## Overview
 
-The `DROP TABLE` and `DROP DATABASE` bans are enforced in the query interceptors,
-which run **before any permission check**. This means once enabled, the bans apply
-to **every user, including administrators**. No one can drop tables or databases
-through the client protocols until the configuration is changed and the frontend
-is restarted.
+The configured operation bans are enforced in the query interceptors, which run
+**before any permission check**. This means the bans apply to **every user,
+including administrators**. No one can run a banned operation through a configured
+frontend until the configuration is changed and the frontend is restarted.
 
 The bans cover both the SQL protocols (MySQL, PostgreSQL, and HTTP) and the gRPC
 protocol:
 
-- SQL path: `DROP TABLE` and `DROP DATABASE` statements are rejected with a
-  `NotSupported` error.
-- gRPC path: structured `DROP TABLE` DDL requests are rejected. The structured
-  gRPC DDL request has no drop-database variant; however, SQL statements sent over
-  gRPC go through the same SQL interceptors, so the `DROP DATABASE` ban applies to
-  SQL over gRPC as well.
+- SQL path: configured `DROP TABLE`, `DROP DATABASE`, and `TRUNCATE TABLE`
+  statements are rejected with a `NotSupported` error.
+- gRPC path: configured structured `DROP TABLE` and `TRUNCATE TABLE` DDL requests
+  are rejected. The structured gRPC DDL request has no drop-database variant;
+  however, SQL statements sent over gRPC go through the same SQL interceptors, so
+  the `DROP DATABASE` ban applies to SQL over gRPC as well.
 
 Internal operations such as TTL-based data expiration and automatic cleanup bypass
 the frontend protocol-layer interceptors and are **not** affected by these bans.
@@ -48,11 +48,16 @@ the following TOML to your GreptimeDB config file:
 [plugins.query_guard]
 # Whether to enable the query guard plugin, defaults to false.
 enable = true
-# Whether to ban DROP TABLE statements for all users, defaults to false.
-ban_drop_table = true
-# Whether to ban DROP DATABASE statements for all users, defaults to false.
-ban_drop_database = true
+# Operations to ban for all users. The list is empty by default.
+banned_ops = ["drop_table", "drop_database", "truncate_table"]
 ```
+
+The supported operation names are `drop_table`, `drop_database`, and
+`truncate_table`. To ban only a subset of these operations, include only their
+names in `banned_ops`.
+
+The former `ban_drop_table`, `ban_drop_database`, and `ban_truncate_table` options
+are no longer supported. Using any of them causes configuration parsing to fail.
 
 The plugin works in both standalone mode and distributed mode. In distributed mode,
 it takes effect on the frontend where it is configured.
@@ -61,11 +66,11 @@ it takes effect on the frontend where it is configured.
 
 - **Every frontend must carry the configuration.** In a deployment with multiple
   frontends, you must add the plugin configuration to every frontend's config file;
-  frontends without the configuration will still execute `DROP` statements.
-- **Enabling the plugin activates all protections except the `DROP` bans.**
-  Turning on `query_guard` automatically rejects `COPY` statements, cross-catalog
-  queries, cross-catalog gRPC DDL requests, and Flight bulk inserts targeting a
-  different catalog, even if you only want the `DROP` bans. The `DROP` bans are
-  controlled separately by `ban_drop_table` and `ban_drop_database`.
+  frontends without the configuration will still execute operations listed in
+  `banned_ops`.
+- **Operation bans must be configured separately.** Turning on `query_guard`
+  automatically rejects `COPY` statements, cross-catalog queries, cross-catalog
+  gRPC DDL requests, and Flight bulk inserts targeting a different catalog. To ban
+  the supported operations, add them to `banned_ops`, which is empty by default.
 - The bans are enforced at the protocol layer. Changing the configuration requires
   a restart of the frontend to take effect.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/deployments-administration/query-guard.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/deployments-administration/query-guard.md
@@ -1,6 +1,6 @@
 ---
-keywords: [query guard, 禁止 drop table, 禁止 drop database, 数据保护, 安全, 配置]
-description: 介绍如何在 GreptimeDB 企业版中配置 Query Guard 插件，为所有用户禁止 DROP TABLE / DROP DATABASE 语句，并禁止跨 catalog 查询。
+keywords: [query guard, 禁止 drop table, 禁止 drop database, 禁止 truncate table, 数据保护, 安全, 配置]
+description: 介绍如何在 GreptimeDB 企业版中配置 Query Guard 插件，为所有用户禁止 DROP TABLE、DROP DATABASE 和 TRUNCATE TABLE 操作，并禁止跨 catalog 查询。
 ---
 
 # Query Guard
@@ -10,23 +10,24 @@ Query Guard 是 GreptimeDB 企业版提供的一个插件，它在 Frontend 协�
 
 - **禁止 `DROP TABLE`**：拒绝所有 `DROP TABLE` 语句。
 - **禁止 `DROP DATABASE`**：拒绝所有 `DROP DATABASE` 语句。
+- **禁止 `TRUNCATE TABLE`**：拒绝所有 `TRUNCATE TABLE` 语句。
 - **拒绝 `COPY` 语句**：拒绝所有 `COPY` 语句。
 - **禁止跨 catalog 访问**：拒绝引用不同 catalog 下表的查询、跨 catalog 的
   gRPC DDL 请求，以及写入其他 catalog 的 Flight bulk insert。
 
 ## 工作原理
 
-对 `DROP TABLE` 和 `DROP DATABASE` 的禁止在查询拦截器中强制执行，
-拦截器在**任何权限检查之前**运行。这意味着一旦启用，该限制对
-**所有用户（包括管理员）**生效。在修改配置并重启 Frontend 之前，
-任何人都无法通过客户端协议删除表或数据库。
+配置中禁止的操作由查询拦截器强制拦截，拦截器在**任何权限检查之前**运行。
+因此，禁止规则对**所有用户（包括管理员）**生效。在修改配置并重启 Frontend
+之前，任何人都无法通过已配置的 Frontend 执行被禁止的操作。
 
 该限制同时覆盖 SQL 协议（MySQL、PostgreSQL 和 HTTP）和 gRPC 协议：
 
-- SQL 路径：`DROP TABLE` 和 `DROP DATABASE` 语句会被拒绝，返回 `NotSupported` 错误。
-- gRPC 路径：结构化的 `DROP TABLE` DDL 请求会被拒绝。结构化 gRPC DDL 请求没有
-  删除数据库的变体；但通过 gRPC 发送的 SQL 语句同样会经过 SQL 拦截器，因此
-  `DROP DATABASE` 禁令对 gRPC 上的 SQL 同样生效。
+- SQL 路径：配置中禁止的 `DROP TABLE`、`DROP DATABASE` 和 `TRUNCATE TABLE`
+  语句会被拒绝，并返回 `NotSupported` 错误。
+- gRPC 路径：配置中禁止的结构化 `DROP TABLE` 和 `TRUNCATE TABLE` DDL 请求会被拒绝。
+  结构化 gRPC DDL 请求没有删除数据库的变体；但通过 gRPC 发送的 SQL 语句同样会
+  经过 SQL 拦截器，因此 `DROP DATABASE` 禁令对 gRPC 上的 SQL 同样生效。
 
 内部操作（例如基于 TTL 的数据过期和自动清理）不经过 Frontend 协议层拦截器，
 因此**不受**这些限制影响。
@@ -41,11 +42,15 @@ Query Guard 以插件形式提供。要启用并配置它，请在 GreptimeDB �
 [plugins.query_guard]
 # 是否启用 query guard 插件，默认为 false。
 enable = true
-# 是否对所有用户禁止 DROP TABLE 语句，默认为 false。
-ban_drop_table = true
-# 是否对所有用户禁止 DROP DATABASE 语句，默认为 false。
-ban_drop_database = true
+# 对所有用户禁止的操作，默认为空列表。
+banned_ops = ["drop_table", "drop_database", "truncate_table"]
 ```
+
+`banned_ops` 支持 `drop_table`、`drop_database` 和 `truncate_table`。
+如果只需禁止其中一部分操作，仅将相应名称加入 `banned_ops` 即可。
+
+原有的 `ban_drop_table`、`ban_drop_database` 和 `ban_truncate_table` 配置项
+已不再受支持。使用其中任意配置项都会导致配置解析失败。
 
 该插件在 standalone 模式和分布式模式下均可工作。在分布式模式下，
 它在配置了该插件的 Frontend 上生效。
@@ -53,10 +58,9 @@ ban_drop_database = true
 ## 注意事项
 
 - **每个 Frontend 都必须携带该配置。** 在多 Frontend 部署中，
-  必须在每个 Frontend 的配置文件中添加该插件配置；
-  未配置的 Frontend 仍会正常执行 `DROP` 语句。
-- **启用插件会激活除 `DROP` 禁令外的所有保护。** 开启 `query_guard` 会自动拒绝
-  `COPY` 语句、跨 catalog 查询、跨 catalog 的 gRPC DDL 请求，以及写入其他
-  catalog 的 Flight bulk insert，即使你只想禁止 `DROP` 语句。`DROP` 禁令由
-  `ban_drop_table` 和 `ban_drop_database` 单独控制。
+  必须在每个 Frontend 的配置文件中添加该插件配置；未配置的 Frontend
+  仍会正常执行 `banned_ops` 中列出的操作。
+- **操作禁令需要单独配置。** 开启 `query_guard` 会自动拒绝 `COPY` 语句、
+  跨 catalog 查询、跨 catalog 的 gRPC DDL 请求，以及写入其他 catalog 的
+  Flight bulk insert。要禁止受支持的操作，请将它们加入默认为空的 `banned_ops`。
 - 该限制在协议层强制执行，修改配置后需要重启 Frontend 才能生效。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/enterprise/deployments-administration/query-guard.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/enterprise/deployments-administration/query-guard.md
@@ -1,6 +1,6 @@
 ---
-keywords: [query guard, 禁止 drop table, 禁止 drop database, 数据保护, 安全, 配置]
-description: 介绍如何在 GreptimeDB 企业版中配置 Query Guard 插件，为所有用户禁止 DROP TABLE / DROP DATABASE 语句，并禁止跨 catalog 查询。
+keywords: [query guard, 禁止 drop table, 禁止 drop database, 禁止 truncate table, 数据保护, 安全, 配置]
+description: 介绍如何在 GreptimeDB 企业版中配置 Query Guard 插件，为所有用户禁止 DROP TABLE、DROP DATABASE 和 TRUNCATE TABLE 操作，并禁止跨 catalog 查询。
 ---
 
 # Query Guard
@@ -10,23 +10,24 @@ Query Guard 是 GreptimeDB 企业版提供的一个插件，它在 Frontend 协�
 
 - **禁止 `DROP TABLE`**：拒绝所有 `DROP TABLE` 语句。
 - **禁止 `DROP DATABASE`**：拒绝所有 `DROP DATABASE` 语句。
+- **禁止 `TRUNCATE TABLE`**：拒绝所有 `TRUNCATE TABLE` 语句。
 - **拒绝 `COPY` 语句**：拒绝所有 `COPY` 语句。
 - **禁止跨 catalog 访问**：拒绝引用不同 catalog 下表的查询、跨 catalog 的
   gRPC DDL 请求，以及写入其他 catalog 的 Flight bulk insert。
 
 ## 工作原理
 
-对 `DROP TABLE` 和 `DROP DATABASE` 的禁止在查询拦截器中强制执行，
-拦截器在**任何权限检查之前**运行。这意味着一旦启用，该限制对
-**所有用户（包括管理员）**生效。在修改配置并重启 Frontend 之前，
-任何人都无法通过客户端协议删除表或数据库。
+配置中禁止的操作由查询拦截器强制拦截，拦截器在**任何权限检查之前**运行。
+因此，禁止规则对**所有用户（包括管理员）**生效。在修改配置并重启 Frontend
+之前，任何人都无法通过已配置的 Frontend 执行被禁止的操作。
 
 该限制同时覆盖 SQL 协议（MySQL、PostgreSQL 和 HTTP）和 gRPC 协议：
 
-- SQL 路径：`DROP TABLE` 和 `DROP DATABASE` 语句会被拒绝，返回 `NotSupported` 错误。
-- gRPC 路径：结构化的 `DROP TABLE` DDL 请求会被拒绝。结构化 gRPC DDL 请求没有
-  删除数据库的变体；但通过 gRPC 发送的 SQL 语句同样会经过 SQL 拦截器，因此
-  `DROP DATABASE` 禁令对 gRPC 上的 SQL 同样生效。
+- SQL 路径：配置中禁止的 `DROP TABLE`、`DROP DATABASE` 和 `TRUNCATE TABLE`
+  语句会被拒绝，并返回 `NotSupported` 错误。
+- gRPC 路径：配置中禁止的结构化 `DROP TABLE` 和 `TRUNCATE TABLE` DDL 请求会被拒绝。
+  结构化 gRPC DDL 请求没有删除数据库的变体；但通过 gRPC 发送的 SQL 语句同样会
+  经过 SQL 拦截器，因此 `DROP DATABASE` 禁令对 gRPC 上的 SQL 同样生效。
 
 内部操作（例如基于 TTL 的数据过期和自动清理）不经过 Frontend 协议层拦截器，
 因此**不受**这些限制影响。
@@ -41,11 +42,15 @@ Query Guard 以插件形式提供。要启用并配置它，请在 GreptimeDB �
 [plugins.query_guard]
 # 是否启用 query guard 插件，默认为 false。
 enable = true
-# 是否对所有用户禁止 DROP TABLE 语句，默认为 false。
-ban_drop_table = true
-# 是否对所有用户禁止 DROP DATABASE 语句，默认为 false。
-ban_drop_database = true
+# 对所有用户禁止的操作，默认为空列表。
+banned_ops = ["drop_table", "drop_database", "truncate_table"]
 ```
+
+`banned_ops` 支持 `drop_table`、`drop_database` 和 `truncate_table`。
+如果只需禁止其中一部分操作，仅将相应名称加入 `banned_ops` 即可。
+
+原有的 `ban_drop_table`、`ban_drop_database` 和 `ban_truncate_table` 配置项
+已不再受支持。使用其中任意配置项都会导致配置解析失败。
 
 该插件在 standalone 模式和分布式模式下均可工作。在分布式模式下，
 它在配置了该插件的 Frontend 上生效。
@@ -53,10 +58,9 @@ ban_drop_database = true
 ## 注意事项
 
 - **每个 Frontend 都必须携带该配置。** 在多 Frontend 部署中，
-  必须在每个 Frontend 的配置文件中添加该插件配置；
-  未配置的 Frontend 仍会正常执行 `DROP` 语句。
-- **启用插件会激活除 `DROP` 禁令外的所有保护。** 开启 `query_guard` 会自动拒绝
-  `COPY` 语句、跨 catalog 查询、跨 catalog 的 gRPC DDL 请求，以及写入其他
-  catalog 的 Flight bulk insert，即使你只想禁止 `DROP` 语句。`DROP` 禁令由
-  `ban_drop_table` 和 `ban_drop_database` 单独控制。
+  必须在每个 Frontend 的配置文件中添加该插件配置；未配置的 Frontend
+  仍会正常执行 `banned_ops` 中列出的操作。
+- **操作禁令需要单独配置。** 开启 `query_guard` 会自动拒绝 `COPY` 语句、
+  跨 catalog 查询、跨 catalog 的 gRPC DDL 请求，以及写入其他 catalog 的
+  Flight bulk insert。要禁止受支持的操作，请将它们加入默认为空的 `banned_ops`。
 - 该限制在协议层强制执行，修改配置后需要重启 Frontend 才能生效。

--- a/versioned_docs/version-1.2/enterprise/deployments-administration/query-guard.md
+++ b/versioned_docs/version-1.2/enterprise/deployments-administration/query-guard.md
@@ -1,6 +1,6 @@
 ---
-keywords: [query guard, ban drop table, ban drop database, data protection, security, configuration]
-description: Guide to configuring the Query Guard plugin in GreptimeDB Enterprise to ban DROP TABLE / DROP DATABASE statements for all users and disallow cross-catalog queries.
+keywords: [query guard, ban drop table, ban drop database, ban truncate table, data protection, security, configuration]
+description: Guide to configuring the Query Guard plugin in GreptimeDB Enterprise to ban DROP TABLE, DROP DATABASE, and TRUNCATE TABLE operations for all users and disallow cross-catalog queries.
 ---
 
 # Query Guard
@@ -11,6 +11,7 @@ It provides the following protections:
 
 - **Ban `DROP TABLE`**: reject all `DROP TABLE` statements.
 - **Ban `DROP DATABASE`**: reject all `DROP DATABASE` statements.
+- **Ban `TRUNCATE TABLE`**: reject all `TRUNCATE TABLE` statements.
 - **Reject `COPY` statements**: reject all `COPY` statements.
 - **Disallow cross-catalog access**: reject queries that reference tables across
   different catalogs, cross-catalog gRPC DDL requests, and Flight bulk inserts
@@ -18,21 +19,20 @@ It provides the following protections:
 
 ## Overview
 
-The `DROP TABLE` and `DROP DATABASE` bans are enforced in the query interceptors,
-which run **before any permission check**. This means once enabled, the bans apply
-to **every user, including administrators**. No one can drop tables or databases
-through the client protocols until the configuration is changed and the frontend
-is restarted.
+The configured operation bans are enforced in the query interceptors, which run
+**before any permission check**. This means the bans apply to **every user,
+including administrators**. No one can run a banned operation through a configured
+frontend until the configuration is changed and the frontend is restarted.
 
 The bans cover both the SQL protocols (MySQL, PostgreSQL, and HTTP) and the gRPC
 protocol:
 
-- SQL path: `DROP TABLE` and `DROP DATABASE` statements are rejected with a
-  `NotSupported` error.
-- gRPC path: structured `DROP TABLE` DDL requests are rejected. The structured
-  gRPC DDL request has no drop-database variant; however, SQL statements sent over
-  gRPC go through the same SQL interceptors, so the `DROP DATABASE` ban applies to
-  SQL over gRPC as well.
+- SQL path: configured `DROP TABLE`, `DROP DATABASE`, and `TRUNCATE TABLE`
+  statements are rejected with a `NotSupported` error.
+- gRPC path: configured structured `DROP TABLE` and `TRUNCATE TABLE` DDL requests
+  are rejected. The structured gRPC DDL request has no drop-database variant;
+  however, SQL statements sent over gRPC go through the same SQL interceptors, so
+  the `DROP DATABASE` ban applies to SQL over gRPC as well.
 
 Internal operations such as TTL-based data expiration and automatic cleanup bypass
 the frontend protocol-layer interceptors and are **not** affected by these bans.
@@ -48,11 +48,16 @@ the following TOML to your GreptimeDB config file:
 [plugins.query_guard]
 # Whether to enable the query guard plugin, defaults to false.
 enable = true
-# Whether to ban DROP TABLE statements for all users, defaults to false.
-ban_drop_table = true
-# Whether to ban DROP DATABASE statements for all users, defaults to false.
-ban_drop_database = true
+# Operations to ban for all users. The list is empty by default.
+banned_ops = ["drop_table", "drop_database", "truncate_table"]
 ```
+
+The supported operation names are `drop_table`, `drop_database`, and
+`truncate_table`. To ban only a subset of these operations, include only their
+names in `banned_ops`.
+
+The former `ban_drop_table`, `ban_drop_database`, and `ban_truncate_table` options
+are no longer supported. Using any of them causes configuration parsing to fail.
 
 The plugin works in both standalone mode and distributed mode. In distributed mode,
 it takes effect on the frontend where it is configured.
@@ -61,11 +66,11 @@ it takes effect on the frontend where it is configured.
 
 - **Every frontend must carry the configuration.** In a deployment with multiple
   frontends, you must add the plugin configuration to every frontend's config file;
-  frontends without the configuration will still execute `DROP` statements.
-- **Enabling the plugin activates all protections except the `DROP` bans.**
-  Turning on `query_guard` automatically rejects `COPY` statements, cross-catalog
-  queries, cross-catalog gRPC DDL requests, and Flight bulk inserts targeting a
-  different catalog, even if you only want the `DROP` bans. The `DROP` bans are
-  controlled separately by `ban_drop_table` and `ban_drop_database`.
+  frontends without the configuration will still execute operations listed in
+  `banned_ops`.
+- **Operation bans must be configured separately.** Turning on `query_guard`
+  automatically rejects `COPY` statements, cross-catalog queries, cross-catalog
+  gRPC DDL requests, and Flight bulk inserts targeting a different catalog. To ban
+  the supported operations, add them to `banned_ops`, which is empty by default.
 - The bans are enforced at the protocol layer. Changing the configuration requires
   a restart of the frontend to take effect.


### PR DESCRIPTION
## What changed

- Replace the obsolete Query Guard boolean options with the `banned_ops` array introduced by [GreptimeTeam/greptimedb-enterprise#869](https://github.com/GreptimeTeam/greptimedb-enterprise/pull/869).
- Document the supported `drop_table`, `drop_database`, and `truncate_table` values and their SQL/gRPC behavior.
- Explain that the former `ban_drop_table`, `ban_drop_database`, and `ban_truncate_table` options now fail configuration parsing.

## Scope

- Documentation versions: Nightly, 1.2
- Languages: English, Chinese

## Verification

- `pnpm build`
- `DOC_LANG=zh pnpm build`
- `git diff --check`
- Verified Nightly and v1.2 content parity for each language.

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors (none changed).
- [x] I updated navigation when the document structure changed (no navigation change required).