### PR TITLE
docs: document query guard delete and drop column bans

### DIFF
--- a/docs/enterprise/deployments-administration/query-guard.md
+++ b/docs/enterprise/deployments-administration/query-guard.md
@@ -1,6 +1,6 @@
 ---
-keywords: [query guard, ban drop table, ban drop database, ban truncate table, data protection, security, configuration]
-description: Guide to configuring the Query Guard plugin in GreptimeDB Enterprise to ban DROP TABLE, DROP DATABASE, and TRUNCATE TABLE operations for all users and disallow cross-catalog queries.
+keywords: [query guard, ban drop table, ban drop database, ban truncate table, ban delete, ban drop column, data protection, security, configuration]
+description: Guide to configuring the Query Guard plugin in GreptimeDB Enterprise to ban destructive operations such as DROP TABLE, DROP DATABASE, TRUNCATE TABLE, DELETE, and ALTER TABLE DROP COLUMN for all users and disallow cross-catalog queries.
 ---
 
 # Query Guard
@@ -12,6 +12,11 @@ It provides the following protections:
 - **Ban `DROP TABLE`**: reject all `DROP TABLE` statements.
 - **Ban `DROP DATABASE`**: reject all `DROP DATABASE` statements.
 - **Ban `TRUNCATE TABLE`**: reject all `TRUNCATE TABLE` statements.
+- **Ban `DELETE`**: reject all `DELETE` statements and native gRPC delete
+  requests.
+- **Ban `ALTER TABLE DROP COLUMN`**: reject `ALTER TABLE ... DROP COLUMN`
+  statements and native gRPC `DropColumns` requests, while allowing other
+  `ALTER TABLE` operations such as `ADD COLUMN`.
 - **Reject `COPY` statements**: reject all `COPY` statements.
 - **Disallow cross-catalog access**: reject queries that reference tables across
   different catalogs, cross-catalog gRPC DDL requests, and Flight bulk inserts
@@ -27,12 +32,16 @@ frontend until the configuration is changed and the frontend is restarted.
 The bans cover both the SQL protocols (MySQL, PostgreSQL, and HTTP) and the gRPC
 protocol:
 
-- SQL path: configured `DROP TABLE`, `DROP DATABASE`, and `TRUNCATE TABLE`
-  statements are rejected with a `NotSupported` error.
-- gRPC path: configured structured `DROP TABLE` and `TRUNCATE TABLE` DDL requests
-  are rejected. The structured gRPC DDL request has no drop-database variant;
-  however, SQL statements sent over gRPC go through the same SQL interceptors, so
-  the `DROP DATABASE` ban applies to SQL over gRPC as well.
+- SQL path: configured `DROP TABLE`, `DROP DATABASE`, `TRUNCATE TABLE`,
+  `DELETE`, and `ALTER TABLE ... DROP COLUMN` statements are rejected with a
+  `NotSupported` error. The `DELETE` ban also rejects `DELETE` statements
+  wrapped in `EXPLAIN ANALYZE` and prepared `DELETE` statements.
+- gRPC path: configured structured `DROP TABLE` and `TRUNCATE TABLE` DDL
+  requests, batched `DropColumns` alter-table requests, and both native delete
+  request encodings (`Deletes` and `RowDeletes`) are rejected. The structured
+  gRPC DDL request has no drop-database variant; however, SQL statements sent
+  over gRPC go through the same SQL interceptors, so the `DROP DATABASE` and
+  `DELETE` bans apply to SQL over gRPC as well.
 
 Internal operations such as TTL-based data expiration and automatic cleanup bypass
 the frontend protocol-layer interceptors and are **not** affected by these bans.
@@ -49,12 +58,12 @@ the following TOML to your GreptimeDB config file:
 # Whether to enable the query guard plugin, defaults to false.
 enable = true
 # Operations to ban for all users. The list is empty by default.
