### PR TITLE
docs: refresh observability concepts foundation

### DIFF
--- a/.github/scripts/check-front-matter.js
+++ b/.github/scripts/check-front-matter.js
@@ -8,6 +8,7 @@ const { minimatch } = require('minimatch')
 const exceptionPatterns = [
   '**/grpc-sdks/template.md',
   '**/db-cloud-shared/**',
+  '**/AGENTS.md',
   '**/CONTRIBUTING.md',
   'skills/**'
 ];

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,10 @@ must not touch lockfiles.
   Docusaurus's broken-link collector. Place the alias immediately before the
   exact heading it represents, and never move one merely to silence the
   checker.
+- Use `AnchorAlias` to preserve fragments that have already been published.
+  Do not add an alias for a heading introduced and renamed within the same
+  unmerged pull request; that intermediate fragment has no published
+  compatibility contract.
 - Edit `skills/<name>/SKILL.md`, not generated files under `static/skills/` or
   `static/SKILL.md`. Do not edit `build/`, `.docusaurus/`, or JavaScript
   transpiled from tracked TypeScript.

--- a/docs/user-guide/concepts/data-model.md
+++ b/docs/user-guide/concepts/data-model.md
@@ -1,38 +1,27 @@
 ---
-keywords: [data model, time-series tables, tags, timestamps, fields, schema management]
-description: Describes the data model of GreptimeDB, focusing on time-series tables. It explains the organization of data into tables with tags, timestamps, and fields, and provides examples of metric and log tables. Design considerations and schema management are also discussed.
+keywords: [data model, time index, tags, timestamps, fields, metrics, logs, traces]
+description: Describes GreptimeDB's relational table model, time index, Tag, Timestamp, and Field semantics, with examples for metrics, logs, and traces.
 ---
 
 # Data Model
 
 ## Model
 
