### PR TITLE
docs: add Observability 2.0 model diagrams

### DIFF
--- a/docs/user-guide/concepts/observability-2.md
+++ b/docs/user-guide/concepts/observability-2.md
@@ -96,7 +96,7 @@ GreptimeDB uses a common [data model](/user-guide/concepts/data-model.md) and qu
 
 Pipeline and Flow handle different stages. Pipeline parses, transforms, and enriches logs during ingestion. Its output is structured, multi-column data; when those fields retain the context of an operation or business event, each row can serve as a wide event. Flow can then continuously aggregate the stored events into metrics tables for dashboards and alerts.
 
-![Pipeline optionally processes logs during ingestion, while Flow aggregates stored events into a derived metrics table.](/optional-pipeline-flow.svg)
+![Pipeline can process logs during ingestion, while Flow can aggregate stored events into a derived metrics table.](/optional-pipeline-flow.svg)
 
 For example, Flow can derive a status metric from an event table:
 

--- a/docs/user-guide/concepts/observability-2.md
+++ b/docs/user-guide/concepts/observability-2.md
@@ -19,6 +19,8 @@ Metrics, logs, and traces remain useful abstractions. The problem is not the sig
 
 A unified model reduces these boundaries by using consistent schemas and query tools. Wide events are one way to retain more context, not a replacement for every metric, log, or trace.
 
+![Metrics, logs, and traces remain in independent tables while sharing common data-model concepts, storage, and query layers.](/unified-observability-model.svg)
+
 ## Wide Events: A Unified Data Model
 
 A wide event is a structured record with many fields describing one operation or business event. It can include high-cardinality values such as user IDs, session IDs, trace IDs, and request attributes.
@@ -93,6 +95,8 @@ GreptimeDB uses a common [data model](/user-guide/concepts/data-model.md) and qu
 **A unified table model does not mean writing all data into one table.** Metrics, logs, traces, and raw events can use separate tables with different schemas, retention policies, and indexes. The unification is at the schema concepts, storage system, and query layer.
 
 Pipeline and Flow handle different stages. Pipeline parses, transforms, and enriches logs during ingestion. Its output is structured, multi-column data; when those fields retain the context of an operation or business event, each row can serve as a wide event. Flow can then continuously aggregate the stored events into metrics tables for dashboards and alerts.
+
+![Pipeline optionally processes logs during ingestion, while Flow aggregates stored events into a derived metrics table.](/optional-pipeline-flow.svg)
 
 For example, Flow can derive a status metric from an event table:
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/observability-2.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/observability-2.md
@@ -19,7 +19,7 @@ Metrics、logs、traces 仍然是有效的抽象。问题不在三类信号本�
 
 统一数据模型通过一致的 schema 和查询方式减少这些边界。宽事件是保留更多上下文的一种做法，不是所有 metrics、logs、traces 的替代品。
 
-![Metrics、logs 和 traces 仍然使用独立的表，同时共享数据模型概念、存储系统和查询层。](/unified-observability-model.svg)
+![Metrics、logs 和 traces 仍然使用独立的表，同时共享数据模型概念、存储系统和查询层。](/unified-observability-model.zh.svg)
 
 ## 宽事件：统一数据模型
 