-banned_ops = ["drop_table", "drop_database", "truncate_table"]
+banned_ops = ["drop_table", "drop_database", "truncate_table", "delete", "drop_column"]
 ```
 
-The supported operation names are `drop_table`, `drop_database`, and
-`truncate_table`. To ban only a subset of these operations, include only their
-names in `banned_ops`.
+The supported operation names are `drop_table`, `drop_database`,
+`truncate_table`, `delete`, and `drop_column`. To ban only a subset of these
+operations, include only their names in `banned_ops`.
 
 The former `ban_drop_table`, `ban_drop_database`, and `ban_truncate_table` options
 are no longer supported. Using any of them causes configuration parsing to fail.

--- a/docs/enterprise/overview.md
+++ b/docs/enterprise/overview.md
@@ -28,8 +28,9 @@ which are described in detail in the documentation in this section:
 - [LDAP Authentication](./deployments-administration/authentication.md): Secure your system with LDAP-based authentication for access management.
 - [Audit Logging](./deployments-administration/monitoring/audit-logging.md): Track and monitor
   user activity with detailed audit logs.
-- [Query Guard](./deployments-administration/query-guard.md): Ban `DROP TABLE` / `DROP DATABASE`
-  statements for all users and reject cross-catalog access.
+- [Query Guard](./deployments-administration/query-guard.md): Ban destructive
+  operations such as `DROP TABLE`, `DELETE`, and `ALTER TABLE DROP COLUMN` for
+  all users and reject cross-catalog access.
 - [Soft-Drop Tables](./soft-drop.md): Protect tables from accidental `DROP TABLE`
   operations and restore them from the recycle bin within the retention period.
 - [Automatic region load balance](./autopilot/region-balancer.md): Auto balance

--- a/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/deployments-administration/query-guard.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/deployments-administration/query-guard.md
@@ -1,6 +1,6 @@
 ---
-keywords: [query guard, 禁止 drop table, 禁止 drop database, 禁止 truncate table, 数据保护, 安全, 配置]
-description: 介绍如何在 GreptimeDB 企业版中配置 Query Guard 插件，为所有用户禁止 DROP TABLE、DROP DATABASE 和 TRUNCATE TABLE 操作，并禁止跨 catalog 查询。
+keywords: [query guard, 禁止 drop table, 禁止 drop database, 禁止 truncate table, 禁止 delete, 禁止 drop column, 数据保护, 安全, 配置]
+description: 介绍如何在 GreptimeDB 企业版中配置 Query Guard 插件，为所有用户禁止 DROP TABLE、DROP DATABASE、TRUNCATE TABLE、DELETE 和 ALTER TABLE DROP COLUMN 等破坏性操作，并禁止跨 catalog 查询。
 ---
 
 # Query Guard
@@ -11,6 +11,10 @@ Query Guard 是 GreptimeDB 企业版提供的一个插件，它在 Frontend 协�
 - **禁止 `DROP TABLE`**：拒绝所有 `DROP TABLE` 语句。
 - **禁止 `DROP DATABASE`**：拒绝所有 `DROP DATABASE` 语句。
 - **禁止 `TRUNCATE TABLE`**：拒绝所有 `TRUNCATE TABLE` 语句。
+- **禁止 `DELETE`**：拒绝所有 `DELETE` 语句和原生 gRPC delete 请求。
+- **禁止 `ALTER TABLE DROP COLUMN`**：拒绝 `ALTER TABLE ... DROP COLUMN`
+  语句和原生 gRPC `DropColumns` 请求，同时仍允许 `ADD COLUMN` 等其他
+  `ALTER TABLE` 操作。
 - **拒绝 `COPY` 语句**：拒绝所有 `COPY` 语句。
 - **禁止跨 catalog 访问**：拒绝引用不同 catalog 下表的查询、跨 catalog 的
   gRPC DDL 请求，以及写入其他 catalog 的 Flight bulk insert。
@@ -23,11 +27,15 @@ Query Guard 是 GreptimeDB 企业版提供的一个插件，它在 Frontend 协�
 
 该限制同时覆盖 SQL 协议（MySQL、PostgreSQL 和 HTTP）和 gRPC 协议：
 
-- SQL 路径：配置中禁止的 `DROP TABLE`、`DROP DATABASE` 和 `TRUNCATE TABLE`
-  语句会被拒绝，并返回 `NotSupported` 错误。
-- gRPC 路径：配置中禁止的结构化 `DROP TABLE` 和 `TRUNCATE TABLE` DDL 请求会被拒绝。
-  结构化 gRPC DDL 请求没有删除数据库的变体；但通过 gRPC 发送的 SQL 语句同样会
-  经过 SQL 拦截器，因此 `DROP DATABASE` 禁令对 gRPC 上的 SQL 同样生效。
+- SQL 路径：配置中禁止的 `DROP TABLE`、`DROP DATABASE`、`TRUNCATE TABLE`、
+  `DELETE` 和 `ALTER TABLE ... DROP COLUMN` 语句会被拒绝，并返回
+  `NotSupported` 错误。`DELETE` 禁令同样会拒绝包裹在 `EXPLAIN ANALYZE`
+  中的 `DELETE` 语句以及预编译（prepared）的 `DELETE` 语句。
+- gRPC 路径：配置中禁止的结构化 `DROP TABLE` 和 `TRUNCATE TABLE` DDL 请求、
+  批量 `DropColumns` alter-table 请求，以及两种原生 delete 请求编码
+  （`Deletes` 和 `RowDeletes`）都会被拒绝。结构化 gRPC DDL 请求没有删除数据库的
+  变体；但通过 gRPC 发送的 SQL 语句同样会经过 SQL 拦截器，因此 `DROP DATABASE`
+  和 `DELETE` 禁令对 gRPC 上的 SQL 同样生效。
 
 内部操作（例如基于 TTL 的数据过期和自动清理）不经过 Frontend 协议层拦截器，
 因此**不受**这些限制影响。
@@ -43,11 +51,12 @@ Query Guard 以插件形式提供。要启用并配置它，请在 GreptimeDB �
 # 是否启用 query guard 插件，默认为 false。
 enable = true
 # 对所有用户禁止的操作，默认为空列表。
-banned_ops = ["drop_table", "drop_database", "truncate_table"]
+banned_ops = ["drop_table", "drop_database", "truncate_table", "delete", "drop_column"]
 ```
 