-GreptimeDB uses the [time-series](https://en.wikipedia.org/wiki/Time_series) table to guide the organization, compression, and expiration management of data.
-The data model is mainly based on the table model in relational databases while considering the characteristics of metrics, logs, and traces data.
+GreptimeDB uses a relational table model extended with a time index and semantic column roles: `Tag`, `Timestamp`, and `Field`. The same model is used for metrics, logs, traces, and event data, while each signal can remain in separate tables.
 
-All data in GreptimeDB is organized into tables with names. Each data item in a table consists of three semantic types of columns: `Tag`, `Timestamp`, and `Field`.
+Every GreptimeDB table has a name and exactly one time index. Columns have the following roles:
 
-- Table names are often the same as the indicator names, log source names, or metric names.
-- `Tag` columns uniquely identify the time-series.
-  Rows with the same `Tag` values belong to the same time-series.
-  Some TSDBs may also call them labels.
-- `Timestamp` is the root of a metrics, logs, and traces database.
-  It represents the date and time when the data was generated.
-  A table can only have one column with the `Timestamp` semantic type, which is also called the `time index`.
-- The other columns are `Field` columns.
-  Fields contain the data indicators or log contents that are collected.
-  These fields are generally numerical values or string values,
-  but may also be other types of data, such as geographic locations or timestamps.
+- `Tag` columns participate in the primary key and group related rows. For metrics, they usually represent labels that identify a time series. Tags are optional: append-only log and event tables can have no primary-key columns.
+- The `Timestamp` column is declared as the table's time index. It records event or sample time, helps GreptimeDB organize data by time, and enables efficient time-range queries.
+- `Field` columns store measurements, log content, trace attributes, or other values. They can use numeric, string, JSON, timestamp, and other supported data types.
 
-A table clusters rows of the same time-series and sorts rows of the same time-series by `Timestamp`.
-The table can also deduplicate rows with the same `Tag` and `Timestamp` values, depending on the requirements of the application.
-GreptimeDB stores and processes data by time-series.
-Physically, GreptimeDB persists data into immutable Parquet SST files, sorting rows by `(primary key, timestamp)` — or by timestamp alone when a table has no primary key (such as the append-only logs table below). To learn how data is laid out and pruned inside SST files, see the [storage engine](/contributor-guide/datanode/storage-engine.md#data-layout-in-sst-files) documentation.
-Choosing the right schema is crucial for efficient data storage and retrieval; please refer to the [schema design guide](/user-guide/deployments-administration/performance-tuning/design-table.md) for more details.
+For tables with primary-key columns, persisted rows are ordered by `(primary key, timestamp)`. Tables can merge rows with the same primary key and timestamp according to their [merge mode](/reference/sql/create.md#create-a-table-with-merge-mode). Append-only tables disable deduplication and, when they have no primary key, order persisted rows by timestamp. GreptimeDB stores table data in immutable Parquet SST files; see [Data Layout in SST Files](/contributor-guide/datanode/storage-engine.md#data-layout-in-sst-files) for details.
+
+Schema design affects write amplification, compression, index size, and query pruning. See the [Schema Design Guide](/user-guide/deployments-administration/performance-tuning/design-table.md) before choosing primary-key columns and indexes.
 
 ### Metrics
 
-Suppose we have a table called `system_metrics` that monitors the resource usage of machines in data centers:
+The following table stores host resource metrics:
 
 ```sql
 CREATE TABLE IF NOT EXISTS system_metrics (
@@ -47,27 +36,18 @@ CREATE TABLE IF NOT EXISTS system_metrics (
 );
 ```
 
-The data model for this table is as follows:
+![The system_metrics table maps host and idc to Tag columns, ts to the Timestamp column and time index, and the remaining measurements to Field columns.](/time-series-data-model.svg)
 
-![time-series-table-model](/time-series-data-model.svg)
+- `host` and `idc` are Tag columns declared by `PRIMARY KEY`.
+- `ts` is the Timestamp column declared by `TIME INDEX`.
+- `cpu_util`, `memory_util`, and `disk_util` are Field columns.
+- With the default [`last_row` merge mode](/reference/sql/create.md#create-a-table-with-merge-mode), queries keep the latest row for each `host`, `idc`, and `ts` combination.
 
-This is very similar to the table model everyone is familiar with. The difference lies in the `TIME INDEX` constraint, which is used to specify the `ts` column as the time index column of this table.
-
-- The table name here is `system_metrics`.
-- The `PRIMARY KEY` constraint specifies the `Tag` columns of the table.
-  The `host` column represents the hostname of the collected standalone machine.
-  The `idc` column shows the data center where the machine is located.
-- The `Timestamp` column `ts` represents the time when the data is collected.
-- The `cpu_util`, `memory_util`, `disk_util`, and `load` columns in the `Field` columns represent
-  the CPU utilization, memory utilization, disk utilization, and load of the machine, respectively.
-  These columns contain the actual data.
-- The table sorts and deduplicates rows by `host`, `idc`, `ts`. So `select count(*) from system_metrics` will scan all rows.
-
-To learn how GreptimeDB maps Prometheus metrics to this model, see [the documentation](/user-guide/ingest-data/for-observability/prometheus/#data-model).
+See [Prometheus Data Model](/user-guide/ingest-data/for-observability/prometheus.md#data-model) for the mapping between Prometheus metrics and GreptimeDB tables.
 
 ### Logs
 
-Another example is creating a table for logs like web server access logs:
+An append-only table is often a better fit for access logs:
 
 ```sql
 CREATE TABLE access_logs (
@@ -77,37 +57,35 @@ CREATE TABLE access_logs (
   http_method STRING,
   http_refer STRING,
   user_agent STRING,
-  request STRING,
-) with ('append_mode'='true');
+  request STRING
+) WITH ('append_mode' = 'true');
 ```
 
-- The time index column is `access_time`.
-- There are no tags.
-- `http_status`, `http_method`, `remote_addr`, `http_refer`, `user_agent` and `request` are fields.
-- The table sorts rows by `access_time`.
-- The table is an [append-only table](/reference/sql/create.md#create-an-append-only-table) for storing logs that do not support deletion or deduplication.
-- Querying an append-only table is usually faster. For example, `select count(*) from access_logs` can use the statistics for result without considering deduplication.
+- `access_time` is the Timestamp column.
+- The table has no Tag columns or primary key.
+- The remaining columns are Fields.
+- [`append_mode`](/reference/sql/create.md#create-an-append-only-table) disables deduplication and deletion. It fits immutable log records, but not workloads that need row updates or deletes.
+- Without a primary key, persisted rows are ordered by `access_time`.
 
-
-To learn how to indicate `Tag`, `Timestamp`, and `Field` columns, please refer to [table management](/user-guide/deployments-administration/manage-data/basic-table-operations.md#create-a-table) and [CREATE statement](/reference/sql/create.md).
+See [Create a Table](/user-guide/deployments-administration/manage-data/basic-table-operations.md#create-a-table) and the [CREATE TABLE reference](/reference/sql/create.md) for column-role syntax and table options.
 
 ### Traces
 
-GreptimeDB supports writing OpenTelemetry traces data directly via the OTLP/HTTP protocol, refer to the [OTLP traces data model](/user-guide/ingest-data/for-observability/opentelemetry.md#data-model-2) for detail.
+GreptimeDB accepts OpenTelemetry traces through OTLP/HTTP and maps spans to tables with a time index, trace identifiers, span identifiers, attributes, and duration fields. See the [OTLP Trace Data Model](/user-guide/ingest-data/for-observability/opentelemetry.md#data-model-2).
+
+Trace ingestion, storage, and SQL queries are first-class capabilities. GreptimeDB also provides a Jaeger-compatible query API.
 
 ## Design Considerations
 
-GreptimeDB is designed on top of the table model for the following reasons:
+The table model provides several practical properties:
 
-- The table model has a broad group of users and it's easy to learn; we have simply introduced the concept of time index to metrics, logs, and traces.
-- Schema is metadata that describes data characteristics, and it's more convenient for users to manage and maintain.
-- Schema brings enormous benefits for optimizing storage and computing with its information like types, lengths, etc., on which we can conduct targeted optimizations.
-- When we have the table model, it's natural for us to introduce SQL and use it to process association analysis and aggregation queries between various tables, reducing the learning and usage costs for users.
-- GreptimeDB uses a multi-value model where a single row can contain multiple field columns, reducing transfer traffic and simplifying queries compared to single-value models that require splitting data into multiple records. Read the [blog](https://greptime.com/blogs/2024-05-09-prometheus) for detailed benefits.
-- GreptimeDB applies the same Tag + Timestamp + Field concepts to metrics, logs, traces, and wide events. These signals can remain in separate tables. All signal types can be queried with SQL; metrics also support PromQL, and traces have a Jaeger-compatible query API. Read [Unified observability data model](./observability-2.md) for the mapping and trade-offs.
+- schemas expose types and column roles to the storage and query engines;
+- SQL can filter, aggregate, and join data across tables;
+- a row can contain multiple Field columns, avoiding the extra rows required by single-value models;
+- tables can choose primary keys, merge behavior, append-only mode, indexes, TTL, and storage providers independently;
+- automatic schema generation can create tables and columns for supported ingestion protocols;
+- the same Tag, Timestamp, and Field concepts apply to metrics, logs, traces, and wide events without requiring them to share a table.
 
-GreptimeDB uses SQL to manage table schema. Please refer to [table management](/user-guide/deployments-administration/manage-data/basic-table-operations.md) for more information.
-However, our definition of schema is not mandatory and leans towards a **schemaless** approach, similar to MongoDB.
-For more details, see [Automatic Schema Generation](/user-guide/ingest-data/overview.md#automatic-schema-generation).
+GreptimeDB manages table schemas with SQL. See [Table Management](/user-guide/deployments-administration/manage-data/basic-table-operations.md) and [Automatic Schema Generation](/user-guide/ingest-data/overview.md#automatic-schema-generation).
 
-Beyond the column schema, a table can carry a [table semantic layer](./semantic-layer.md) — semantic metadata recording which observability concept it represents (signal type, source, metric type, and more) — so AI agents and tooling can understand it without guessing from column names.
+Tables can also carry an optional [table semantic layer](./semantic-layer.md) describing signal identity and ingestion metadata for machine consumers. Read [Unified observability data model](./observability-2.md) for how native signals and context-rich events use the shared table model without sharing one table.

--- a/docs/user-guide/concepts/data-model.md
+++ b/docs/user-guide/concepts/data-model.md
@@ -88,4 +88,4 @@ The table model provides several practical properties:
 
 GreptimeDB manages table schemas with SQL. See [Table Management](/user-guide/deployments-administration/manage-data/basic-table-operations.md) and [Automatic Schema Generation](/user-guide/ingest-data/overview.md#automatic-schema-generation).
 
-Tables can also carry an optional [table semantic layer](./semantic-layer.md) describing signal identity and ingestion metadata for machine consumers. Read [Unified observability data model](./observability-2.md) for how native signals and context-rich events use the shared table model without sharing one table.
+Tables can also carry an optional [table semantic layer](./semantic-layer.md) describing signal identity and ingestion metadata for machine consumers. Read [Unified observability data model](./observability-2.md) for how native signals and wide events use the shared table model without sharing one table.

--- a/docs/user-guide/concepts/overview.md
+++ b/docs/user-guide/concepts/overview.md
@@ -1,24 +1,24 @@
 ---
 title: "GreptimeDB Concepts Overview"
 keywords: [GreptimeDB, features, data model, architecture, storage locations, key concepts]
-description: Provides an overview of GreptimeDB, including its features, data model, architecture, storage locations, key concepts, and notable features.
+description: Provides an overview of GreptimeDB, including its data model, architecture, storage locations, and core concepts.
 ---
 
 # Concepts
 
-GreptimeDB is an observability database that unifies metrics, logs, and traces in a single engine. This section covers the core concepts you need to understand how GreptimeDB works and why it's designed this way.
+GreptimeDB is the open-source observability database. It uses one columnar engine to process metrics, logs, and traces, and supports scalable deployments backed by object storage. The signals share Tag, Timestamp, and Field column semantics, but can remain in separate tables with different schemas and retention policies.
 
 **Start here:**
-- [Why GreptimeDB](./why-greptimedb.md) — The problem with three-pillar observability stacks, and how GreptimeDB solves it
-- [Data Model](./data-model.md) — How metrics, logs, and traces are represented as timestamped events with tags and fields
-- [Architecture](./architecture.md) — Compute-storage separation, stateless frontends, and how GreptimeDB scales
+- [Why GreptimeDB](./why-greptimedb.md) — Product scope, unified processing, scaling, protocol boundaries, and deployment options
+- [Data Model](./data-model.md) — Shared Tag, Timestamp, and Field semantics for metrics, logs, traces, and event data
+- [Architecture](./architecture.md) — Standalone and distributed deployments, compute-storage separation, and component responsibilities
 
 **Deep dives:**
 - [Unified observability data model](./observability-2.md) — The role and trade-offs of wide events alongside native signals
-- [Table Semantic Layer](./semantic-layer.md) — Semantic metadata that tells AI agents and tools what observability concept each table represents
-- [Storage Location](./storage-location.md) — Object storage, local disk, and multi-engine storage options
-- [Key Concepts](./key-concepts.md) — Tables, regions, time index, data types, views, and flows
-- [Common Questions](./features-that-you-concern.md) — FAQ on updates, deletions, TTL, compression, high cardinality, and more
+- [Table Semantic Layer](./semantic-layer.md) — Optional metadata that tells machine consumers what observability concept each table represents
+- [Storage Location](./storage-location.md) — Local storage, object storage, and per-table storage providers
+- [Key Concepts](./key-concepts.md) — Tables, Regions, time index, data types, views, and Flow
+- [Common Questions](./features-that-you-concern.md) — FAQ on updates, deletion, TTL, compression, high cardinality, and other technical boundaries
 
 ## Further Reading
 

--- a/docs/user-guide/concepts/storage-location.md
+++ b/docs/user-guide/concepts/storage-location.md
@@ -1,47 +1,67 @@
 ---
-keywords: [storage options, local file system, cloud storage, AWS S3, Azure Blob Storage]
-description: Describes the storage options for GreptimeDB, including local file systems, cloud storage services like AWS S3, Azure Blob Storage, and more. It explains the local file structure and considerations for disaster recovery and multiple storage engines.
+keywords: [storage architecture, local storage, object storage, storage providers, WAL, metadata, cache]
+description: Explains local and object-storage deployments, the roles of data files, WAL, metadata, and cache, and how tables select configured storage providers.
 ---
 
 # Storage Location
 
-GreptimeDB supports storing data in local file system, AWS S3 and compatible services (including minio, digitalocean space, Tencent Cloud Object Storage(COS), Baidu Object Storage(BOS) and so on), Azure Blob Storage and Aliyun OSS.
+GreptimeDB can keep persistent data files on a local file system or in object storage. Local storage is the default fit for standalone deployments. Shared object storage is commonly used by distributed deployments that need compute-storage separation.
 
-## Local File Structure
+Storage location is separate from table engine selection. [Mito Engine and Metric Engine](/reference/about-greptimedb-engines.md) define how table data is organized and processed; local file systems, Amazon S3, Google Cloud Storage, and Azure Blob Storage are storage providers used to persist the resulting data files. Metric Engine is built on Mito Engine and uses its storage capabilities.
 
-The storage file structure of GreptimeDB includes of the following:
+<AnchorAlias id="local-file-structure" />
 
-```cmd
-├── metadata
-    ├── raftlog
-    ├── rewrite
-    └── LOCK
-├── data
-│   ├── greptime
-│       └── public
-├── cache
-├── logs
-├── index_intermediate
-│   └── staging
-└── wal
-    ├── raftlog
-    ├── rewrite
-    └── LOCK
+## Local and Object Storage
+
+With local storage, persistent data files are placed under the configured `data_home`. This is simple for standalone deployments, but the files are tied to that host and must be included in its backup and recovery plan.
+
+With object storage, persistent data files are placed in a configured bucket or container. Datanodes can use local disks as cache while object storage remains the shared persistent location. Object storage makes it possible to scale compute separately from storage, but query latency and cost still depend on cache behavior, network performance, request volume, and provider pricing.
+
+## Storage Responsibilities
+
+A GreptimeDB deployment contains several kinds of state:
+
+| State | Responsibility | Typical location | Durability and recovery |
+| --- | --- | --- | --- |
+| Persistent data files | Table data, SST files, and persistent indexes | Local file system or object storage | Protect local files with backups. For object storage, configure retention, versioning, and replication to match recovery requirements. |
+| WAL | Records accepted writes before they are represented in persistent data files | Local WAL, remote WAL, or Noop WAL, depending on configuration | Protects accepted but unflushed writes. Recovery depends on the selected WAL mode; Noop WAL does not retain these writes. |
+| Metadata | Catalogs, schemas, table definitions, Region routes, and procedure state | Local metadata in standalone mode; Metasrv state in cluster mode | Required to reconstruct database state. Persist, replicate, or back it up according to the deployment mode. |
+| Local cache | Cached object-storage data and temporary index data | Datanode or standalone local disk | Disposable and rebuildable from persistent data. It should not be part of the durability boundary. |
+| Process logs | Operational logs from GreptimeDB components | Local logging destination or configured log collector | Not required for database recovery. Retain them according to operational and compliance requirements. |
+
+These requirements are deployment-dependent. See the recovery documentation below before assigning an RPO or RTO.
+
+<AnchorAlias id="cloud-storage" />
+
+## Object Storage and Disaster Recovery
+
+Putting persistent data files in object storage does not by itself provide a complete disaster-recovery plan. Recovery also depends on the selected WAL mode, metadata backup or replication, Region state, object-store versioning and retention, and deployment configuration.
+
+For recovery planning, see [Disaster Recovery](/user-guide/deployments-administration/disaster-recovery/overview.md) and the [WAL Overview](/user-guide/deployments-administration/wal/overview.md). Disabling WAL with Noop WAL changes the durability boundary and should be evaluated separately.
+
+## Supported Storage Providers
+
+GreptimeDB supports:
+
+- local file storage;
+- Amazon S3 and S3-compatible services, including MinIO, DigitalOcean Spaces, Tencent Cloud Object Storage, and Baidu Object Storage;
+- Google Cloud Storage;
+- Azure Blob Storage;
+- Alibaba Cloud OSS.
+
+See [Storage Options](/user-guide/deployments-administration/configuration.md#storage-options) for the complete configuration keys and current provider list.
+
+<AnchorAlias id="multiple-storage-engines" />
+
+## Multiple Storage Providers
+
+An administrator can configure multiple storage providers under `[[storage.providers]]`. A table can then select one configured provider through its `storage` table option:
+
+```sql
+CREATE TABLE archive_events (
+  ts TIMESTAMP TIME INDEX,
+  payload STRING
+) WITH (storage = 'archive_s3');
 ```
 
-- `metadata`:  The internal metadata directory that keeps catalog, database and table info, procedure states, etc. In cluster mode, this directory does not exist, because all those states including region route info are saved in `Metasrv`.
-- `data`: The files in data directory store time series data and index files of GreptimeDB. To customize this path, please refer to [Storage option](/user-guide/deployments-administration/configuration.md#storage-options). The directory is organized in a two-level structure of catalog and schema.
-- `cache`: The directory for internal caching, such as object storage cache, etc.
-- `logs`: The log files contains all the logs of operations in GreptimeDB.
-- `wal`: The wal directory contains the write-ahead log files.
-- `index_intermediate`: the temporary intermediate data while indexing.
-
-## Cloud storage
-
-The `data` directory in the file structure can be stored in cloud storage. Please refer to [Storage option](/user-guide/deployments-administration/configuration.md#storage-options) for more details.
-
-Please note that only storing the data directory in object storage is not sufficient to ensure data reliability and disaster recovery. The `wal` and `metadata` also need to be considered for disaster recovery. Please refer to the [disaster recovery documentation](/user-guide/deployments-administration/disaster-recovery/overview.md).
-
-## Multiple storage engines
-
-Another powerful feature of GreptimeDB is that you can choose the storage engine for each table. For example, you can store some tables on the local disk, and some tables in Amazon S3 or Google Cloud Storage, see [create table](/reference/sql/create.md#create-table).
+This setting chooses where the table engine stores persistent files. It does not select a different table engine. Provider names and credentials must be configured before the table is created. See [Create a Table with Custom Storage](/reference/sql/create.md#create-a-table-with-custom-storage).

--- a/docs/user-guide/concepts/why-greptimedb.md
+++ b/docs/user-guide/concepts/why-greptimedb.md
@@ -33,14 +33,14 @@ Unification happens at the engine, storage, and query layers. It does not requir
 
 ## One Columnar Engine, Separate Tables
 
-Reducing the number of systems should not force unlike signals into the same schema. Metric samples, log records, spans, and context-rich events have different access patterns and retention needs.
+Reducing the number of systems should not force unlike signals into the same schema. Metric samples, log records, spans, and wide events have different access patterns and retention needs.
 
 GreptimeDB lets each workload use tables suited to its data:
 
 - metrics commonly use primary-key columns for labels and PromQL for queries;
 - logs often use append-only tables and text or inverted indexes selected for the workload;
 - traces retain trace and span identifiers and can be queried with SQL or the Jaeger-compatible API;
-- context-rich events can use wider schemas where retrospective analysis justifies the added storage cost.
+- wide events can retain more context where retrospective analysis justifies the added storage cost.
 
 These tables can have different schemas, indexes, TTL settings, compaction options, and storage providers. See [Data Model](./data-model.md) and [Storage Location](./storage-location.md) for the underlying mechanisms.
 
@@ -82,16 +82,16 @@ Edition boundaries matter when evaluating scale, availability, and operating eff
 
 [GreptimeDB Enterprise](/enterprise/overview.md) adds separately documented capabilities such as read replicas, workload isolation through Datanode groups, automatic Region balancing and repartitioning, RBAC, LDAP integration, audit logging, and enterprise disaster-recovery options. These capabilities are not implied when this guide describes the open-source cluster.
 
-## What You Still Configure
+## Configuration Choices
 
-Using one system changes the controls you operate; it does not make the workloads identical. A production deployment still needs explicit choices:
+Using one system changes the controls you operate; it does not make the workloads identical. You can tune each workload through these controls:
 
-- set schemas, indexes, TTLs, and compaction options for each workload;
-- size caches, query concurrency, and compute capacity for the expected mix of recent and historical queries;
-- choose WAL, metadata, object-storage, backup, and restore settings that meet durability and recovery targets;
-- plan Region placement, failover, and resource isolation where the workload requires them.
+- [Table design](/user-guide/deployments-administration/performance-tuning/design-table.md): choose schemas, primary keys, indexes, append-only behavior, and partitioning. Set retention with [TTL policies](/user-guide/manage-data/overview.md#manage-data-retention-with-ttl-policies) and tune [compaction](/user-guide/deployments-administration/manage-data/compaction.md) when the workload needs it.
+- [Capacity planning](/user-guide/deployments-administration/capacity-plan.md): size compute, memory, and local cache for the expected ingestion rate and mix of recent and historical queries. Use the [performance tuning guide](/user-guide/deployments-administration/performance-tuning/performance-tuning-tips.md) to adjust cache and query behavior from runtime evidence.
+- [Durability and recovery](/user-guide/deployments-administration/disaster-recovery/overview.md): select a [WAL mode](/user-guide/deployments-administration/wal/overview.md), metadata storage, object-storage policy, and backup and restore process that meet the deployment's RPO and RTO.
+- [Region operations](/user-guide/deployments-administration/manage-data/overview.md): plan table sharding, manual Region migration, and failover for distributed deployments. Enterprise deployments can also use [Datanode groups](/enterprise/deployments-administration/deploy-on-kubernetes/configure-datanode-groups.md) for workload isolation and [Region Balancer](/enterprise/autopilot/region-balancer.md) for automatic balancing.
 
-See [Storage Location](./storage-location.md) and [Disaster Recovery](/user-guide/deployments-administration/disaster-recovery/overview.md) before assigning RPO, RTO, or availability targets.
+The right settings depend on the workload and deployment mode; they are not a single preset shared by every signal.
 
 <AnchorAlias id="high-performance" />
 
@@ -99,7 +99,7 @@ See [Storage Location](./storage-location.md) and [Disaster Recovery](/user-guid
 
 Published case studies give results for specific workloads and configurations:
 
-- [OceanBase Cloud](https://greptime.com/blogs/2025-07-22-user-case-obcloud-log-management-greptimedb) runs more than 80 GreptimeDB clusters with 300 TB of log and SQL audit data under a seven-day retention period. It reports around 1 GB/s of sustained writes and more than 60% lower overall log-storage cost after moving from Loki.
+- [OceanBase Cloud](https://greptime.com/blogs/2025-07-22-user-case-obcloud-log-management-greptimedb) runs 80+ GreptimeDB clusters with 300 TB of log and SQL audit data under a seven-day retention period. The case study reports around 1 GB/s of sustained writes and 60%+ lower overall log storage cost after moving from Loki.
 - [Poizon](https://greptime.com/blogs/2025-05-06-poizon-observability-greptimedb-monitoring-use-case) uses Flow to maintain 10-second, 1-minute, and 10-minute rollups from detailed events. Its case study reports that pre-aggregation reduced P99 query latency from seconds to milliseconds.
 
 Results depend on schema, indexes, retention, hardware, object-storage pricing, cache configuration, and query workload. Use published [benchmark reports](https://greptime.com/blogs/2024-09-09-report-summary) with their test conditions when sizing a deployment.

--- a/docs/user-guide/concepts/why-greptimedb.md
+++ b/docs/user-guide/concepts/why-greptimedb.md
@@ -29,6 +29,8 @@ GreptimeDB uses the same columnar engine and [Tag, Timestamp, and Field semantic
 
 Unification happens at the engine, storage, and query layers. It does not require metrics, logs, and traces to use one table, one schema, or the [wide-event model](./observability-2.md).
 
+![Metrics, logs, and traces remain in separate tables while sharing schema concepts, storage, and query layers.](/unified-observability-model.svg)
+
 ## One Columnar Engine, Separate Tables
 
 Reducing the number of systems should not force unlike signals into the same schema. Metric samples, log records, spans, and context-rich events have different access patterns and retention needs.
@@ -47,6 +49,8 @@ These tables can have different schemas, indexes, TTL settings, compaction optio
 Incident response needs fast queries over recent data. Trend analysis, capacity work, and investigations may scan weeks or months. Splitting these workloads between a monitoring backend and an analytics database adds another ingestion path, another copy of the data, and another system to operate.
 
 GreptimeDB handles both workloads with the same engine, storage system, and query layer. Recent data can be served from memory and local caches, while persistent data remains in object storage for longer-range queries. Historical analysis does not require a separate analytics database and data-copy pipeline.
+
+![Real-time monitoring and historical analysis have different workload profiles but share GreptimeDB's engine, storage system, and query layer.](/shared-system-realtime-historical.svg)
 
 <AnchorAlias id="cost-effective-with-object-storage" />
 <AnchorAlias id="elastic-scaling-with-kubernetes" />

--- a/docs/user-guide/concepts/why-greptimedb.md
+++ b/docs/user-guide/concepts/why-greptimedb.md
@@ -1,100 +1,115 @@
 ---
-keywords: [cloud-native, observability database, high performance, cost-effective, unified design]
-description: Explains the motivations and benefits of using GreptimeDB, including its unified design for metrics, logs, and traces, cloud-native architecture, cost-effectiveness, high performance, and ease of use. It highlights key features and deployment strategies.
+keywords: [open-source observability database, metrics, logs, traces, object storage, compute-storage separation]
+description: Explains why teams evaluate GreptimeDB, how it handles metrics, logs, and traces, and where open-source and Enterprise capabilities differ.
 ---
 
 # Why GreptimeDB
 
-## The Problem: Three Systems for Three Signals
+Teams usually evaluate a new observability backend when separate signal stores, storage expansion, or long-term analysis have become too expensive to operate. GreptimeDB addresses these problems with one columnar engine for metrics, logs, and traces, while keeping the data model and deployment choices explicit.
 
-Most observability stacks today look like this: [Prometheus](/user-guide/ingest-data/for-observability/prometheus.md) (or Thanos/Mimir) for metrics, [Grafana Loki](/user-guide/ingest-data/for-observability/loki.md) (or ELK) for logs, and [Elasticsearch](/user-guide/protocols/elasticsearch.md) (or Tempo) for traces. Each system has its own query language, storage backend, scaling model, and operational overhead.
+## What GreptimeDB Is
 
-This "three pillars" architecture made sense when these were separate concerns. But in practice, it means:
+GreptimeDB is an open-source observability database. It stores and queries metrics, logs, and traces with one columnar engine and a shared SQL layer. It can run as a standalone process on local storage or as a distributed cluster backed by object storage.
 
-- **3x operational complexity** — three systems to deploy, monitor, upgrade, and debug
-- **Data silos** — correlating a spike in error logs with a metrics anomaly requires manual context-switching between systems
-- **Cost escalation** — each system stores redundant metadata, and scaling each independently leads to over-provisioning
+GreptimeDB is not a general-purpose transactional database. Its storage, indexing, retention, and query paths are designed for append-heavy, time-indexed workloads such as observability and IoT data.
 
-GreptimeDB takes a different approach: one database engine for all three signal types, built on object storage with compute-storage separation.
+<AnchorAlias id="the-problem-three-systems-for-three-signals" />
+<AnchorAlias id="unified-processing-for-observability-data" />
 
-## Unified Processing for Observability Data
+## Why One Engine for Three Signals
 
-GreptimeDB unifies the processing of metrics, logs, and traces through:
-- A consistent [data model](./data-model.md) that treats all observability data as timestamped wide events with context
-- Native support for both [SQL](/user-guide/query-data/sql.md) and [PromQL](/user-guide/query-data/promql.md) queries
-- Built-in continuous aggregation capabilities ([Flow](/user-guide/flow-computation/overview.md)) for real-time aggregation and analytics
-- Seamless correlation analysis across different types of observability data (read the [SQL example](/getting-started/quick-start.md#correlate-metrics-logs-and-traces) for detailed info)
+When metrics, logs, and traces live in separate databases, each store brings its own capacity model, lifecycle policy, query path, and failure modes. Correlation also depends on moving data between systems or coordinating several queries during an incident.
 
-It replaces complex legacy data stacks with a high-performance single solution.
+GreptimeDB uses the same columnar engine and [Tag, Timestamp, and Field semantics](./data-model.md) across the three signal types. This gives teams:
 
-This means you can replace the [Prometheus](/user-guide/ingest-data/for-observability/prometheus.md) + [Loki](/user-guide/ingest-data/for-observability/loki.md) + [Elasticsearch](/user-guide/protocols/elasticsearch.md) stack with a single database, and use SQL to correlate metrics spikes with log patterns and trace latency — in one query, without context-switching between systems.
+- one storage and lifecycle-management system for metrics, logs, and traces;
+- SQL across all signal tables and PromQL for metrics;
+- [Flow](/user-guide/flow-computation/overview.md) for continuous aggregation and materialized derived data;
+- SQL correlation through common identifiers when instrumentation records them.
 
-<p align='center'><img src="/unify-processing.png" alt="Replaces complex legacy data stacks with a high-performance single solution" width="400"/></p>
+Unification happens at the engine, storage, and query layers. It does not require metrics, logs, and traces to use one table, one schema, or the [wide-event model](./observability-2.md).
 
-## Cost-Effective with Object Storage
+## One Columnar Engine, Separate Tables
 
-GreptimeDB leverages [cloud object storage](/user-guide/concepts/storage-location.md) (like AWS S3 and Azure Blob Storage etc.) as its storage layer, dramatically reducing costs compared to traditional storage solutions. Its optimized columnar storage and advanced compression algorithms achieve up to 50x cost efficiency. Scale flexibly across cloud storage systems (e.g., S3, Azure Blob Storage) for simplified management, dramatic cost efficiency, and **no vendor lock-in**.
+Reducing the number of systems should not force unlike signals into the same schema. Metric samples, log records, spans, and context-rich events have different access patterns and retention needs.
 
-In production deployments, teams have achieved:
-- **Logs**: 60%+ storage cost reduction in production at OceanBase Cloud (migrated from [Loki](/user-guide/ingest-data/for-observability/loki.md) — 80+ GreptimeDB clusters, 300TB of multi-cloud logs and SQL audit data)
-- **Traces**: 45x storage cost reduction, 3x faster queries (replaced [Elasticsearch](/user-guide/protocols/elasticsearch.md) as [Jaeger](/user-guide/query-data/jaeger.md) backend — one-week migration)
-- **Metrics**: Replaced Thanos with native compute-storage separation, significantly reducing operational complexity
+GreptimeDB lets each workload use tables suited to its data:
 
-## High Performance
+- metrics commonly use primary-key columns for labels and PromQL for queries;
+- logs often use append-only tables and text or inverted indexes selected for the workload;
+- traces retain trace and span identifiers and can be queried with SQL or the Jaeger-compatible API;
+- context-rich events can use wider schemas where retrospective analysis justifies the added storage cost.
 
-As for performance optimization, GreptimeDB utilizes different techniques such as LSM Tree, data sharding, and flexible WAL options (local disk or distributed services like Kafka), to handle large workloads of observability data ingestion.
+These tables can have different schemas, indexes, TTL settings, compaction options, and storage providers. See [Data Model](./data-model.md) and [Storage Location](./storage-location.md) for the underlying mechanisms.
 
-GreptimeDB is written in pure Rust for superior performance and reliability. The powerful and fast query engine is powered by vectorized execution and distributed parallel processing (thanks to [Apache DataFusion](https://datafusion.apache.org/)), and combined with [indexing capabilities](/user-guide/manage-data/data-index.md) such as inverted index, skipping index, and full-text index. GreptimeDB combines smart indexing and Massively Parallel Processing (MPP) to boost pruning and filtering.
+## One System for Real-Time Monitoring and Historical Analysis
 
-[GreptimeDB achieves 1 billion cold runs #1 in JSONBench!](https://greptime.com/blogs/2025-03-18-jsonbench-greptimedb-performance) Read more [benchmark reports](https://www.greptime.com/blogs/2024-09-09-report-summary).
+Incident response needs fast queries over recent data. Trend analysis, capacity work, and investigations may scan weeks or months. Splitting these workloads between a monitoring backend and an analytics database adds another ingestion path, another copy of the data, and another system to operate.
 
-## Elastic Scaling with Kubernetes
+GreptimeDB handles both workloads with the same engine, storage system, and query layer. Recent data can be served from memory and local caches, while persistent data remains in object storage for longer-range queries. Historical analysis does not require a separate analytics database and data-copy pipeline.
 
-Built from the ground up for [Kubernetes](/user-guide/deployments-administration/deploy-on-kubernetes/overview.md), GreptimeDB features a disaggregated storage and compute [architecture](/user-guide/concepts/architecture.md) that enables true elastic scaling:
-- Independent scaling of storage and compute resources
-- Unlimited horizontal scalability through Kubernetes
-- Resource isolation between different workloads (ingestion, querying, compaction)
-- Automatic failover and high availability
+<AnchorAlias id="cost-effective-with-object-storage" />
+<AnchorAlias id="elastic-scaling-with-kubernetes" />
 
-Unlike Thanos or Mimir, which require multiple stateful components (ingesters with persistent disks, store-gateways, compactors) to achieve scalability, GreptimeDB's architecture separates compute from storage at the core — data persists in object storage, compute nodes scale independently, with local disk serving as buffer/cache. WAL can be configured flexibly (local or distributed via Kafka). Scaling up means adding nodes; scaling down loses no data.
+## Object Storage and Independent Scaling
 
-![Storage/Compute Disaggregation, Compute/Compute separation](/storage-compute-disaggregation-compute-compute-separation.png)
+When persistent files are tied to compute nodes, adding capacity can require moving data, rebalancing local disks, or provisioning storage and compute together. That makes a storage-heavy observability cluster harder to change as retention grows.
 
-## Flexible Architecture: From Edge to Cloud
+In distributed GreptimeDB deployments configured with shared object storage, persistent data files are kept in services such as Amazon S3, Google Cloud Storage, or Azure Blob Storage. Datanodes perform writes, compaction, and queries, while local disks can cache remote data. Compute and object-storage capacity can be adjusted separately without copying every persistent data file between Datanodes. See [Architecture](./architecture.md) and [Storage Location](./storage-location.md).
 
-![The architecture of GreptimeDB](/architecture-2.png)
+<AnchorAlias id="easy-to-integrate" />
+<AnchorAlias id="flexible-architecture-from-edge-to-cloud" />
 
-GreptimeDB's modularized [architecture](/user-guide/concepts/architecture.md) allows different components to operate independently or in unison as needed. Its flexible design supports a wide variety of deployment scenarios, from edge devices to cloud environments, while still using consistent APIs for operations. For example:
-- Frontend, datanode, and metasrv can be merged into a standalone binary
-- Components like WAL or indexing can be enabled or disabled per table
+## Protocols and Query Boundaries
 
-This flexibility ensures that GreptimeDB meets deployment requirements for edge-to-cloud solutions, like the [Edge-Cloud Integrated Solution](https://greptime.com/product/carcloud).
+Replacing collection agents, dashboards, and client code can cost more than deploying a new database. GreptimeDB therefore accepts data through several established protocols:
 
-From embedded and standalone deployments to cloud-native clusters, GreptimeDB adapts to various environments easily.
+- Prometheus Remote Write for metrics;
+- OpenTelemetry OTLP/HTTP for metrics, logs, and traces;
+- Loki Push API for logs;
+- Elasticsearch Bulk API for document ingestion;
+- InfluxDB Line Protocol, MySQL, PostgreSQL, and the GreptimeDB gRPC and HTTP APIs.
 
-## Easy to Integrate
+These integrations cover specific ingestion or client interfaces, not every feature of the source system. Loki ingestion does not provide LogQL, and the open-source Elasticsearch integration covers the Bulk API rather than the full Query DSL. Use [SQL](/user-guide/query-data/sql.md) across signal types, [PromQL](/user-guide/query-data/promql.md) for metrics, and the Jaeger-compatible query API for traces. Review each protocol page before planning a migration.
 
-GreptimeDB supports [PromQL](/user-guide/query-data/promql.md), [Prometheus remote write](/user-guide/ingest-data/for-observability/prometheus.md), [OpenTelemetry](/user-guide/ingest-data/for-observability/opentelemetry.md), [Jaeger](/user-guide/query-data/jaeger.md), [Loki](/user-guide/ingest-data/for-observability/loki.md), [Elasticsearch](/user-guide/protocols/elasticsearch.md), [MySQL](/user-guide/protocols/mysql.md), and [PostgreSQL](/user-guide/protocols/postgresql.md) protocols — migrate from your existing stack without rewriting queries or pipelines. Query with [SQL](/user-guide/query-data/sql.md) or PromQL, visualize with [Grafana](/user-guide/integrations/grafana.md).
+## Open-Source and Enterprise Scope
 
-The combination of SQL and PromQL means GreptimeDB can replace the classic "Prometheus + data warehouse" combo — use PromQL for real-time monitoring and alerting, SQL for deep analytics, joins, and aggregations, all in one system. GreptimeDB also supports a [multi-value model](/user-guide/concepts/data-model.md), where a single row can contain multiple field columns, reducing transfer traffic and simplifying queries compared to single-value models.
+Edition boundaries matter when evaluating scale, availability, and operating effort. The open-source project includes standalone and cluster deployment, object-storage support, SQL and PromQL, Flow, indexing, and the ingestion interfaces listed above.
 
-Beyond querying, SQL is also GreptimeDB's management interface — [create tables](/user-guide/deployments-administration/manage-data/basic-table-operations.md), [manage schemas](/reference/sql/alter.md), set [TTL policies](/user-guide/manage-data/overview.md#manage-data-retention-with-ttl-policies), and configure [indexes](/user-guide/manage-data/data-index.md), all through standard SQL. No proprietary config files, no custom APIs, no YAML-driven control planes. This is a key operational difference from systems like Prometheus (configured via YAML + relabeling rules), Loki (LogQL + config files), or Elasticsearch (REST API + JSON mappings). Teams with SQL skills can manage GreptimeDB without learning new tooling.
+[GreptimeDB Enterprise](/enterprise/overview.md) adds separately documented capabilities such as read replicas, workload isolation through Datanode groups, automatic Region balancing and repartitioning, RBAC, LDAP integration, audit logging, and enterprise disaster-recovery options. These capabilities are not implied when this guide describes the open-source cluster.
 
-## How GreptimeDB Compares
+## What You Still Configure
 
-The following comparison is based on general architectural characteristics and typical deployment scenarios:
+Using one system changes the controls you operate; it does not make the workloads identical. A production deployment still needs explicit choices:
 
-| | GreptimeDB | Prometheus / Thanos / Mimir | Grafana Loki | Elasticsearch |
-|---|---|---|---|---|
-| Data types | Metrics, logs, traces | Metrics only | Logs only | Logs, traces |
-| Query language | SQL + PromQL | PromQL | LogQL | Query DSL |
-| Storage | Native object storage (S3, etc.) | Local disk + object storage (Thanos/Mimir), ingester requires persistent disk | Object storage (chunks) | Local disk |
-| Scaling | Compute-storage separation, compute nodes scale independently | Federation / Thanos / Mimir — multi-component, ops heavy | Stateless + object storage | Shard-based, ops heavy |
-| Cost efficiency | Up to 50x lower storage | High at scale | Moderate | High (inverted index overhead) |
-| OpenTelemetry | Native (metrics + logs + traces) | Partial (metrics only) | Partial (logs only) | Via instrumentation |
-| Management | Standard SQL (DDL, TTL, indexes) | YAML config + relabeling rules | YAML config + LogQL | REST API + JSON mappings |
+- set schemas, indexes, TTLs, and compaction options for each workload;
+- size caches, query concurrency, and compute capacity for the expected mix of recent and historical queries;
+- choose WAL, metadata, object-storage, backup, and restore settings that meet durability and recovery targets;
+- plan Region placement, failover, and resource isolation where the workload requires them.
 
-For more details, explore:
-- [Unified observability data model](./observability-2.md) — How native signals and wide events map to GreptimeDB
-- [Unified Storage for Observability - GreptimeDB's Approach](https://greptime.com/blogs/2024-12-24-observability) — GreptimeDB's approach to unified storage
-- [Beyond Loki: Lightweight and Scalable Cloud-Native Log Monitoring](https://greptime.com/blogs/2025-08-07-beyond-loki-greptimedb-log-scenario-performance-report)
+See [Storage Location](./storage-location.md) and [Disaster Recovery](/user-guide/deployments-administration/disaster-recovery/overview.md) before assigning RPO, RTO, or availability targets.
+
+<AnchorAlias id="high-performance" />
+
+## What Production Users Report
+
+Published case studies give results for specific workloads and configurations:
+
+- [OceanBase Cloud](https://greptime.com/blogs/2025-07-22-user-case-obcloud-log-management-greptimedb) runs more than 80 GreptimeDB clusters with 300 TB of log and SQL audit data under a seven-day retention period. It reports around 1 GB/s of sustained writes and more than 60% lower overall log-storage cost after moving from Loki.
+- [Poizon](https://greptime.com/blogs/2025-05-06-poizon-observability-greptimedb-monitoring-use-case) uses Flow to maintain 10-second, 1-minute, and 10-minute rollups from detailed events. Its case study reports that pre-aggregation reduced P99 query latency from seconds to milliseconds.
+
+Results depend on schema, indexes, retention, hardware, object-storage pricing, cache configuration, and query workload. Use published [benchmark reports](https://greptime.com/blogs/2024-09-09-report-summary) with their test conditions when sizing a deployment.
+
+<AnchorAlias id="how-greptimedb-compares" />
+
+## Compare Against Your Current Stack
+
+The useful comparison is usually against the systems already carrying the workload: Prometheus, Mimir, or Thanos for metrics; Loki or Tempo for logs and traces; Elasticsearch; VictoriaMetrics; or ClickHouse and ClickStack.
+
+The [GreptimeDB comparison hub](https://greptime.com/compare/) links to product-specific pages covering architecture, protocol and query differences, migration paths, and benchmark conditions. Use the page for the system you run today rather than a context-free feature matrix.
+
+## Choose a Next Step
+
+- Run the [Quick Start](/getting-started/quick-start.md) to test ingestion and queries locally.
+- Review the [product comparisons](https://greptime.com/compare/) against your current stack.
+- Use the [migration guides](/user-guide/migrate-to-greptimedb/overview.md) to check protocol, query, dashboard, and historical-data changes before a production cutover.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/data-model.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/data-model.md
@@ -88,4 +88,4 @@ Trace 写入、存储和 SQL 查询都是一等能力。GreptimeDB 还提供 Jae
 
 GreptimeDB 使用 SQL 管理表 schema，详见[表管理](/user-guide/deployments-administration/manage-data/basic-table-operations.md)和[自动生成表结构](/user-guide/ingest-data/overview.md#自动生成表结构)。
 
-表还可以携带可选的[表语义层](./semantic-layer.md)，向机器消费者说明信号身份和写入元数据。[统一的可观测数据模型](./observability-2.md)进一步解释了原生信号和上下文事件如何共用表模型，但不共用同一张表。
+表还可以携带可选的[表语义层](./semantic-layer.md)，向机器消费者说明信号身份和写入元数据。[统一的可观测数据模型](./observability-2.md)进一步解释了原生信号和宽事件如何共用表模型，但不共用同一张表。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/data-model.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/data-model.md
@@ -1,26 +1,27 @@
 ---
-keywords: [数据模型, 表结构, 列类型, 设计考虑, 时序表, Tag, Timestamp, Field, Metrics, Logs, Traces]
-description: 介绍 GreptimeDB 的数据模型，包括表结构、列类型和设计考虑，适用于 metrics、logs 和 traces 数据。
+keywords: [数据模型, 时间索引, Tag, Timestamp, Field, Metrics, Logs, Traces]
+description: 介绍 GreptimeDB 的关系表模型、时间索引和 Tag、Timestamp、Field 列语义，并给出 metrics、logs、traces 示例。
 ---
 
 # 数据模型
 
 ## 模型
 
-GreptimeDB 使用时序表来组织、压缩和管理数据的过期。数据模型基于关系型数据库的表模型，同时针对 metrics、logs、traces 的特点做了适配。
+GreptimeDB 使用关系表模型，并增加时间索引以及 `Tag`、`Timestamp`、`Field` 三类列语义。Metrics、logs、traces 和事件数据都使用这套模型，但可以保存在不同的表中。
 
-所有数据按表组织，每个表中的列分为三种语义类型：`Tag`、`Timestamp` 和 `Field`。
+每张表都有表名和唯一的时间索引。各类列的含义如下：
 
-- 表名通常和指标名、日志源名或 metric 名称一致。
-- `Tag` 列标识时间序列的身份。相同 Tag 值的行属于同一条时间序列（有些 TSDB 也叫 label）。
-- `Timestamp` 是时序数据库的根基，表示数据的生成时间。每个表只能有一个 `Timestamp` 类型的列，也叫时间索引（`Time Index`）。
-- 其余列是 `Field` 列，存放实际的数据指标或日志内容，通常是数值或字符串，也可以是地理位置、时间戳等其他类型。
+- `Tag` 列参与主键，用来组织相关的数据行。在 metrics 表中，Tag 通常对应标识时间序列的 labels。Tag 不是必选项，append-only 日志表和事件表可以没有主键列。
+- `Timestamp` 列通过 `TIME INDEX` 声明为时间索引，用来记录事件或采样时间。GreptimeDB 据此按时间组织数据，并优化时间范围查询。
+- `Field` 列保存测量值、日志内容、trace 属性或其他数据，可以使用数值、字符串、JSON、时间戳等 GreptimeDB 支持的数据类型。
 
-表按时间序列组织行，同一时间序列内按 `Timestamp` 排序。表还可以对相同 `Tag` + `Timestamp` 的行做去重，具体取决于业务需求。物理上，GreptimeDB 会把数据持久化为不可变的 Parquet SST 文件，行按照 `(primary key, timestamp)` 排序；当表没有 primary key（例如下面的 append-only 日志表）时，仅按照 timestamp 排序。要了解 SST 文件中的数据布局和裁剪方式，详见[存储引擎](/contributor-guide/datanode/storage-engine.md#sst-文件中的数据布局)文档。选择合适的表结构对查询和存储效率至关重要，详见[表设计指南](/user-guide/deployments-administration/performance-tuning/design-table.md)。
+对于有主键的表，持久化数据按 `(primary key, timestamp)` 排序。主键和时间戳相同的数据如何合并，由 [merge mode](/reference/sql/create.md#创建带有-merge-模式的表)决定。Append-only 表关闭去重；如果表没有主键，持久化数据按时间戳排序。GreptimeDB 将表数据存为不可变的 Parquet SST 文件，详见 [SST 文件中的数据布局](/contributor-guide/datanode/storage-engine.md#sst-文件中的数据布局)。
+
+Schema 会影响写放大、压缩率、索引大小和查询裁剪效果。选择主键和索引前，请阅读[表设计指南](/user-guide/deployments-administration/performance-tuning/design-table.md)。
 
 ### Metrics
 
-假设有一个 `system_metrics` 表，监控数据中心机器的资源使用：
+下面的表用于保存主机资源指标：
 
 ```sql
 CREATE TABLE IF NOT EXISTS system_metrics (
@@ -35,23 +36,18 @@ CREATE TABLE IF NOT EXISTS system_metrics (
 );
 ```
 
-数据模型如下：
+![system_metrics 表中，host 和 idc 是 Tag 列，ts 是 Timestamp 列和时间索引，其余测量值是 Field 列。](/time-series-data-model.zh.svg)
 
-![time-series-table-model](/time-series-data-model.svg)
+- `host` 和 `idc` 是通过 `PRIMARY KEY` 声明的 Tag 列。
+- `ts` 是通过 `TIME INDEX` 声明的 Timestamp 列。
+- `cpu_util`、`memory_util`、`disk_util` 是 Field 列。
+- 使用默认的 [`last_row` merge mode](/reference/sql/create.md#创建带有-merge-模式的表)时，查询会为每组相同的 `host`、`idc`、`ts` 保留最后写入的一行。
 
-和常见的关系表模型很像，区别在于 `TIME INDEX` 约束——用来指定 `ts` 列为时间索引。
-
-- 表名 `system_metrics`。
-- `PRIMARY KEY` 指定 Tag 列：`host` 是主机名，`idc` 是数据中心。
-- `ts` 是 Timestamp 列，表示数据采集时间。
-- `cpu_util`、`memory_util`、`disk_util` 是 Field 列，存放实际数据。
-- 表按 `host`、`idc`、`ts` 排序和去重，所以 `select count(*) from system_metrics` 需要扫全表。
-
-Prometheus metrics 如何映射到这个模型，参见[文档](/user-guide/ingest-data/for-observability/prometheus/#数据模型)。
+Prometheus metrics 与 GreptimeDB 表的映射方式，参见 [Prometheus 数据模型](/user-guide/ingest-data/for-observability/prometheus.md#数据模型)。
 
 ### Logs
 
-创建一个存 Web Server 访问日志的表：
+Web Server 访问日志通常适合使用 append-only 表：
 
 ```sql
 CREATE TABLE access_logs (
@@ -61,34 +57,35 @@ CREATE TABLE access_logs (
   http_method STRING,
   http_refer STRING,
   user_agent STRING,
-  request STRING,
-) with ('append_mode'='true');
+  request STRING
+) WITH ('append_mode' = 'true');
 ```
 
-- 时间索引列是 `access_time`。
-- 没有 Tag 列。
-- `http_status`、`http_method`、`remote_addr`、`http_refer`、`user_agent`、`request` 是 Field 列。
-- 按 `access_time` 排序。
-- 这是一个 [append-only 表](/reference/sql/create.md#创建-append-only-表)，不支持去重和删除，适合日志场景。
-- 查询 append-only 表通常更快，比如 `select count(*) from access_logs` 可以直接用统计信息返回结果，不需要考虑去重。
+- `access_time` 是 Timestamp 列。
+- 表没有 Tag 列或主键。
+- 其余列都是 Field。
+- [`append_mode`](/reference/sql/create.md#创建-append-only-表)会关闭去重和删除，适合不可变的日志记录，不适合需要更新或删除数据行的 workload。
+- 表没有主键，持久化数据按 `access_time` 排序。
 
-如何指定 `Tag`、`Timestamp`、`Field` 列，参见[表管理](/user-guide/deployments-administration/manage-data/basic-table-operations.md#创建表)和 [CREATE 语句](/reference/sql/create.md)。
+列语义和表选项的语法参见[建表](/user-guide/deployments-administration/manage-data/basic-table-operations.md#创建表)和 [CREATE TABLE 参考](/reference/sql/create.md)。
 
 ### Traces
 
-GreptimeDB 支持通过 OTLP/HTTP 协议直接写入 OpenTelemetry traces 数据，详见 [OTLP traces 数据模型](/user-guide/ingest-data/for-observability/opentelemetry.md#数据模型-2)。
+GreptimeDB 通过 OTLP/HTTP 接收 OpenTelemetry traces，并将 spans 映射到包含时间索引、trace 标识、span 标识、属性和耗时字段的表中。详见 [OTLP Trace 数据模型](/user-guide/ingest-data/for-observability/opentelemetry.md#数据模型-2)。
+
+Trace 写入、存储和 SQL 查询都是一等能力。GreptimeDB 还提供 Jaeger 兼容查询接口。
 
 ## 设计考虑
 
-GreptimeDB 为什么选择表模型：
+采用表模型有几个直接收益：
 
-- 表模型用户基础广、学习门槛低。在此基础上加一个时间索引的概念，就能统一处理 metrics、logs、traces。
-- Schema 是描述数据特征的元数据，方便管理和维护。
-- Schema 提供类型、长度等信息，存储和计算引擎可以做针对性优化。
-- 有了表模型，自然引入 SQL，用 SQL 做跨表关联分析和聚合查询，降低用户的学习成本。
-- GreptimeDB 采用多值模型，单行可以有多个 Field 列，相比需要把数据拆成多条记录的单值模型，省传输流量、查询也更简洁。详见[博客](https://greptime.cn/blogs/2024-05-09-prometheus)。
-- GreptimeDB 对 metrics、logs、traces 和宽事件采用共同的 Tag + Timestamp + Field 概念。这些信号可以使用不同的表。所有信号都能使用 SQL 查询，metrics 还支持 PromQL，traces 还提供 Jaeger 兼容查询接口。具体对应关系和工程取舍参见[统一的可观测数据模型](./observability-2.md)。
+- schema 向存储和查询引擎提供类型与列语义；
+- SQL 可以跨表过滤、聚合和关联数据；
+- 一行可以包含多个 Field，避免单值模型把同一采样拆成多行；
+- 每张表可以独立选择主键、merge mode、append-only 模式、索引、TTL 和存储后端；
+- 支持的写入协议可以通过自动建表创建表和列；
+- metrics、logs、traces 和宽事件采用共同的 Tag、Timestamp、Field 概念，但不要求写入同一张表。
 
-GreptimeDB 用 SQL 管理表 schema，参见[表管理](/user-guide/deployments-administration/manage-data/basic-table-operations.md)。不过 schema 定义不是强制的，更偏向 **Schemaless** 的方式——写入时自动建表、自动加列。详见[自动生成表结构](../ingest-data/overview.md#自动生成表结构)。
+GreptimeDB 使用 SQL 管理表 schema，详见[表管理](/user-guide/deployments-administration/manage-data/basic-table-operations.md)和[自动生成表结构](/user-guide/ingest-data/overview.md#自动生成表结构)。
 
-除了列 schema，一张表还可以携带一层[表语义层](./semantic-layer.md)——记录它代表什么可观测性概念的语义元数据（signal type、source、metric type 等）——让 AI agent 和工具无需从列名去猜就能理解它。
+表还可以携带可选的[表语义层](./semantic-layer.md)，向机器消费者说明信号身份和写入元数据。[统一的可观测数据模型](./observability-2.md)进一步解释了原生信号和上下文事件如何共用表模型，但不共用同一张表。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/overview.md
@@ -1,24 +1,24 @@
 ---
 title: "GreptimeDB 概念概述"
 keywords: [GreptimeDB, 特性, 数据模型, 架构, 存储位置, 核心概念]
-description: GreptimeDB 概念概览，包括为什么选择 GreptimeDB、数据模型、架构、存储位置、核心概念和常见问题。
+description: GreptimeDB 概念概览，包括产品定位、数据模型、架构、存储位置和核心概念。
 ---
 
 # 概念
 
-GreptimeDB 是一个可观测性数据库，在单一引擎中统一处理 metrics、logs 和 traces。这里介绍理解 GreptimeDB 所需的核心概念。
+GreptimeDB 是开源的可观测性数据库。它用同一个列式引擎处理 metrics、logs 和 traces，并支持以对象存储为持久化存储的可扩展部署。三类信号共享 Tag、Timestamp、Field 列语义，但可以使用不同的表、schema 和留存策略。
 
 **从这里开始：**
-- [为什么选择 GreptimeDB](./why-greptimedb.md) — 三支柱架构的问题，GreptimeDB 怎么解决
-- [数据模型](./data-model.md) — Metrics、logs、traces 如何用 Tag + Timestamp + Field 统一表示
-- [架构](./architecture.md) — 计算存储分离、无状态 Frontend、GreptimeDB 如何扩展
+- [为什么选择 GreptimeDB](./why-greptimedb.md) — 产品边界、统一处理、扩展方式、协议边界和部署形态
+- [数据模型](./data-model.md) — Metrics、logs、traces 和事件数据共用的 Tag、Timestamp、Field 语义
+- [架构](./architecture.md) — 单机与分布式部署、计算存储分离和组件职责
 
 **深入了解：**
 - [统一的可观测数据模型](./observability-2.md) — 宽事件与原生信号的关系及工程取舍
-- [表语义层](./semantic-layer.md) — 告诉 AI agent 和工具每张表代表什么可观测性概念的语义元数据
-- [存储位置](./storage-location.md) — 对象存储、本地盘、多引擎存储
-- [核心概念](./key-concepts.md) — 表、Region、时间索引、数据类型、视图、Flow
-- [常见问题](./features-that-you-concern.md) — 更新、删除、TTL、压缩、高基数等 FAQ
+- [表语义层](./semantic-layer.md) — 告诉机器消费者每张表代表什么可观测性概念的可选元数据
+- [存储位置](./storage-location.md) — 本地存储、对象存储和按表选择的存储后端
+- [核心概念](./key-concepts.md) — 表、Region、时间索引、数据类型、View 和 Flow
+- [常见问题](./features-that-you-concern.md) — 更新、删除、TTL、压缩、高基数等技术边界
 
 ## 延伸阅读
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/storage-location.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/storage-location.md
@@ -1,47 +1,67 @@
 ---
-keywords: [存储位置, 本地文件系统, 云存储, AWS S3, Azure Blob Storage, 阿里云 OSS, 存储文件结构]
-description: 介绍 GreptimeDB 支持的存储位置，包括本地文件系统和各种云存储服务，以及存储文件结构。
+keywords: [存储架构, 本地存储, 对象存储, 存储后端, WAL, metadata, cache]
+description: 介绍本地存储和对象存储部署，以及数据文件、WAL、metadata、cache 和按表选择存储后端的职责边界。
 ---
 
 # 存储位置
 
-GreptimeDB 支持将数据存储在本地文件系统、AWS S3 及其兼容服务（包括 minio、digitalocean space、腾讯云对象存储 (COS)、百度云对象存储 (BOS) 等）、Azure Blob Storage 和阿里云 OSS 中。
+GreptimeDB 可以把持久化数据文件放在本地文件系统或对象存储中。本地存储适合 standalone 部署；需要计算存储分离的分布式部署通常使用共享对象存储。
 
-## 本地文件结构
+存储位置和 table engine 是两层不同的抽象。[Mito Engine 和 Metric Engine](/reference/about-greptimedb-engines.md)决定表数据如何组织和处理；本地文件系统、Amazon S3、Google Cloud Storage、Azure Blob Storage 等 storage provider 负责保存引擎生成的数据文件。Metric Engine 基于 Mito Engine，并复用其存储能力。
 
-GreptimeDB 的存储文件结构包括以下内容：
+<AnchorAlias id="本地文件结构" />
 
-```cmd
-├── metadata
-    ├── raftlog
-    ├── rewrite
-    └── LOCK
-├── data
-│   ├── greptime
-│       └── public
-├── cache
-├── logs
-├── index_intermediate
-│   └── staging
-└── wal
-    ├── raftlog
-    ├── rewrite
-    └── LOCK
+## 本地存储与对象存储
+
+使用本地存储时，持久化数据文件放在配置的 `data_home` 下。这种方式适合 standalone，但文件与所在主机绑定，备份和恢复方案需要覆盖该目录。
+
+使用对象存储时，持久化数据文件放在配置的 bucket 或 container 中。Datanode 可以用本地磁盘做 cache，对象存储则是共享的持久化位置。这样可以分别调整计算和存储容量，但查询延迟与成本仍取决于 cache、网络、请求量和服务价格。
+
+## 各类存储的职责
+
+GreptimeDB 部署中包含几类不同的状态：
+
+| 状态 | 职责 | 常见位置 | 持久性与恢复要求 |
+| --- | --- | --- | --- |
+| 持久化数据文件 | 表数据、SST 文件和持久化索引 | 本地文件系统或对象存储 | 本地文件需要备份；对象存储应根据恢复要求配置留存、版本控制和复制。 |
+| WAL | 在写入形成持久化数据文件前记录已接收的数据 | 根据配置使用 Local WAL、Remote WAL 或 Noop WAL | 用于恢复已接收但尚未 flush 的写入。恢复能力取决于 WAL 模式；Noop WAL 不保留这部分数据。 |
+| Metadata | Catalog、schema、表定义、Region 路由和 procedure 状态 | Standalone 使用本地 metadata；集群模式由 Metasrv 管理 | 恢复数据库状态时必须具备。应根据部署模式持久化、复制或备份。 |
+| 本地 cache | 缓存对象存储数据和索引临时数据 | Datanode 或 standalone 的本地磁盘 | 可以从持久化数据重建，不属于数据持久性边界。 |
+| 进程日志 | GreptimeDB 组件运行日志 | 本地日志目录或配置的日志采集系统 | 数据库恢复不依赖进程日志，可按运维和合规要求留存。 |
+
+具体要求取决于部署方式。在确定 RPO 和 RTO 前，应结合下文的恢复文档评估。
+
+<AnchorAlias id="云存储" />
+
+## 对象存储与灾备
+
+把持久化数据文件放入对象存储，不等于已经具备完整的灾备能力。恢复还取决于 WAL 模式、metadata 备份或复制、Region 状态、对象存储的版本与留存设置，以及部署配置。
+
+规划恢复方案时，请同时阅读[灾备](/user-guide/deployments-administration/disaster-recovery/overview.md)和 [WAL 概述](/user-guide/deployments-administration/wal/overview.md)。使用 Noop WAL 会改变数据持久性边界，需要单独评估。
+
+## 支持的存储后端
+
+GreptimeDB 支持：
+
+- 本地文件系统；
+- Amazon S3 及 S3 兼容服务，包括 MinIO、DigitalOcean Spaces、腾讯云对象存储和百度对象存储；
+- Google Cloud Storage；
+- Azure Blob Storage；
+- 阿里云 OSS。
+
+完整配置项和当前支持列表参见[存储选项](/user-guide/deployments-administration/configuration.md#storage-options)。
+
+<AnchorAlias id="多存储引擎支持" />
+
+## 多个存储后端
+
+管理员可以通过 `[[storage.providers]]` 配置多个存储后端。建表时，再通过 `storage` 表选项选择其中一个：
+
+```sql
+CREATE TABLE archive_events (
+  ts TIMESTAMP TIME INDEX,
+  payload STRING
+) WITH (storage = 'archive_s3');
 ```
 
-- `metadata`: 内部元数据目录，保存 catalog、数据库以及表的元信息、procedure 状态等内部状态。在集群模式下，此目录不存在，因为所有这些状态（包括区域路由信息）都保存在 `Metasrv` 中。
-- `data`: 存储 GreptimeDB 的实际的时间序列数据和索引文件。如果要自定义此路径，请参阅 [存储选项](/user-guide/deployments-administration/configuration.md#storage-options)。该目录按照 catalog 和 schema 的两级结构组织。
-- `cache`: 内部的数据缓存目录，比如对象存储的本地缓存等。
-- `logs`: GreptimeDB 日志文件目录。
-- `wal`:  预写日志文件目录。
-- `index_intermediate`: 索引构建和查询相关的临时中间数据目录。
-
-## 云存储
-
-文件结构中的 `data` 目录可以存储在云存储中。请参考[存储选项](/user-guide/deployments-administration/configuration.md#storage-options)了解更多细节。
-
-请注意，仅将 `data` 目录存储在对象存储中不足以确保数据可靠性和灾难恢复，`wal` 和 `metadata` 也需要考虑灾难恢复，更详细地请参阅[灾难恢复文档](/user-guide/deployments-administration/disaster-recovery/overview.md)。
-
-## 多存储引擎支持
-
-GreptimeDB 的另一个强大功能是可以为每张表单独选择存储引擎。例如，您可以将一些表存储在本地磁盘上，将另一些表存储在 Amazon S3 或 Google Cloud Storage 中，请参考 [create table](/reference/sql/create.md#create-table)。
+这个选项决定 table engine 把持久化文件存到哪里，不会切换 table engine。建表前需要先配置 provider name 和访问凭证。详见[创建自定义存储的表](/reference/sql/create.md#创建自定义存储的表)。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/why-greptimedb.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/why-greptimedb.md
@@ -29,6 +29,8 @@ GreptimeDB 用同一个列式引擎处理三类信号，并采用共同的 [Tag�
 
 这里的“统一”指引擎、存储和查询层，不要求 metrics、logs、traces 使用同一张表、同一套 schema，也不要求采用[宽事件模型](./observability-2.md)。
 
+![Metrics、logs 和 traces 仍然使用独立的表，同时共享 schema 概念、存储系统和查询层。](/unified-observability-model.zh.svg)
+
 ## 一个列式引擎，不同的表
 
 减少系统数量，不等于把不同信号硬塞进同一种 schema。指标点、日志、span 和包含完整上下文的事件，其访问方式和留存要求并不相同。
@@ -47,6 +49,8 @@ GreptimeDB 允许每类 workload 使用适合自己的表：
 故障处置需要快速查询近期数据，趋势分析、容量评估和事后排查则可能扫描几周甚至几个月的数据。如果分别使用监控后端和分析数据库，就要多维护一条写入链路、一份数据副本和一套系统。
 
 GreptimeDB 用同一个引擎、同一套存储与查询基础处理这两类 workload。近期数据可以通过内存和本地 cache 加速，持久化数据则保存在对象存储中，供更长时间范围的查询使用。长期分析不需要另建分析数据库和数据复制链路。
+
+![实时监控与历史分析的 workload 特征不同，但共用 GreptimeDB 的引擎、存储系统和查询层。](/shared-system-realtime-historical.zh.svg)
 
 <AnchorAlias id="对象存储成本低一个数量级" />
 <AnchorAlias id="基于-kubernetes-的弹性扩展" />

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/why-greptimedb.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/why-greptimedb.md
@@ -1,98 +1,115 @@
 ---
-keywords: [云原生, 可观测性数据库, 高性能, 成本效益, 统一设计]
-description: 解释使用 GreptimeDB 的动机和优势，包括统一处理 metrics、logs 和 traces 的设计、云原生架构、成本优势、高性能和易集成性。
+keywords: [开源可观测性数据库, metrics, logs, traces, 对象存储, 计算存储分离]
+description: 说明团队为什么评估 GreptimeDB、GreptimeDB 如何处理 metrics、logs 和 traces，以及开源版与 Enterprise 的能力边界。
 ---
 
 # 为什么选择 GreptimeDB
 
-## 问题：三种信号，三套系统
+团队开始评估新的可观测后端，往往是因为多套信号存储、存储扩容或长期分析的运维成本已经难以忽略。GreptimeDB 用同一个列式引擎处理 metrics、logs 和 traces，同时保留清晰的数据模型和部署边界。
 
-大多数团队的可观测性栈长这样：[Prometheus](/user-guide/ingest-data/for-observability/prometheus.md)（或 Thanos/Mimir）跑 metrics，[Grafana Loki](/user-guide/ingest-data/for-observability/loki.md)（或 ELK）跑日志，[Elasticsearch](/user-guide/protocols/elasticsearch.md)（或 Tempo）跑 traces。每套系统各有一套查询语言、存储方案、扩展方式，运维各管各的。
+## GreptimeDB 是什么
 
-"三支柱"架构在这些关注点各自独立时是合理的。但实际跑起来就是：
+GreptimeDB 是开源的可观测性数据库。它用同一个列式引擎存储和查询 metrics、logs、traces，并提供统一的 SQL 查询层。GreptimeDB 既可以使用本地存储以单机模式运行，也可以组成以对象存储为持久化存储的分布式集群。
 
-- **3 倍运维量** — 三套系统要分别部署、监控、升级、排障
-- **数据孤岛** — 错误率飙升和日志里的异常模式要手动在系统间切换才能关联
-- **成本失控** — 每套系统存一份冗余元数据，各自独立扩展导致资源浪费
+GreptimeDB 不是通用事务数据库。它的存储、索引、留存和查询路径面向以追加写入为主的时间索引数据，例如可观测数据和 IoT 数据。
 
-GreptimeDB 的思路不同：一个引擎处理三种信号，数据放对象存储，计算存储分离。
+<AnchorAlias id="问题三种信号三套系统" />
+<AnchorAlias id="统一处理可观测数据" />
 
-## 统一处理可观测数据
+## 为什么用一个引擎处理三种信号
 
-GreptimeDB 通过以下方式统一处理 metrics、logs 和 traces：
-- 一致的[数据模型](./data-model.md)，将所有可观测数据视为带上下文的时间戳宽事件
-- 原生支持 [SQL](/user-guide/query-data/sql.md) 和 [PromQL](/user-guide/query-data/promql.md) 双查询
-- 内置持续聚合能力（[Flow](/user-guide/flow-computation/overview.md)）做实时聚合和分析
-- 跨信号无缝关联分析（参见 [SQL 示例](/getting-started/quick-start.md#关联-metricslogs-和-traces)）
+metrics、logs 和 traces 分散在不同数据库时，每套系统都有自己的容量模型、生命周期策略、查询方式和故障边界。故障排查要么搬运数据，要么在几套系统之间来回查询。
 
-一套系统替代原来的多组件栈。
+GreptimeDB 用同一个列式引擎处理三类信号，并采用共同的 [Tag、Timestamp、Field 列语义](./data-model.md)：
 
-具体来说：用一个数据库替代 [Prometheus](/user-guide/ingest-data/for-observability/prometheus.md) + [Loki](/user-guide/ingest-data/for-observability/loki.md) + [Elasticsearch](/user-guide/protocols/elasticsearch.md)，用 SQL 在一条查询里关联 metrics 异常、日志模式和 trace 延迟——不用在系统间来回切换。
+- metrics、logs、traces 共用一套存储和生命周期管理机制；
+- 所有信号都可以使用 SQL 查询，metrics 还可以使用 PromQL；
+- [Flow](/user-guide/flow-computation/overview.md)用于持续聚合，并把派生结果物化到 sink table；
+- instrumentation 记录了共同标识时，可以通过 SQL 关联不同信号。
 
-<p align='center'><img src="/unify-processing.png" alt="用单一引擎替代多组件可观测性栈" width="400"/></p>
+这里的“统一”指引擎、存储和查询层，不要求 metrics、logs、traces 使用同一张表、同一套 schema，也不要求采用[宽事件模型](./observability-2.md)。
 
-## 对象存储，成本低一个数量级
+## 一个列式引擎，不同的表
 
-GreptimeDB 以[云对象存储](/user-guide/concepts/storage-location.md)（S3、Azure Blob Storage 等）为主存储层，配合列式压缩，存储成本最高可降低 50 倍。支持灵活扩展到各类云存储，管理简单，**无厂商锁定**。
+减少系统数量，不等于把不同信号硬塞进同一种 schema。指标点、日志、span 和包含完整上下文的事件，其访问方式和留存要求并不相同。
 
-生产环境实测：
-- **Logs**：OceanBase Cloud 生产环境存储成本下降 60%+（从 [Loki](/user-guide/ingest-data/for-observability/loki.md) 迁移到 GreptimeDB，80+ 集群、300TB 多云日志和 SQL 审计数据）
-- **Traces**：存储成本降低 45 倍，查询快 3 倍（替换 [Elasticsearch](/user-guide/protocols/elasticsearch.md) 作为 [Jaeger](/user-guide/query-data/jaeger.md) 后端，一周完成迁移）
-- **Metrics**：用原生计算存储分离替代 Thanos，运维复杂度大幅下降
+GreptimeDB 允许每类 workload 使用适合自己的表：
 
-## 高性能
+- metrics 通常用主键列保存 labels，并使用 PromQL 查询；
+- logs 常用 append-only 表，并根据查询方式选择全文索引或倒排索引；
+- traces 保留 trace 和 span 标识，可以使用 SQL 或 Jaeger 兼容接口查询；
+- 只有在事后分析确实需要完整上下文时，才需要使用更宽的事件表，并承担相应的存储成本。
 
-写入端，GreptimeDB 用 LSM Tree、数据分片、灵活的 WAL 配置（本地盘或 Kafka）等手段处理大规模可观测数据的写入负载。
+这些表可以分别配置 schema、索引、TTL、compaction 选项和存储后端。具体机制参见[数据模型](./data-model.md)和[存储位置](./storage-location.md)。
 
-查询端，GreptimeDB 用纯 Rust 编写，查询引擎基于 [Apache DataFusion](https://datafusion.apache.org/) 做向量化执行和分布式并行处理，结合[多种索引](/user-guide/manage-data/data-index.md)（倒排索引、跳数索引、全文索引）做智能裁剪和过滤。
+## 实时监控与历史分析，共用一套系统
 
-[GreptimeDB 在 JSONBench 10 亿条记录冷查询中拿下第一！](https://greptime.cn/blogs/2025-03-18-json-benchmark-greptimedb) 更多[性能测试报告](https://greptime.cn/blogs/2024-09-09-report-summary)。
+故障处置需要快速查询近期数据，趋势分析、容量评估和事后排查则可能扫描几周甚至几个月的数据。如果分别使用监控后端和分析数据库，就要多维护一条写入链路、一份数据副本和一套系统。
 
-## 基于 Kubernetes 的弹性扩展
+GreptimeDB 用同一个引擎、同一套存储与查询基础处理这两类 workload。近期数据可以通过内存和本地 cache 加速，持久化数据则保存在对象存储中，供更长时间范围的查询使用。长期分析不需要另建分析数据库和数据复制链路。
 
-GreptimeDB 从底层就为 [Kubernetes](/user-guide/deployments-administration/deploy-on-kubernetes/overview.md) 设计，采用计算存储分离[架构](/user-guide/concepts/architecture.md)，实现真正的弹性扩展：
-- 存储和计算资源独立伸缩
-- 通过 Kubernetes 水平扩展，无上限
-- 写入、查询、压缩等不同负载之间做资源隔离
-- 自动故障转移和高可用
+<AnchorAlias id="对象存储成本低一个数量级" />
+<AnchorAlias id="基于-kubernetes-的弹性扩展" />
 
-Thanos 和 Mimir 要靠多个有状态组件（ingester 需要持久盘、store-gateway、compactor）才能扩展。GreptimeDB 从架构层面就是计算存储分离——数据持久化在对象存储，计算节点独立扩展，本地盘只做缓冲和缓存。扩容加节点，缩容不丢数据。
+## 对象存储与独立扩展
 
-![存储/计算分离，计算/计算分离](/storage-compute-disaggregation-compute-compute-separation.png)
+持久化文件绑定在计算节点上时，增加容量往往伴随数据迁移、本地磁盘再均衡，或者存储与计算一起扩容。留存数据越多，集群调整越重。
 
-## 灵活部署：从边缘到云
+分布式 GreptimeDB 使用共享对象存储时，持久化数据文件可以放在 Amazon S3、Google Cloud Storage、Azure Blob Storage 等服务中。Datanode 负责写入、compaction 和查询，本地磁盘可以缓存远端数据。计算容量与对象存储容量可以分别调整，不必在 Datanode 之间复制全部持久化文件。具体参见[架构](./architecture.md)和[存储位置](./storage-location.md)。
 
-![GreptimeDB 架构](/architecture-2.png)
+<AnchorAlias id="易于集成" />
+<AnchorAlias id="灵活部署从边缘到云" />
 
-GreptimeDB 的模块化[架构](/user-guide/concepts/architecture.md)让各组件既能独立运行，也能协同部署。从边缘设备到云环境，都用同一套 API。比如：
-- Frontend、Datanode 和 Metasrv 可以合并成单一二进制（standalone 模式）
-- WAL、索引等组件可以按表级别启用或关闭
+## 协议和查询边界
 
-这种灵活性让 GreptimeDB 能覆盖从边缘到云的完整场景，比如[边云一体化解决方案](https://greptime.cn/carcloud)。
+迁移成本常常不在数据库部署本身，而在采集端、仪表盘和客户端代码。GreptimeDB 支持通过多种现有协议写入数据：
 
-从嵌入式单机部署到云原生集群，GreptimeDB 都能适配。
+- Prometheus Remote Write 写入 metrics；
+- OpenTelemetry OTLP/HTTP 写入 metrics、logs 和 traces；
+- Loki Push API 写入 logs；
+- Elasticsearch Bulk API 写入文档；
+- InfluxDB Line Protocol、MySQL、PostgreSQL，以及 GreptimeDB 的 gRPC 和 HTTP API。
 
-## 易于集成
+这些集成只覆盖对应的写入或客户端接口，不代表完整兼容原系统。Loki 写入不包含 LogQL；开源版 Elasticsearch 集成支持 Bulk API，不等于完整支持 Query DSL。所有信号都可以使用 [SQL](/user-guide/query-data/sql.md) 查询，metrics 还可以使用 [PromQL](/user-guide/query-data/promql.md)，traces 还可以使用 Jaeger 兼容查询接口。规划迁移前，应先核对各协议页面列出的边界。
 
-GreptimeDB 支持 [PromQL](/user-guide/query-data/promql.md)、[Prometheus remote write](/user-guide/ingest-data/for-observability/prometheus.md)、[OpenTelemetry](/user-guide/ingest-data/for-observability/opentelemetry.md)、[Jaeger](/user-guide/query-data/jaeger.md)、[Loki](/user-guide/ingest-data/for-observability/loki.md)、[Elasticsearch](/user-guide/protocols/elasticsearch.md)、[MySQL](/user-guide/protocols/mysql.md)、[PostgreSQL](/user-guide/protocols/postgresql.md) 协议——从现有栈迁移不用改查询、不用改 pipeline。查询用 [SQL](/user-guide/query-data/sql.md) 或 PromQL，可视化接 [Grafana](/user-guide/integrations/grafana.md)。
+## 开源版与 Enterprise 的边界
 
-SQL + PromQL 双引擎意味着 GreptimeDB 可以替代"Prometheus + 数据仓库"的经典组合——PromQL 做实时监控告警，SQL 做深度分析、JOIN、聚合，全在一个系统里。GreptimeDB 还支持[多值模型](/user-guide/concepts/data-model.md)，单行可以有多个字段列，比单值模型省流量、查询也更简洁。
+评估扩展能力、可用性和运维成本时，需要先分清版本边界。开源版包括单机和集群部署、对象存储、SQL、PromQL、Flow、索引，以及上面列出的写入接口。
 
-SQL 不只是查询语言，也是 GreptimeDB 的管理入口——[建表](/user-guide/deployments-administration/manage-data/basic-table-operations.md)、[管理 schema](/reference/sql/alter.md)、设置 [TTL 策略](/user-guide/manage-data/overview.md#使用-ttl-策略保留数据)、配置[索引](/user-guide/manage-data/data-index.md)，全部用标准 SQL 完成。不需要专有配置文件，不需要自定义 API，不需要 YAML 驱动的控制面。这是和 Prometheus（YAML 配置 + relabeling rules）、Loki（YAML 配置 + LogQL）、Elasticsearch（REST API + JSON mappings）在运维层面的关键区别。团队只要会 SQL，就能管理 GreptimeDB，不用学新工具。
+[GreptimeDB Enterprise](/enterprise/overview.md) 另行提供读副本、通过 Datanode group 隔离 workload、自动 Region 均衡与重分区、RBAC、LDAP 集成、审计日志和企业灾备方案等能力。概念文档提到开源集群时，不默认包含这些功能。
 
-## GreptimeDB 对比
+## 仍然需要配置什么
 
-| | GreptimeDB | Prometheus / Thanos / Mimir | Grafana Loki | Elasticsearch |
-|---|---|---|---|---|
-| 数据类型 | Metrics、Logs、Traces | 仅 Metrics | 仅 Logs | Logs、Traces |
-| 查询语言 | SQL + PromQL | PromQL | LogQL | Query DSL |
-| 存储 | 原生对象存储（S3 等） | 本地盘 + 对象存储（Thanos/Mimir），ingester 需要持久盘 | 对象存储（chunks） | 本地盘 |
-| 扩展 | 计算存储分离，计算节点独立扩展 | Federation / Thanos / Mimir — 多组件，运维重 | 无状态 + 对象存储 | 基于分片，运维重 |
-| 成本 | 存储成本最高降低 50 倍 | 大规模下成本高 | 中等 | 高（倒排索引开销） |
-| OpenTelemetry | 原生支持（Metrics + Logs + Traces） | 部分（仅 Metrics） | 部分（仅 Logs） | 通过 instrumentation |
-| 管理方式 | 标准 SQL（DDL、TTL、索引） | YAML 配置 + relabeling rules | YAML 配置 + LogQL | REST API + JSON mappings |
+共用一套系统改变的是运维对象，不会让不同 workload 变得完全相同。生产部署仍要明确配置：
 
-了解更多：
-- [统一的可观测数据模型](./observability-2.md) — 原生信号和宽事件如何对应 GreptimeDB 的能力
-- [可观测性统一存储](https://greptime.cn/blogs/2024-12-24-observability) — GreptimeDB 的统一存储设计
-- [替换 Loki！GreptimeDB 在 OB Cloud 的大规模日志存储实践](https://greptime.cn/blogs/2025-07-22-user-case-obcloud-log-storage-greptimedb)
+- 按 workload 设置 schema、索引、TTL 和 compaction；
+- 根据近期查询与历史查询的比例，规划 cache、查询并发和计算容量；
+- 根据持久性和恢复目标配置 WAL、metadata、对象存储、备份和恢复；
+- 按需规划 Region 放置、failover 和资源隔离。
+
+确定 RPO、RTO 或可用性目标前，请先阅读[存储位置](./storage-location.md)和[灾备](/user-guide/deployments-administration/disaster-recovery/overview.md)。
+
+<AnchorAlias id="高性能" />
+
+## 生产用户公开的数据
+
+下面的数据来自特定 workload 和配置下的公开案例：
+
+- [OceanBase Cloud](https://greptime.cn/blogs/2025-07-22-user-case-obcloud-log-storage-greptimedb) 运行着 80 多个 GreptimeDB 集群，保存 300 TB 日志与 SQL 审计数据，留存周期为 7 天，持续写入吞吐约 1 GB/s。从 Loki 迁移后，整体日志存储成本下降 60% 以上。
+- [得物](https://greptime.cn/blogs/2025-05-06-poizon-greptimedb-observability)使用 Flow 从明细事件持续维护 10 秒、1 分钟和 10 分钟粒度的聚合结果。公开案例显示，预聚合将 P99 查询延迟从秒级降到毫秒级。
+
+实际结果取决于 schema、索引、留存周期、硬件、对象存储价格、cache 配置和查询 workload。规划容量时，应结合带测试条件的[性能报告](https://greptime.cn/blogs/2024-09-09-report-summary)。
+
+<AnchorAlias id="greptimedb-对比" />
+
+## 和现有方案比较
+
+实际选型通常是在现有可观测系统之间比较：指标侧的 Prometheus、Mimir、Thanos，日志与链路侧的 Loki、Tempo、Elasticsearch，以及 VictoriaMetrics、ClickHouse 或 ClickStack。
+
+[GreptimeDB 对比页面](https://greptime.cn/compare/)按产品列出了架构、协议与查询差异、迁移路径和基准测试条件。应从当前正在使用的系统进入对应页面，而不是只看一张脱离版本和 workload 的功能表。
+
+## 下一步
+
+- 通过[快速开始](/getting-started/quick-start.md)在本地验证写入和查询。
+- 对照[产品比较](https://greptime.cn/compare/)检查当前技术栈的差异。
+- 生产切换前，通过[迁移指南](/user-guide/migrate-to-greptimedb/overview.md)确认协议、查询、仪表盘和历史数据的改动范围。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/why-greptimedb.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/why-greptimedb.md
@@ -33,14 +33,14 @@ GreptimeDB 用同一个列式引擎处理三类信号，并采用共同的 [Tag�
 
 ## 一个列式引擎，不同的表
 
-减少系统数量，不等于把不同信号硬塞进同一种 schema。指标点、日志、span 和包含完整上下文的事件，其访问方式和留存要求并不相同。
+减少系统数量，不等于把不同信号硬塞进同一种 schema。指标点、日志、span 和宽事件，其访问方式和留存要求并不相同。
 
 GreptimeDB 允许每类 workload 使用适合自己的表：
 
 - metrics 通常用主键列保存 labels，并使用 PromQL 查询；
 - logs 常用 append-only 表，并根据查询方式选择全文索引或倒排索引；
 - traces 保留 trace 和 span 标识，可以使用 SQL 或 Jaeger 兼容接口查询；
-- 只有在事后分析确实需要完整上下文时，才需要使用更宽的事件表，并承担相应的存储成本。
+- 事后分析需要更多上下文时，可以采用宽事件，并承担相应的存储成本。
 
 这些表可以分别配置 schema、索引、TTL、compaction 选项和存储后端。具体机制参见[数据模型](./data-model.md)和[存储位置](./storage-location.md)。
 
@@ -82,16 +82,16 @@ GreptimeDB 用同一个引擎、同一套存储与查询基础处理这两类 wo
 
 [GreptimeDB Enterprise](/enterprise/overview.md) 另行提供读副本、通过 Datanode group 隔离 workload、自动 Region 均衡与重分区、RBAC、LDAP 集成、审计日志和企业灾备方案等能力。概念文档提到开源集群时，不默认包含这些功能。
 
-## 仍然需要配置什么
+## 可以按需调整的配置
 
-共用一套系统改变的是运维对象，不会让不同 workload 变得完全相同。生产部署仍要明确配置：
+共用一套系统改变的是运维对象，不会让不同 workload 变得完全相同。可以通过下面几类配置分别调整：
 
-- 按 workload 设置 schema、索引、TTL 和 compaction；
-- 根据近期查询与历史查询的比例，规划 cache、查询并发和计算容量；
-- 根据持久性和恢复目标配置 WAL、metadata、对象存储、备份和恢复；
-- 按需规划 Region 放置、failover 和资源隔离。
+- [表设计](/user-guide/deployments-administration/performance-tuning/design-table.md)：选择 schema、主键、索引、append-only 模式和分区方式；通过 [TTL](/user-guide/manage-data/overview.md#使用-ttl-策略保留数据)控制留存周期，并按 workload 调整 [compaction](/user-guide/deployments-administration/manage-data/compaction.md)。
+- [容量规划](/user-guide/deployments-administration/capacity-plan.md)：根据写入量以及近期查询与历史查询的比例，规划计算资源、内存和本地 cache；再结合[性能调优指南](/user-guide/deployments-administration/performance-tuning/performance-tuning-tips.md)中的运行指标调整 cache 和查询配置。
+- [持久性与恢复](/user-guide/deployments-administration/disaster-recovery/overview.md)：根据 RPO 和 RTO 选择 [WAL 模式](/user-guide/deployments-administration/wal/overview.md)、metadata 存储、对象存储策略以及备份恢复流程。
+- [Region 运维](/user-guide/deployments-administration/manage-data/overview.md)：为分布式部署规划分片、手动 Region 迁移和 failover。Enterprise 还可以使用 [Datanode group](/enterprise/deployments-administration/deploy-on-kubernetes/configure-datanode-groups.md)隔离 workload，并通过 [Region Balancer](/enterprise/autopilot/region-balancer.md)自动均衡 Region。
 
-确定 RPO、RTO 或可用性目标前，请先阅读[存储位置](./storage-location.md)和[灾备](/user-guide/deployments-administration/disaster-recovery/overview.md)。
+具体配置取决于 workload 和部署方式，不存在适用于所有信号的统一预设。
 
 <AnchorAlias id="高性能" />
 
@@ -99,7 +99,7 @@ GreptimeDB 用同一个引擎、同一套存储与查询基础处理这两类 wo
 
 下面的数据来自特定 workload 和配置下的公开案例：
 
-- [OceanBase Cloud](https://greptime.cn/blogs/2025-07-22-user-case-obcloud-log-storage-greptimedb) 运行着 80 多个 GreptimeDB 集群，保存 300 TB 日志与 SQL 审计数据，留存周期为 7 天，持续写入吞吐约 1 GB/s。从 Loki 迁移后，整体日志存储成本下降 60% 以上。
+- [OceanBase Cloud](https://greptime.cn/blogs/2025-07-22-user-case-obcloud-log-storage-greptimedb) 运行着 80+ GreptimeDB 集群，保存 300 TB 日志与 SQL 审计数据，留存周期为 7 天，持续写入吞吐约 1 GB/s。从 Loki 迁移后，整体日志存储成本下降 60%+。
 - [得物](https://greptime.cn/blogs/2025-05-06-poizon-greptimedb-observability)使用 Flow 从明细事件持续维护 10 秒、1 分钟和 10 分钟粒度的聚合结果。公开案例显示，预聚合将 P99 查询延迟从秒级降到毫秒级。
 
 实际结果取决于 schema、索引、留存周期、硬件、对象存储价格、cache 配置和查询 workload。规划容量时，应结合带测试条件的[性能报告](https://greptime.cn/blogs/2024-09-09-report-summary)。

--- a/static/shared-system-realtime-historical.svg
+++ b/static/shared-system-realtime-historical.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
+  <title id="title">One shared system for real-time monitoring and historical analysis</title>
+  <desc id="desc">Real-time monitoring and historical analysis share one engine, storage system, and query layer. Memory and node-local caches accelerate recent and frequently accessed data, while persistent object storage retains data for long-range queries. The workloads can be configured independently for resources, concurrency, and isolation.</desc>
+  <defs>
+    <marker id="arrow-slate" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L10,5 L0,10 z" fill="#94A3B8"/></marker>
+    <marker id="arrow-purple" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L10,5 L0,10 z" fill="#7C3AED"/></marker>
+    <marker id="arrow-teal" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L10,5 L0,10 z" fill="#0F766E"/></marker>
+    <style>
+      .kicker { font: 650 17px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: .08em; text-transform: uppercase; fill: #64748B; }
+      .title { font: 650 28px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #1F2937; }
+      .subtitle { font: 400 19px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #64748B; }
+      .small { font: 500 17px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
+      .purple { font: 600 17px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #6D28D9; }
+      .teal { font: 600 17px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0F766E; }
+      .blue { font: 600 17px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #1D4ED8; }
+    </style>
+  </defs>
+
+  <rect width="1600" height="900" fill="#FFFFFF"/>
+
+  <!-- Workload heading and cards -->
+  <text x="100" y="82" class="kicker">Different workload profiles</text>
+  <line x1="100" y1="105" x2="1500" y2="105" stroke="#E2E8F0" stroke-width="2"/>
+
+  <rect x="160" y="150" width="490" height="160" rx="16" fill="#F5F3FF" stroke="#A78BFA" stroke-width="2.5"/>
+  <circle cx="214" cy="202" r="24" fill="#EDE9FE" stroke="#C4B5FD" stroke-width="1.5"/>
+  <path d="M214 187 L214 202 L225 209" fill="none" stroke="#7C3AED" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="255" y="210" class="title">Real-time monitoring</text>
+  <text x="255" y="242" class="subtitle">recent data · latency-sensitive queries</text>
+  <rect x="255" y="264" width="132" height="29" rx="14" fill="#EDE9FE"/>
+  <text x="321" y="284" text-anchor="middle" class="purple">hot path</text>
+
+  <rect x="950" y="150" width="490" height="160" rx="16" fill="#ECFEFF" stroke="#5EEAD4" stroke-width="2.5"/>
+  <circle cx="1004" cy="202" r="24" fill="#CCFBF1" stroke="#99F6E4" stroke-width="1.5"/>
+  <path d="M992 207 C1000 193, 1008 214, 1018 199" fill="none" stroke="#0F766E" stroke-width="3" stroke-linecap="round"/>
+  <text x="1045" y="210" class="title">Historical analysis</text>
+  <text x="1045" y="242" class="subtitle">long-range scans · more data</text>
+  <rect x="1045" y="264" width="168" height="29" rx="14" fill="#CCFBF1"/>
+  <text x="1129" y="284" text-anchor="middle" class="teal">long-range path</text>
+
+  <!-- Independent settings, deliberately outside the data path -->
+  <rect x="520" y="350" width="560" height="68" rx="14" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="2" stroke-dasharray="7 5"/>
+  <text x="800" y="378" text-anchor="middle" class="small">Workload-specific configuration</text>
+  <text x="800" y="403" text-anchor="middle" class="small">resources · query concurrency · isolation</text>
+  <path d="M520 370 C430 350, 370 325, 330 310" fill="none" stroke="#94A3B8" stroke-width="2" stroke-dasharray="6 5"/>
+  <path d="M1080 370 C1170 350, 1230 325, 1270 310" fill="none" stroke="#94A3B8" stroke-width="2" stroke-dasharray="6 5"/>
+
+  <!-- Converging lines: common query foundation -->
+  <path d="M405 310 C485 405, 590 432, 690 465" fill="none" stroke="#A78BFA" stroke-width="3" marker-end="url(#arrow-purple)"/>
+  <path d="M1195 310 C1115 405, 1010 432, 910 465" fill="none" stroke="#2DD4BF" stroke-width="3" marker-end="url(#arrow-teal)"/>
+  <text x="800" y="448" text-anchor="middle" class="kicker">Shared foundation</text>
+
+  <rect x="540" y="470" width="520" height="125" rx="18" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="3"/>
+  <text x="800" y="520" text-anchor="middle" class="title">GreptimeDB</text>
+  <text x="800" y="552" text-anchor="middle" class="subtitle">one system for real-time and historical analysis</text>
+  <text x="800" y="578" text-anchor="middle" class="purple">same engine · storage system · query layer</text>
+
+  <!-- Storage hierarchy; a single shared path -->
+  <path d="M800 595 L800 650" fill="none" stroke="#94A3B8" stroke-width="3" marker-end="url(#arrow-slate)"/>
+  <rect x="560" y="655" width="480" height="95" rx="14" fill="#EFF6FF" stroke="#60A5FA" stroke-width="2.5"/>
+  <text x="800" y="694" text-anchor="middle" class="title">Memory and node-local caches</text>
+  <text x="800" y="722" text-anchor="middle" class="blue">accelerate recent and frequently accessed data</text>
+
+  <path d="M800 750 L800 793" fill="none" stroke="#94A3B8" stroke-width="3" marker-end="url(#arrow-slate)"/>
+  <rect x="560" y="798" width="480" height="76" rx="18" fill="#ECFDF5" stroke="#2DD4BF" stroke-width="3"/>
+  <text x="800" y="831" text-anchor="middle" class="title">Persistent object storage</text>
+  <text x="800" y="858" text-anchor="middle" class="teal">persistent data · supports long-range queries</text>
+</svg>

--- a/static/shared-system-realtime-historical.zh.svg
+++ b/static/shared-system-realtime-historical.zh.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
+  <title id="title">实时监控与历史分析共用一套系统</title>
+  <desc id="desc">实时监控与历史分析共用同一个引擎、存储系统和查询层。内存与节点本地缓存加速近期数据和高频访问数据，持久化对象存储保存数据并支持长时间范围查询。两类工作负载可分别配置资源、查询并发和隔离。</desc>
+  <defs>
+    <marker id="arrow-slate" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L10,5 L0,10 z" fill="#94A3B8"/></marker>
+    <marker id="arrow-purple" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L10,5 L0,10 z" fill="#7C3AED"/></marker>
+    <marker id="arrow-teal" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L10,5 L0,10 z" fill="#0F766E"/></marker>
+    <style>
+      .kicker { font: 650 17px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: .08em; text-transform: uppercase; fill: #64748B; }
+      .title { font: 650 28px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #1F2937; }
+      .subtitle { font: 400 19px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #64748B; }
+      .small { font: 500 17px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
+      .purple { font: 600 17px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #6D28D9; }
+      .teal { font: 600 17px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0F766E; }
+      .blue { font: 600 17px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #1D4ED8; }
+    </style>
+  </defs>
+
+  <rect width="1600" height="900" fill="#FFFFFF"/>
+
+  <!-- Workload heading and cards -->
+  <text x="100" y="82" class="kicker">不同的工作负载特征</text>
+  <line x1="100" y1="105" x2="1500" y2="105" stroke="#E2E8F0" stroke-width="2"/>
+
+  <rect x="160" y="150" width="490" height="160" rx="16" fill="#F5F3FF" stroke="#A78BFA" stroke-width="2.5"/>
+  <circle cx="214" cy="202" r="24" fill="#EDE9FE" stroke="#C4B5FD" stroke-width="1.5"/>
+  <path d="M214 187 L214 202 L225 209" fill="none" stroke="#7C3AED" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="255" y="210" class="title">实时监控</text>
+  <text x="255" y="242" class="subtitle">近期数据 · 低延迟查询</text>
+  <rect x="255" y="264" width="132" height="29" rx="14" fill="#EDE9FE"/>
+  <text x="321" y="284" text-anchor="middle" class="purple">热路径</text>
+
+  <rect x="950" y="150" width="490" height="160" rx="16" fill="#ECFEFF" stroke="#5EEAD4" stroke-width="2.5"/>
+  <circle cx="1004" cy="202" r="24" fill="#CCFBF1" stroke="#99F6E4" stroke-width="1.5"/>
+  <path d="M992 207 C1000 193, 1008 214, 1018 199" fill="none" stroke="#0F766E" stroke-width="3" stroke-linecap="round"/>
+  <text x="1045" y="210" class="title">历史分析</text>
+  <text x="1045" y="242" class="subtitle">长时间范围扫描 · 更多数据</text>
+  <rect x="1045" y="264" width="168" height="29" rx="14" fill="#CCFBF1"/>
+  <text x="1129" y="284" text-anchor="middle" class="teal">长范围查询路径</text>
+
+  <!-- Independent settings, deliberately outside the data path -->
+  <rect x="520" y="350" width="560" height="68" rx="14" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="2" stroke-dasharray="7 5"/>
+  <text x="800" y="378" text-anchor="middle" class="small">按工作负载分别配置</text>
+  <text x="800" y="403" text-anchor="middle" class="small">资源 · 查询并发 · 隔离</text>
+  <path d="M520 370 C430 350, 370 325, 330 310" fill="none" stroke="#94A3B8" stroke-width="2" stroke-dasharray="6 5"/>
+  <path d="M1080 370 C1170 350, 1230 325, 1270 310" fill="none" stroke="#94A3B8" stroke-width="2" stroke-dasharray="6 5"/>
+
+  <!-- Converging lines: common query foundation -->
+  <path d="M405 310 C485 405, 590 432, 690 465" fill="none" stroke="#A78BFA" stroke-width="3" marker-end="url(#arrow-purple)"/>
+  <path d="M1195 310 C1115 405, 1010 432, 910 465" fill="none" stroke="#2DD4BF" stroke-width="3" marker-end="url(#arrow-teal)"/>
+  <text x="800" y="448" text-anchor="middle" class="kicker">共享基础</text>
+
+  <rect x="540" y="470" width="520" height="125" rx="18" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="3"/>
+  <text x="800" y="520" text-anchor="middle" class="title">GreptimeDB</text>
+  <text x="800" y="552" text-anchor="middle" class="subtitle">同一套系统服务实时与历史分析</text>
+  <text x="800" y="578" text-anchor="middle" class="purple">同一引擎 · 存储系统 · 查询层</text>
+
+  <!-- Storage hierarchy; a single shared path -->
+  <path d="M800 595 L800 650" fill="none" stroke="#94A3B8" stroke-width="3" marker-end="url(#arrow-slate)"/>
+  <rect x="560" y="655" width="480" height="95" rx="14" fill="#EFF6FF" stroke="#60A5FA" stroke-width="2.5"/>
+  <text x="800" y="694" text-anchor="middle" class="title">内存与节点本地缓存</text>
+  <text x="800" y="722" text-anchor="middle" class="blue">加速近期数据与高频访问数据</text>
+
+  <path d="M800 750 L800 793" fill="none" stroke="#94A3B8" stroke-width="3" marker-end="url(#arrow-slate)"/>
+  <rect x="560" y="798" width="480" height="76" rx="18" fill="#ECFDF5" stroke="#2DD4BF" stroke-width="3"/>
+  <text x="800" y="831" text-anchor="middle" class="title">持久化对象存储</text>
+  <text x="800" y="858" text-anchor="middle" class="teal">持久数据 · 支持长时间范围查询</text>
+</svg>

--- a/static/time-series-data-model.zh.svg
+++ b/static/time-series-data-model.zh.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="520" viewBox="0 0 1400 520" role="img" aria-labelledby="title desc">
-  <title id="title">Column roles in the system_metrics table</title>
-  <desc id="desc">The system_metrics table uses host and idc as Tag columns, ts as the Timestamp column and time index, and cpu_util, memory_util, and disk_util as Field columns.</desc>
+  <title id="title">system_metrics 表中的列语义</title>
+  <desc id="desc">system_metrics 表使用 host 和 idc 作为 Tag 列，ts 作为 Timestamp 列和时间索引，cpu_util、memory_util 和 disk_util 作为 Field 列。</desc>
   <defs>
     <style>
       .kicker { font: 600 16px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: .08em; fill: #64748B; }
@@ -14,15 +14,15 @@
 
   <rect width="1400" height="520" fill="#FFFFFF"/>
 
-  <text x="70" y="72" class="kicker">RELATIONAL TABLE WITH A TIME INDEX</text>
-  <text x="70" y="112" class="title">Column roles in system_metrics</text>
-  <text x="70" y="144" class="subtitle">One table can contain multiple Tag and Field columns, with one Timestamp column as its time index.</text>
+  <text x="70" y="72" class="kicker">带时间索引的关系表</text>
+  <text x="70" y="112" class="title">system_metrics 表中的列语义</text>
+  <text x="70" y="144" class="subtitle">一张表可以包含多个 Tag 和 Field，并使用一个 Timestamp 列作为时间索引。</text>
 
   <rect x="70" y="190" width="1260" height="250" rx="18" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="2"/>
   <rect x="105" y="220" width="1190" height="54" rx="12" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
   <text x="135" y="254" class="label">system_metrics</text>
 
-  <text x="105" y="315" class="small">TAG COLUMNS · PRIMARY KEY</text>
+  <text x="105" y="315" class="small">TAG 列 · 主键</text>
   <rect x="105" y="335" width="145" height="66" rx="12" fill="#FFFBEB" stroke="#F59E0B" stroke-width="2"/>
   <text x="177.5" y="376" text-anchor="middle" class="column" fill="#B45309">host</text>
   <rect x="265" y="335" width="120" height="66" rx="12" fill="#FFFBEB" stroke="#F59E0B" stroke-width="2"/>
@@ -30,13 +30,13 @@
 
   <line x1="430" y1="306" x2="430" y2="410" stroke="#E2E8F0" stroke-width="2"/>
 
-  <text x="470" y="315" class="small">TIMESTAMP · TIME INDEX</text>
+  <text x="470" y="315" class="small">TIMESTAMP · 时间索引</text>
   <rect x="470" y="335" width="140" height="66" rx="12" fill="#ECFDF5" stroke="#14B8A6" stroke-width="2"/>
   <text x="540" y="376" text-anchor="middle" class="column" fill="#0F766E">ts</text>
 
   <line x1="655" y1="306" x2="655" y2="410" stroke="#E2E8F0" stroke-width="2"/>
 
-  <text x="695" y="315" class="small">FIELD COLUMNS</text>
+  <text x="695" y="315" class="small">FIELD 列</text>
   <rect x="695" y="335" width="170" height="66" rx="12" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="2"/>
   <text x="780" y="376" text-anchor="middle" class="column" fill="#6D28D9">cpu_util</text>
   <rect x="880" y="335" width="190" height="66" rx="12" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="2"/>
@@ -45,5 +45,5 @@
   <text x="1175" y="376" text-anchor="middle" class="column" fill="#6D28D9">disk_util</text>
 
   <line x1="70" y1="480" x2="1330" y2="480" stroke="#E2E8F0" stroke-width="2"/>
-  <text x="70" y="508" class="small">Tag, Timestamp, and Field describe column roles within a table.</text>
+  <text x="70" y="508" class="small">Tag、Timestamp 和 Field 描述同一张表内不同列的语义。</text>
 </svg>


### PR DESCRIPTION
## What changed

Refresh the Nightly concepts foundation around the questions teams ask when evaluating an observability backend.

- Rework `why-greptimedb.md` around operating problems and their corresponding mechanisms instead of presenting an architecture inventory.
- Explain one columnar engine with separate tables, schemas, indexes, TTLs, and compaction settings for different signal types.
- Show how real-time monitoring and historical analysis share one system while retaining separate workload controls.
- State ingestion and query boundaries without implying full compatibility with source systems.
- Separate open-source capabilities from GreptimeDB Enterprise features.
- Clarify the time index, Tag/Timestamp/Field roles, merge modes, table engines, storage providers, and recovery responsibilities.
- Redraw the time-series table model and add localized diagrams for the unified signal model and shared monitoring workloads.
- Preserve published routes and fragments. Add repository guidance that `AnchorAlias` protects published fragments, not intermediate headings from an unmerged PR.

## Stack

- Base: `main`
- Dependency: none; #2739 and #2742 are already merged into `main`
- Position: Stack PR 1
- Dependent PR: #2741

## Scope

- Documentation versions: Nightly only; released versions are unchanged
- Languages: English and Chinese
- Repository guidance and CI: narrow updates for `AnchorAlias` handling and the front-matter exception for `AGENTS.md`

## Verification

- `git diff --check origin/main...HEAD`
- `pnpm dlx markdownlint-cli <changed files> --config .markdownlint.yaml`
- `pnpm exec typos <changed files>`
- `DOC_LANG=en pnpm check:links`
- `DOC_LANG=zh pnpm check:links`
- `xmllint --noout` for the new SVG files
- Rendered and inspected the English and Chinese diagrams for clipping, overlap, and text alignment
- Reviewed the complete diff for versioned docs, generated files, and lockfile changes

Both strict link checks completed their production builds successfully.

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] Navigation is unchanged; existing routes remain in place.