@@ -98,7 +98,7 @@ GreptimeDB 在不同可观测场景中使用共同的[数据模型](/user-guide/
 
 Pipeline 和 Flow 处理不同阶段。Pipeline 在写入时解析、转换和补充日志，输出结构化的多列数据；如果这些字段保留了一次操作或业务事件的上下文，每一行就可以作为宽事件。Flow 再对已存储的事件做持续聚合，生成供仪表板和告警使用的 metrics 表。
 
-![Pipeline 可以在写入阶段处理日志，Flow 则把已存储的事件聚合到派生 metrics 表。](/optional-pipeline-flow.svg)
+![Pipeline 可以在写入阶段处理日志，Flow 可以把已存储的事件聚合到派生 metrics 表。](/optional-pipeline-flow.zh.svg)
 
 例如，Flow 可以从事件表派生状态指标：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/observability-2.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/observability-2.md
@@ -19,6 +19,8 @@ Metrics、logs、traces 仍然是有效的抽象。问题不在三类信号本�
 
 统一数据模型通过一致的 schema 和查询方式减少这些边界。宽事件是保留更多上下文的一种做法，不是所有 metrics、logs、traces 的替代品。
 
+![Metrics、logs 和 traces 仍然使用独立的表，同时共享数据模型概念、存储系统和查询层。](/unified-observability-model.svg)
+
 ## 宽事件：统一数据模型
 
 宽事件（wide event）是一条包含较多字段的结构化记录，用于描述一次操作或业务事件。它可以带有用户 ID、session ID、trace ID、请求属性等高基数字段。
@@ -95,6 +97,8 @@ GreptimeDB 在不同可观测场景中使用共同的[数据模型](/user-guide/
 **“统一表模型”不等于“所有数据写入同一张表”。** Metrics、logs、traces 和原始事件可以使用不同的表、schema、留存策略和索引。统一的是 schema 概念、存储系统和查询层。
 
 Pipeline 和 Flow 处理不同阶段。Pipeline 在写入时解析、转换和补充日志，输出结构化的多列数据；如果这些字段保留了一次操作或业务事件的上下文，每一行就可以作为宽事件。Flow 再对已存储的事件做持续聚合，生成供仪表板和告警使用的 metrics 表。
+
+![Pipeline 可以在写入阶段处理日志，Flow 则把已存储的事件聚合到派生 metrics 表。](/optional-pipeline-flow.svg)
 
 例如，Flow 可以从事件表派生状态指标：
 

--- a/static/optional-pipeline-flow.svg
+++ b/static/optional-pipeline-flow.svg
@@ -1,0 +1,107 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
+  <title id="title">Optional Pipeline and Flow data path</title>
+  <desc id="desc">Log input can write directly into a context-rich event table when it is already structured. When parsing, transformation, or enrichment is needed during ingestion, the input can optionally pass through Pipeline first. After storage, Flow continuously aggregates events into a derived metrics table for dashboards and alerts. The event table also supports SQL investigation and optional trace correlation when identifiers are present.</desc>
+  <defs>
+    <marker id="arrow-slate" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L10,5 L0,10 z" fill="#94A3B8"/></marker>
+    <marker id="arrow-amber" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L10,5 L0,10 z" fill="#D97706"/></marker>
+    <marker id="arrow-purple" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L10,5 L0,10 z" fill="#8B5CF6"/></marker>
+    <style>
+      .font { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .kicker { font: 600 17px Inter, ui-sans-serif, system-ui, sans-serif; letter-spacing: .08em; text-transform: uppercase; fill: #64748B; }
+      .title { font: 650 30px Inter, ui-sans-serif, system-ui, sans-serif; fill: #1F2937; }
+      .sub { font: 400 20px Inter, ui-sans-serif, system-ui, sans-serif; fill: #64748B; }
+      .small { font: 500 18px Inter, ui-sans-serif, system-ui, sans-serif; fill: #475569; }
+      .edge { font: 600 18px Inter, ui-sans-serif, system-ui, sans-serif; fill: #475569; }
+      .amberText { font: 600 18px Inter, ui-sans-serif, system-ui, sans-serif; fill: #B45309; }
+      .purpleText { font: 600 18px Inter, ui-sans-serif, system-ui, sans-serif; fill: #6D28D9; }
+      .tealText { font: 600 18px Inter, ui-sans-serif, system-ui, sans-serif; fill: #0F766E; }
+    </style>
+  </defs>
+
+  <!-- Section labels -->
+  <text x="80" y="105" class="kicker">Ingestion</text>
+  <line x1="80" y1="126" x2="930" y2="126" stroke="#E2E8F0" stroke-width="2"/>
+  <text x="1010" y="105" class="kicker">After storage</text>
+  <line x1="1010" y1="126" x2="1515" y2="126" stroke="#E2E8F0" stroke-width="2"/>
+
+  <!-- Raw log input -->
+  <rect x="80" y="285" width="265" height="108" rx="12" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+  <text x="212.5" y="330" text-anchor="middle" class="title">Log input</text>
+  <text x="212.5" y="362" text-anchor="middle" class="sub">structured or parse-ready</text>
+
+  <!-- Direct path -->
+  <path d="M345 325 C425 260, 515 250, 620 300" fill="none" stroke="#94A3B8" stroke-width="3" marker-end="url(#arrow-slate)"/>
+  <rect x="407" y="214" width="150" height="36" rx="18" fill="#FFFFFF"/>
+  <text x="482" y="239" text-anchor="middle" class="edge">write directly</text>
+
+  <!-- Optional Pipeline card -->
+  <rect x="190" y="535" width="355" height="160" rx="15" fill="#FFFEF8" stroke="#D97706" stroke-width="2.5" stroke-dasharray="9 7"/>
+  <rect x="215" y="554" width="125" height="30" rx="15" fill="#FEF3C7"/>
+  <text x="277.5" y="575" text-anchor="middle" class="amberText">OPTIONAL</text>
+  <text x="367.5" y="620" text-anchor="middle" class="title">Pipeline</text>
+  <text x="367.5" y="650" text-anchor="middle" class="sub">Parse · Transform · Enrich</text>
+  <text x="367.5" y="676" text-anchor="middle" class="small">during ingestion</text>
+
+  <!-- Optional pathway -->
+  <path d="M212 393 C212 465, 254 497, 285 535" fill="none" stroke="#D97706" stroke-width="3" stroke-dasharray="9 7" marker-end="url(#arrow-amber)"/>
+  <rect x="91" y="452" width="193" height="30" rx="15" fill="#FFFFFF"/>
+  <text x="187.5" y="473" text-anchor="middle" class="amberText">optional processing</text>
+  <path d="M545 615 C590 610, 612 522, 660 450" fill="none" stroke="#D97706" stroke-width="3" stroke-dasharray="9 7" marker-end="url(#arrow-amber)"/>
+
+  <!-- Context-rich event table -->
+  <rect x="620" y="280" width="345" height="180" rx="18" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="3"/>
+  <text x="792.5" y="330" text-anchor="middle" class="title">Context-rich event table</text>
+  <text x="792.5" y="362" text-anchor="middle" class="sub">structured multi-column rows</text>
+  <g fill="#EDE9FE" stroke="#C4B5FD" stroke-width="1.5">
+    <rect x="660" y="390" width="86" height="31" rx="15"/>
+    <rect x="756" y="390" width="74" height="31" rx="15"/>
+    <rect x="840" y="390" width="85" height="31" rx="15"/>
+  </g>
+  <text x="703" y="412" text-anchor="middle" class="purpleText">service</text>
+  <text x="793" y="412" text-anchor="middle" class="purpleText">status</text>
+  <text x="882.5" y="412" text-anchor="middle" class="purpleText">trace_id</text>
+
+  <!-- Flow path -->
+  <path d="M965 340 C993 340, 1003 340, 1030 340" fill="none" stroke="#2DD4BF" stroke-width="3" marker-end="url(#arrow-slate)"/>
+  <text x="997" y="315" text-anchor="middle" class="tealText">after storage</text>
+  <rect x="1035" y="275" width="230" height="130" rx="14" fill="#ECFDF5" stroke="#2DD4BF" stroke-width="3"/>
+  <text x="1150" y="325" text-anchor="middle" class="title">Flow</text>
+  <text x="1150" y="356" text-anchor="middle" class="sub">Continuous aggregation</text>
+  <text x="1150" y="382" text-anchor="middle" class="small">stored events → metrics</text>
+
+  <!-- Derived table -->
+  <path d="M1265 340 L1315 340" fill="none" stroke="#2DD4BF" stroke-width="3" marker-end="url(#arrow-slate)"/>
+  <rect x="1320" y="275" width="195" height="130" rx="18" fill="#ECFDF5" stroke="#14B8A6" stroke-width="3"/>
+  <text x="1417.5" y="325" text-anchor="middle" class="title">Derived</text>
+  <text x="1417.5" y="357" text-anchor="middle" class="title">metrics table</text>
+  <text x="1417.5" y="383" text-anchor="middle" class="sub">status · time window</text>
+
+  <!-- Consumer -->
+  <path d="M1418 405 L1418 485" fill="none" stroke="#2DD4BF" stroke-width="3" marker-end="url(#arrow-slate)"/>
+  <rect x="1305" y="500" width="225" height="110" rx="12" fill="#FFFFFF" stroke="#99F6E4" stroke-width="2"/>
+  <text x="1417.5" y="536" text-anchor="middle" class="title">Dashboards</text>
+  <text x="1417.5" y="567" text-anchor="middle" class="title">&amp; alerts</text>
+  <text x="1417.5" y="594" text-anchor="middle" class="sub">fixed operational views</text>
+
+  <!-- SQL investigation -->
+  <path d="M792 460 L792 568" fill="none" stroke="#94A3B8" stroke-width="2.5" marker-end="url(#arrow-slate)"/>
+  <rect x="620" y="585" width="345" height="105" rx="12" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="2"/>
+  <text x="792.5" y="628" text-anchor="middle" class="title">SQL investigation</text>
+  <text x="792.5" y="659" text-anchor="middle" class="sub">detailed / retrospective analysis</text>
+
+  <!-- Trace correlation -->
+  <path d="M965 425 C1005 475, 1065 530, 1120 575" fill="none" stroke="#94A3B8" stroke-width="2.5" stroke-dasharray="7 6" marker-end="url(#arrow-slate)"/>
+  <text x="1044" y="493" text-anchor="middle" class="edge">trace_id</text>
+  <rect x="1005" y="585" width="240" height="105" rx="12" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="2"/>
+  <text x="1125" y="621" text-anchor="middle" class="title">Trace / span</text>
+  <text x="1125" y="651" text-anchor="middle" class="title">correlation</text>
+  <text x="1125" y="676" text-anchor="middle" class="sub">when identifiers are present</text>
+
+  <!-- Key -->
+  <line x1="80" y1="795" x2="135" y2="795" stroke="#94A3B8" stroke-width="3"/>
+  <text x="148" y="801" class="small">direct path</text>
+  <line x1="330" y1="795" x2="385" y2="795" stroke="#D97706" stroke-width="3" stroke-dasharray="9 7"/>
+  <text x="398" y="801" class="small">optional Pipeline path</text>
+  <line x1="80" y1="835" x2="1515" y2="835" stroke="#E2E8F0" stroke-width="2"/>
+  <text x="80" y="872" class="small">Use Pipeline only when input needs to be parsed, transformed, or enriched during ingestion.</text>
+</svg>

--- a/static/optional-pipeline-flow.zh.svg
+++ b/static/optional-pipeline-flow.zh.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
-  <title id="title">Optional Pipeline and Flow data paths</title>
-  <desc id="desc">Log input can write directly into a structured event table or optionally pass through Pipeline for parsing, transformation, or enrichment. Rows can serve as wide events when their fields retain the context of an operation or business event. After storage, Flow can aggregate events into a derived metrics table for dashboards and alerts. The event table also supports SQL investigation and optional trace correlation when identifiers are present.</desc>
+  <title id="title">可选的 Pipeline 与 Flow 数据路径</title>
+  <desc id="desc">日志可以直接写入结构化事件表，也可以先经过 Pipeline 解析、转换或补充字段。字段保留了一次操作或业务事件的上下文时，每一行可以作为宽事件。数据存储后，可以使用 Flow 将事件聚合到派生 metrics 表，供仪表板和告警使用。事件表也支持 SQL 分析；存在关联标识时，还可以关联 trace 或 span。</desc>
   <defs>
     <marker id="arrow-slate" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L10,5 L0,10 z" fill="#94A3B8"/></marker>
     <marker id="arrow-amber" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L10,5 L0,10 z" fill="#D97706"/></marker>
     <marker id="arrow-purple" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L10,5 L0,10 z" fill="#8B5CF6"/></marker>
     <style>
       .font { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
-      .kicker { font: 600 17px Inter, ui-sans-serif, system-ui, sans-serif; letter-spacing: .08em; text-transform: uppercase; fill: #64748B; }
+      .kicker { font: 600 17px Inter, ui-sans-serif, system-ui, sans-serif; letter-spacing: .08em; fill: #64748B; }
       .title { font: 650 30px Inter, ui-sans-serif, system-ui, sans-serif; fill: #1F2937; }
       .sub { font: 400 20px Inter, ui-sans-serif, system-ui, sans-serif; fill: #64748B; }
       .small { font: 500 18px Inter, ui-sans-serif, system-ui, sans-serif; fill: #475569; }
@@ -20,40 +20,40 @@
 
   <rect width="1600" height="900" fill="#FFFFFF"/>
 
-  <!-- Section labels -->
-  <text x="80" y="105" class="kicker">Ingestion</text>
+  <!-- 阶段 -->
+  <text x="80" y="105" class="kicker">写入阶段</text>
   <line x1="80" y1="126" x2="930" y2="126" stroke="#E2E8F0" stroke-width="2"/>
-  <text x="1010" y="105" class="kicker">After storage</text>
+  <text x="1010" y="105" class="kicker">存储之后</text>
   <line x1="1010" y1="126" x2="1515" y2="126" stroke="#E2E8F0" stroke-width="2"/>
 
-  <!-- Raw log input -->
+  <!-- 日志输入 -->
   <rect x="80" y="285" width="265" height="108" rx="12" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
-  <text x="212.5" y="330" text-anchor="middle" class="title">Log input</text>
-  <text x="212.5" y="362" text-anchor="middle" class="sub">structured or unstructured</text>
+  <text x="212.5" y="330" text-anchor="middle" class="title">日志输入</text>
+  <text x="212.5" y="362" text-anchor="middle" class="sub">结构化或非结构化</text>
 
-  <!-- Direct path -->
+  <!-- 直接写入 -->
   <path d="M345 325 C425 260, 515 250, 620 300" fill="none" stroke="#94A3B8" stroke-width="3" marker-end="url(#arrow-slate)"/>
   <rect x="407" y="214" width="150" height="36" rx="18" fill="#FFFFFF"/>
-  <text x="482" y="239" text-anchor="middle" class="edge">write directly</text>
+  <text x="482" y="239" text-anchor="middle" class="edge">直接写入</text>
 
-  <!-- Optional Pipeline card -->
+  <!-- 可选 Pipeline -->
   <rect x="190" y="535" width="355" height="160" rx="15" fill="#FFFEF8" stroke="#D97706" stroke-width="2.5" stroke-dasharray="9 7"/>
   <rect x="215" y="554" width="125" height="30" rx="15" fill="#FEF3C7"/>
-  <text x="277.5" y="575" text-anchor="middle" class="amberText">OPTIONAL</text>
+  <text x="277.5" y="575" text-anchor="middle" class="amberText">可选</text>
   <text x="367.5" y="620" text-anchor="middle" class="title">Pipeline</text>
-  <text x="367.5" y="650" text-anchor="middle" class="sub">Parse · Transform · Enrich</text>
-  <text x="367.5" y="676" text-anchor="middle" class="small">during ingestion</text>
+  <text x="367.5" y="650" text-anchor="middle" class="sub">解析 · 转换 · 补充字段</text>
+  <text x="367.5" y="676" text-anchor="middle" class="small">在写入阶段处理</text>
 
-  <!-- Optional pathway -->
+  <!-- 可选处理路径 -->
   <path d="M212 393 C212 465, 254 497, 285 535" fill="none" stroke="#D97706" stroke-width="3" stroke-dasharray="9 7" marker-end="url(#arrow-amber)"/>
   <rect x="91" y="452" width="193" height="30" rx="15" fill="#FFFFFF"/>
-  <text x="187.5" y="473" text-anchor="middle" class="amberText">optional processing</text>
+  <text x="187.5" y="473" text-anchor="middle" class="amberText">按需处理</text>
   <path d="M545 615 C590 610, 612 522, 660 450" fill="none" stroke="#D97706" stroke-width="3" stroke-dasharray="9 7" marker-end="url(#arrow-amber)"/>
 
-  <!-- Structured event table -->
+  <!-- 结构化事件表 -->
   <rect x="620" y="280" width="345" height="180" rx="18" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="3"/>
-  <text x="792.5" y="330" text-anchor="middle" class="title">Structured event table</text>
-  <text x="792.5" y="362" text-anchor="middle" class="sub">wide when fields retain context</text>
+  <text x="792.5" y="330" text-anchor="middle" class="title">结构化事件表</text>
+  <text x="792.5" y="362" text-anchor="middle" class="sub">字段保留上下文时可作为宽事件</text>
   <g fill="#EDE9FE" stroke="#C4B5FD" stroke-width="1.5">
     <rect x="660" y="390" width="86" height="31" rx="15"/>
     <rect x="756" y="390" width="74" height="31" rx="15"/>
@@ -63,49 +63,49 @@
   <text x="793" y="412" text-anchor="middle" class="purpleText">status</text>
   <text x="882.5" y="412" text-anchor="middle" class="purpleText">trace_id</text>
 
-  <!-- Flow path -->
+  <!-- Flow 路径 -->
   <path d="M965 340 C993 340, 1003 340, 1030 340" fill="none" stroke="#2DD4BF" stroke-width="3" marker-end="url(#arrow-slate)"/>
-  <text x="997" y="315" text-anchor="middle" class="tealText">after storage</text>
+  <text x="997" y="315" text-anchor="middle" class="tealText">存储后</text>
   <rect x="1035" y="275" width="230" height="130" rx="14" fill="#ECFDF5" stroke="#2DD4BF" stroke-width="3"/>
   <rect x="1055" y="288" width="92" height="27" rx="13.5" fill="#CCFBF1"/>
-  <text x="1101" y="308" text-anchor="middle" class="tealText">OPTIONAL</text>
+  <text x="1101" y="308" text-anchor="middle" class="tealText">可选</text>
   <text x="1150" y="340" text-anchor="middle" class="title">Flow</text>
-  <text x="1150" y="368" text-anchor="middle" class="sub">Continuous aggregation</text>
-  <text x="1150" y="393" text-anchor="middle" class="small">stored events → metrics</text>
+  <text x="1150" y="368" text-anchor="middle" class="sub">持续聚合</text>
+  <text x="1150" y="393" text-anchor="middle" class="small">存储事件 → metrics</text>
 
-  <!-- Derived table -->
+  <!-- 派生表 -->
   <path d="M1265 340 L1315 340" fill="none" stroke="#2DD4BF" stroke-width="3" marker-end="url(#arrow-slate)"/>
   <rect x="1320" y="275" width="195" height="130" rx="18" fill="#ECFDF5" stroke="#14B8A6" stroke-width="3"/>
-  <text x="1417.5" y="325" text-anchor="middle" class="title">Derived</text>
-  <text x="1417.5" y="357" text-anchor="middle" class="title">metrics table</text>
-  <text x="1417.5" y="383" text-anchor="middle" class="sub">status · time window</text>
+  <text x="1417.5" y="325" text-anchor="middle" class="title">派生</text>
+  <text x="1417.5" y="357" text-anchor="middle" class="title">metrics 表</text>
+  <text x="1417.5" y="383" text-anchor="middle" class="sub">状态 · 时间窗口</text>
 
-  <!-- Consumer -->
+  <!-- 使用方 -->
   <path d="M1418 405 L1418 485" fill="none" stroke="#2DD4BF" stroke-width="3" marker-end="url(#arrow-slate)"/>
   <rect x="1305" y="500" width="225" height="110" rx="12" fill="#FFFFFF" stroke="#99F6E4" stroke-width="2"/>
-  <text x="1417.5" y="536" text-anchor="middle" class="title">Dashboards</text>
-  <text x="1417.5" y="567" text-anchor="middle" class="title">&amp; alerts</text>
-  <text x="1417.5" y="594" text-anchor="middle" class="sub">fixed operational views</text>
+  <text x="1417.5" y="536" text-anchor="middle" class="title">仪表板</text>
+  <text x="1417.5" y="567" text-anchor="middle" class="title">与告警</text>
+  <text x="1417.5" y="594" text-anchor="middle" class="sub">固定的运维视图</text>
 
-  <!-- SQL investigation -->
+  <!-- SQL 分析 -->
   <path d="M792 460 L792 568" fill="none" stroke="#94A3B8" stroke-width="2.5" marker-end="url(#arrow-slate)"/>
   <rect x="620" y="585" width="345" height="105" rx="12" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="2"/>
-  <text x="792.5" y="628" text-anchor="middle" class="title">SQL investigation</text>
-  <text x="792.5" y="659" text-anchor="middle" class="sub">detailed / retrospective analysis</text>
+  <text x="792.5" y="628" text-anchor="middle" class="title">SQL 分析</text>
+  <text x="792.5" y="659" text-anchor="middle" class="sub">详细分析 / 事后分析</text>
 
-  <!-- Trace correlation -->
+  <!-- Trace 关联 -->
   <path d="M965 425 C1005 475, 1065 530, 1120 575" fill="none" stroke="#94A3B8" stroke-width="2.5" stroke-dasharray="7 6" marker-end="url(#arrow-slate)"/>
   <text x="1044" y="493" text-anchor="middle" class="edge">trace_id</text>
   <rect x="1005" y="585" width="240" height="105" rx="12" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="2"/>
-  <text x="1125" y="621" text-anchor="middle" class="title">Trace / span</text>
-  <text x="1125" y="651" text-anchor="middle" class="title">correlation</text>
-  <text x="1125" y="676" text-anchor="middle" class="sub">when identifiers are present</text>
+  <text x="1125" y="621" text-anchor="middle" class="title">关联 Trace</text>
+  <text x="1125" y="651" text-anchor="middle" class="title">或 Span</text>
+  <text x="1125" y="676" text-anchor="middle" class="sub">存在关联标识时</text>
 
-  <!-- Key -->
+  <!-- 图例 -->
   <line x1="80" y1="795" x2="135" y2="795" stroke="#94A3B8" stroke-width="3"/>
-  <text x="148" y="801" class="small">direct path</text>
+  <text x="148" y="801" class="small">直接写入</text>
   <line x1="330" y1="795" x2="385" y2="795" stroke="#D97706" stroke-width="3" stroke-dasharray="9 7"/>
-  <text x="398" y="801" class="small">optional Pipeline path</text>
+  <text x="398" y="801" class="small">可选的 Pipeline 路径</text>
   <line x1="80" y1="835" x2="1515" y2="835" stroke="#E2E8F0" stroke-width="2"/>
-  <text x="80" y="872" class="small">Use Pipeline when input needs processing; use Flow when a derived metrics table is useful.</text>
+  <text x="80" y="872" class="small">需要处理输入时使用 Pipeline；需要派生 metrics 表时使用 Flow。</text>
 </svg>

--- a/static/unified-observability-model.svg
+++ b/static/unified-observability-model.svg
@@ -1,0 +1,93 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
+  <title id="title">From isolated signals to a unified observability model</title>
+  <desc id="desc">Metrics, logs, and traces can each remain in independent tables. In a unified observability model, they share common data model concepts, one storage system, and a query layer offering SQL, PromQL, and Trace API access.</desc>
+  <defs>
+    <marker id="arrow-slate" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L10,5 L0,10 z" fill="#94A3B8"/></marker>
+    <marker id="arrow-purple" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L10,5 L0,10 z" fill="#5B4BB7"/></marker>
+    <style>
+      .kicker { font: 600 17px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: .08em; text-transform: uppercase; fill: #64748B; }
+      .title { font: 650 27px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #1F2937; }
+      .subtitle { font: 400 17px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #64748B; }
+      .small { font: 500 16px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
+      .pill { font: 600 16px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #6D28D9; }
+      .teal { font: 600 16px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0F766E; }
+    </style>
+  </defs>
+
+  <!-- Left: isolated operational boundaries -->
+  <rect x="70" y="85" width="490" height="720" rx="18" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="2"/>
+  <text x="110" y="135" class="kicker">Separate operational boundaries</text>
+  <text x="110" y="170" class="subtitle">Signals are stored and queried apart.</text>
+
+  <rect x="115" y="230" width="400" height="110" rx="13" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+  <text x="150" y="275" class="title">Metrics</text>
+  <text x="150" y="308" class="subtitle">separate storage · query</text>
+  <circle cx="464" cy="285" r="18" fill="#F1F5F9" stroke="#CBD5E1" stroke-width="1.5"/>
+  <path d="M456 285 L463 292 L475 277" fill="none" stroke="#64748B" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <line x1="315" y1="340" x2="315" y2="390" stroke="#CBD5E1" stroke-width="2" stroke-dasharray="7 7"/>
+  <circle cx="315" cy="365" r="4" fill="#CBD5E1"/>
+
+  <rect x="115" y="390" width="400" height="110" rx="13" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+  <text x="150" y="435" class="title">Logs</text>
+  <text x="150" y="468" class="subtitle">separate storage · query</text>
+  <circle cx="464" cy="445" r="18" fill="#F1F5F9" stroke="#CBD5E1" stroke-width="1.5"/>
+  <path d="M456 445 L463 452 L475 437" fill="none" stroke="#64748B" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <line x1="315" y1="500" x2="315" y2="550" stroke="#CBD5E1" stroke-width="2" stroke-dasharray="7 7"/>
+  <circle cx="315" cy="525" r="4" fill="#CBD5E1"/>
+
+  <rect x="115" y="550" width="400" height="110" rx="13" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+  <text x="150" y="595" class="title">Traces</text>
+  <text x="150" y="628" class="subtitle">separate storage · query</text>
+  <circle cx="464" cy="605" r="18" fill="#F1F5F9" stroke="#CBD5E1" stroke-width="1.5"/>
+  <path d="M456 605 L463 612 L475 597" fill="none" stroke="#64748B" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Transition -->
+  <path d="M560 445 L678 445" fill="none" stroke="#94A3B8" stroke-width="3" marker-end="url(#arrow-slate)"/>
+  <polygon points="705,405 764,425 780,485 705,505 646,485 630,425" fill="#5B4BB7"/>
+  <text x="705" y="463" text-anchor="middle" style="font:650 24px Inter,ui-sans-serif,system-ui,sans-serif;fill:#FFFFFF">Unify</text>
+  <path d="M780 445 L850 445" fill="none" stroke="#94A3B8" stroke-width="3" marker-end="url(#arrow-slate)"/>
+
+  <!-- Right: unified storage and query -->
+  <rect x="850" y="85" width="680" height="720" rx="18" fill="#FAFAFF" stroke="#DDD6FE" stroke-width="2"/>
+  <text x="890" y="135" class="kicker">Unified storage and query</text>
+  <text x="890" y="170" class="subtitle">Signals keep independent tables, then share common concepts.</text>
+
+  <text x="890" y="245" class="small">INDEPENDENT TABLES</text>
+  <rect x="890" y="270" width="175" height="110" rx="13" fill="#FFFFFF" stroke="#C4B5FD" stroke-width="2"/>
+  <text x="977.5" y="317" text-anchor="middle" class="title">Metrics</text>
+  <text x="977.5" y="348" text-anchor="middle" class="subtitle">table</text>
+
+  <rect x="1105" y="270" width="175" height="110" rx="13" fill="#FFFFFF" stroke="#C4B5FD" stroke-width="2"/>
+  <text x="1192.5" y="317" text-anchor="middle" class="title">Logs</text>
+  <text x="1192.5" y="348" text-anchor="middle" class="subtitle">table</text>
+
+  <rect x="1320" y="270" width="175" height="110" rx="13" fill="#FFFFFF" stroke="#C4B5FD" stroke-width="2"/>
+  <text x="1407.5" y="317" text-anchor="middle" class="title">Traces</text>
+  <text x="1407.5" y="348" text-anchor="middle" class="subtitle">table</text>
+
+  <path d="M977 380 C977 425, 1038 447, 1105 480" fill="none" stroke="#94A3B8" stroke-width="2.5" marker-end="url(#arrow-slate)"/>
+  <path d="M1192 380 L1192 480" fill="none" stroke="#94A3B8" stroke-width="2.5" marker-end="url(#arrow-slate)"/>
+  <path d="M1408 380 C1408 425, 1347 447, 1280 480" fill="none" stroke="#94A3B8" stroke-width="2.5" marker-end="url(#arrow-slate)"/>
+
+  <rect x="1015" y="485" width="355" height="135" rx="15" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="3"/>
+  <text x="1192.5" y="535" text-anchor="middle" class="title">Common data model</text>
+  <g fill="#EDE9FE" stroke="#C4B5FD" stroke-width="1.5">
+    <rect x="1060" y="560" width="75" height="31" rx="15"/>
+    <rect x="1148" y="560" width="100" height="31" rx="15"/>
+    <rect x="1260" y="560" width="70" height="31" rx="15"/>
+  </g>
+  <text x="1097.5" y="582" text-anchor="middle" class="pill">Tag</text>
+  <text x="1198" y="582" text-anchor="middle" class="pill">Timestamp</text>
+  <text x="1295" y="582" text-anchor="middle" class="pill">Field</text>
+
+  <path d="M1192 620 L1192 675" fill="none" stroke="#2DD4BF" stroke-width="3" marker-end="url(#arrow-slate)"/>
+  <rect x="980" y="680" width="425" height="85" rx="14" fill="#ECFDF5" stroke="#2DD4BF" stroke-width="3"/>
+  <text x="1192.5" y="716" text-anchor="middle" class="title">Shared query layer</text>
+  <text x="1192.5" y="746" text-anchor="middle" class="teal">SQL · PromQL · Trace API</text>
+
+  <!-- Footer rule and takeaway -->
+  <line x1="70" y1="842" x2="1530" y2="842" stroke="#E2E8F0" stroke-width="2"/>
+  <text x="70" y="878" class="small">Unification happens at the data-model, storage, and query layers; it does not require all signals in one table.</text>
+</svg>

--- a/static/unified-observability-model.zh.svg
+++ b/static/unified-observability-model.zh.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
-  <title id="title">From isolated signals to a unified observability model</title>
-  <desc id="desc">Metrics, logs, and traces can each remain in independent tables. In a unified observability model, they share common data model concepts, one storage system, and a query layer offering SQL, PromQL, and Trace API access.</desc>
+  <title id="title">从信号隔离走向统一的可观测数据模型</title>
+  <desc id="desc">Metrics、logs 和 traces 可以继续存放在独立表中。在统一的可观测数据模型下，它们共用数据模型概念、存储系统和查询层，并通过 SQL、PromQL 和 Trace API 查询。</desc>
   <defs>
     <marker id="arrow-slate" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L10,5 L0,10 z" fill="#94A3B8"/></marker>
     <marker id="arrow-purple" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L10,5 L0,10 z" fill="#5B4BB7"/></marker>
     <style>
-      .kicker { font: 600 17px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: .08em; text-transform: uppercase; fill: #64748B; }
+      .kicker { font: 600 17px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: .08em; fill: #64748B; }
       .title { font: 650 27px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #1F2937; }
       .subtitle { font: 400 17px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #64748B; }
       .small { font: 500 16px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
@@ -16,14 +16,14 @@
 
   <rect width="1600" height="900" fill="#FFFFFF"/>
 
-  <!-- Left: isolated operational boundaries -->
+  <!-- 左侧：信号各自独立 -->
   <rect x="70" y="85" width="490" height="720" rx="18" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="2"/>
-  <text x="110" y="135" class="kicker">Separate operational boundaries</text>
-  <text x="110" y="170" class="subtitle">Signals are stored and queried apart.</text>
+  <text x="110" y="135" class="kicker">各自独立的运维边界</text>
+  <text x="110" y="170" class="subtitle">各类信号分别存储和查询。</text>
 
   <rect x="115" y="230" width="400" height="110" rx="13" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
   <text x="150" y="275" class="title">Metrics</text>
-  <text x="150" y="308" class="subtitle">separate storage · query</text>
+  <text x="150" y="308" class="subtitle">独立存储 · 独立查询</text>
   <circle cx="464" cy="285" r="18" fill="#F1F5F9" stroke="#CBD5E1" stroke-width="1.5"/>
   <path d="M456 285 L463 292 L475 277" fill="none" stroke="#64748B" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
 
@@ -32,7 +32,7 @@
 
   <rect x="115" y="390" width="400" height="110" rx="13" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
   <text x="150" y="435" class="title">Logs</text>
-  <text x="150" y="468" class="subtitle">separate storage · query</text>
+  <text x="150" y="468" class="subtitle">独立存储 · 独立查询</text>
   <circle cx="464" cy="445" r="18" fill="#F1F5F9" stroke="#CBD5E1" stroke-width="1.5"/>
   <path d="M456 445 L463 452 L475 437" fill="none" stroke="#64748B" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
 
@@ -41,40 +41,40 @@
 
   <rect x="115" y="550" width="400" height="110" rx="13" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
   <text x="150" y="595" class="title">Traces</text>
-  <text x="150" y="628" class="subtitle">separate storage · query</text>
+  <text x="150" y="628" class="subtitle">独立存储 · 独立查询</text>
   <circle cx="464" cy="605" r="18" fill="#F1F5F9" stroke="#CBD5E1" stroke-width="1.5"/>
   <path d="M456 605 L463 612 L475 597" fill="none" stroke="#64748B" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
 
-  <!-- Transition -->
+  <!-- 过渡 -->
   <path d="M560 445 L678 445" fill="none" stroke="#94A3B8" stroke-width="3" marker-end="url(#arrow-slate)"/>
   <polygon points="705,405 764,425 780,485 705,505 646,485 630,425" fill="#5B4BB7"/>
-  <text x="705" y="463" text-anchor="middle" style="font:650 24px Inter,ui-sans-serif,system-ui,sans-serif;fill:#FFFFFF">Unify</text>
+  <text x="705" y="463" text-anchor="middle" style="font:650 24px Inter,ui-sans-serif,system-ui,sans-serif;fill:#FFFFFF">统一</text>
   <path d="M780 445 L850 445" fill="none" stroke="#94A3B8" stroke-width="3" marker-end="url(#arrow-slate)"/>
 
-  <!-- Right: unified storage and query -->
+  <!-- 右侧：统一存储与查询 -->
   <rect x="850" y="85" width="680" height="720" rx="18" fill="#FAFAFF" stroke="#DDD6FE" stroke-width="2"/>
-  <text x="890" y="135" class="kicker">Unified storage and query</text>
-  <text x="890" y="170" class="subtitle">Signals keep independent tables in one storage system.</text>
+  <text x="890" y="135" class="kicker">统一存储与查询</text>
+  <text x="890" y="170" class="subtitle">各类信号保留独立表，共用一套存储系统。</text>
 
-  <text x="890" y="245" class="small">INDEPENDENT TABLES · SHARED STORAGE SYSTEM</text>
+  <text x="890" y="245" class="small">独立表 · 共用一套存储系统</text>
   <rect x="890" y="270" width="175" height="110" rx="13" fill="#FFFFFF" stroke="#C4B5FD" stroke-width="2"/>
   <text x="977.5" y="317" text-anchor="middle" class="title">Metrics</text>
-  <text x="977.5" y="348" text-anchor="middle" class="subtitle">table</text>
+  <text x="977.5" y="348" text-anchor="middle" class="subtitle">表</text>
 
   <rect x="1105" y="270" width="175" height="110" rx="13" fill="#FFFFFF" stroke="#C4B5FD" stroke-width="2"/>
   <text x="1192.5" y="317" text-anchor="middle" class="title">Logs</text>
-  <text x="1192.5" y="348" text-anchor="middle" class="subtitle">table</text>
+  <text x="1192.5" y="348" text-anchor="middle" class="subtitle">表</text>
 
   <rect x="1320" y="270" width="175" height="110" rx="13" fill="#FFFFFF" stroke="#C4B5FD" stroke-width="2"/>
   <text x="1407.5" y="317" text-anchor="middle" class="title">Traces</text>
-  <text x="1407.5" y="348" text-anchor="middle" class="subtitle">table</text>
+  <text x="1407.5" y="348" text-anchor="middle" class="subtitle">表</text>
 
   <path d="M977 380 C977 425, 1038 447, 1105 480" fill="none" stroke="#94A3B8" stroke-width="2.5" marker-end="url(#arrow-slate)"/>
   <path d="M1192 380 L1192 480" fill="none" stroke="#94A3B8" stroke-width="2.5" marker-end="url(#arrow-slate)"/>
   <path d="M1408 380 C1408 425, 1347 447, 1280 480" fill="none" stroke="#94A3B8" stroke-width="2.5" marker-end="url(#arrow-slate)"/>
 
   <rect x="1015" y="485" width="355" height="135" rx="15" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="3"/>
-  <text x="1192.5" y="535" text-anchor="middle" class="title">Shared schema concepts</text>
+  <text x="1192.5" y="535" text-anchor="middle" class="title">共用的 schema 概念</text>
   <g fill="#EDE9FE" stroke="#C4B5FD" stroke-width="1.5">
     <rect x="1060" y="560" width="75" height="31" rx="15"/>
     <rect x="1148" y="560" width="100" height="31" rx="15"/>
@@ -86,10 +86,10 @@
 
   <path d="M1192 620 L1192 675" fill="none" stroke="#2DD4BF" stroke-width="3" marker-end="url(#arrow-slate)"/>
   <rect x="980" y="680" width="425" height="85" rx="14" fill="#ECFDF5" stroke="#2DD4BF" stroke-width="3"/>
-  <text x="1192.5" y="716" text-anchor="middle" class="title">Shared query layer</text>
+  <text x="1192.5" y="716" text-anchor="middle" class="title">统一查询层</text>
   <text x="1192.5" y="746" text-anchor="middle" class="teal">SQL · PromQL · Trace API</text>
 
-  <!-- Footer rule and takeaway -->
+  <!-- 总结 -->
   <line x1="70" y1="842" x2="1530" y2="842" stroke="#E2E8F0" stroke-width="2"/>
-  <text x="70" y="878" class="small">Unification happens at the data-model, storage, and query layers; it does not require all signals in one table.</text>
+  <text x="70" y="878" class="small">统一发生在数据模型、存储和查询层，不要求所有信号写入同一张表。</text>
 </svg>


### PR DESCRIPTION
## What changed

Added two diagrams to the Nightly Observability 2.0 concept page:

- a unified observability model that keeps metrics, logs, and traces in independent tables while sharing schema concepts, storage, and query access;
- an optional Pipeline and Flow path from log input to structured events and derived metrics.

The Chinese page uses localized versions of both diagrams. Pipeline and Flow are shown as optional, and structured rows are described as wide events only when they retain operation or business context.

## Scope

- Documentation versions: Nightly
- Languages: English, Chinese

## Verification

- `pnpm dlx markdownlint-cli@0.41.0 docs/user-guide/concepts/observability-2.md i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/observability-2.md --config .markdownlint.yaml`
- `typos --config .typos.toml docs/user-guide/concepts/observability-2.md i18n/zh/docusaurus-plugin-content-docs/current/user-guide/concepts/observability-2.md static/unified-observability-model.svg static/unified-observability-model.zh.svg static/optional-pipeline-flow.svg static/optional-pipeline-flow.zh.svg`
- `DOC_LANG=en pnpm check:links`
- `DOC_LANG=zh pnpm check:links`
- `pnpm build`
- `DOC_LANG=zh pnpm build`
- `xmllint --noout` for all four SVG files
- Rendered all four SVG files at 1600 × 900 and checked text, spacing, and clipping
- `git diff --check`

The normal builds still report existing warnings from released documentation and existing SVG assets. Strict link checks pass.

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] I updated navigation when the document structure changed. No navigation change was needed.