-`banned_ops` 支持 `drop_table`、`drop_database` 和 `truncate_table`。
-如果只需禁止其中一部分操作，仅将相应名称加入 `banned_ops` 即可。
+`banned_ops` 支持 `drop_table`、`drop_database`、`truncate_table`、`delete`
+和 `drop_column`。如果只需禁止其中一部分操作，仅将相应名称加入
+`banned_ops` 即可。
 
 原有的 `ban_drop_table`、`ban_drop_database` 和 `ban_truncate_table` 配置项
 已不再受支持。使用其中任意配置项都会导致配置解析失败。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/overview.md
@@ -26,7 +26,7 @@ GreptimeDB Enterprise 包括以下高级功能，
 - [基于双活互备的 DR 解决方案](./deployments-administration/disaster-recovery/overview.md)：通过高级灾难恢复解决方案确保服务不中断和数据保护。
 - [部署 GreptimeDB](./deployments-administration/overview.md)：设置认证信息及其他关键配置后，将 GreptimeDB 部署在 Kubernetes 上并监控关键指标。
 - [审计日志](./deployments-administration/monitoring/audit-logging.md)：记录数据库用户行为的日志。
-- [Query Guard](./deployments-administration/query-guard.md)：对所有用户（包括管理员）禁止 `DROP TABLE` / `DROP DATABASE` 语句，并拒绝跨 catalog 访问。
+- [Query Guard](./deployments-administration/query-guard.md)：对所有用户（包括管理员）禁止 `DROP TABLE`、`DELETE`、`ALTER TABLE DROP COLUMN` 等破坏性操作，并拒绝跨 catalog 访问。
 - [Soft-Drop Table](./soft-drop.md)：防止误删表，可在保留期内从 recycle bin 中恢复表。
 - [自动分区平衡](./autopilot/region-balancer.md)：通过分区监控和迁移在 datanode 之间自动平衡负载。
 - [定时 Compaction](./deployments-administration/scheduled-compaction.md)：定期为所有物理 Region 提交 regular Compaction 请求，并提供用于人工触发和任务查询的 HTTP endpoints。


### PR DESCRIPTION
## Summary

Update the Query Guard documentation for [GreptimeTeam/greptimedb-enterprise#884](https://github.com/GreptimeTeam/greptimedb-enterprise/pull/884), which adds two new `banned_ops` operations:

- `delete`: rejects SQL `DELETE` statements and both native gRPC delete request encodings (`Deletes` and `RowDeletes`); also covers `DELETE` wrapped in `EXPLAIN ANALYZE` and prepared `DELETE` statements.
- `drop_column`: rejects `ALTER TABLE ... DROP COLUMN` statements and native gRPC batched `DropColumns` requests, while other `ALTER TABLE` operations such as `ADD COLUMN` remain allowed.

## Changes

- `docs/enterprise/deployments-administration/query-guard.md`: add the new bans to the protection list, SQL/gRPC interceptor descriptions, configuration example, and supported operation names.
- `i18n/zh/.../current/enterprise/deployments-administration/query-guard.md`: corresponding Chinese updates.
- `docs/enterprise/overview.md` and the Chinese `current` overview: refresh the Query Guard summary to mention destructive operations beyond `DROP TABLE` / `DROP DATABASE`.

Nightly docs only; the feature is unreleased, so no versioned docs are touched.

## Checks

- [x] `git diff --check`
- [x] `pnpm build` (English)
- [x] `DOC_LANG=zh pnpm build` (Chinese)
- [x] `DOC_LANG=en pnpm check:links`
- [x] `DOC_LANG=zh pnpm check:links`