### PR TITLE
docs: document event actors

### DIFF
--- a/docs/user-guide/deployments-administration/monitoring/events/event-data-model.md
+++ b/docs/user-guide/deployments-administration/monitoring/events/event-data-model.md
@@ -12,7 +12,23 @@ description: Understand the GreptimeDB events table data model.
 | `type`          | Event type, such as `create_table` or `region_migration`.   |
 | `timestamp`     | Time at which the row was recorded.                         |
 | `payload`       | JSON data for the event type.                               |
+| `actor`         | Database user recorded as the operation's initiator; SQL `NULL` when the event is not associated with a user request. |
 | `event_context` | JSON describing why the event was triggered when available. |
+
+## Event actor {#actor}
+
+The `actor` is the database user recorded as the initiator of an operation. Use
+it to identify who ran an `ADMIN` statement or submitted a Procedure.
+
+For a Procedure, `actor` comes from the request that submitted it. Every
+lifecycle event for the Procedure records the same `actor`. Events that are not
+associated with a user request have a SQL `NULL` actor.
+
+When [authentication](/user-guide/deployments-administration/authentication/overview.md)
+is enabled, `actor` is the authenticated database user. Without authentication,
+`actor` does not verify who sent the request. MySQL and PostgreSQL record the
+username supplied by the client, while HTTP SQL and gRPC record the default user
+`greptime`.
 
 ## Procedure event columns
 
@@ -56,7 +72,6 @@ An `admin_function` event records the result returned by an `ADMIN` statement.
 
 | Column                   | Meaning                                                                                                                                |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `actor`                  | The current database user that executed the `ADMIN` function.                                                                        |
 | `admin_function_name`    | The name of the executed ADMIN function.                                                                                              |
 | `admin_function_status`  | The execution status: `Succeeded` or `Failed`.                                                                                        |
 | `admin_function_output`  | JSON containing `result` when the function succeeds or `error` when it fails.                                                         |

--- a/docs/user-guide/deployments-administration/monitoring/events/event-data-model.md
+++ b/docs/user-guide/deployments-administration/monitoring/events/event-data-model.md
@@ -20,14 +20,15 @@ description: Understand the GreptimeDB events table data model.
 The `actor` is the database user recorded as the initiator of an operation. Use
 it to identify who ran an `ADMIN` statement or submitted a Procedure.
 
-For a Procedure, `actor` comes from the request that submitted it. Every
-lifecycle event for the Procedure records the same `actor`. Events that are not
-associated with a user request have a SQL `NULL` actor.
+When an operation starts a Procedure, GreptimeDB records the database user as
+its `actor`. The Procedure and any child Procedures it starts keep the same
+`actor` throughout their lifecycle. Events that are not associated with a user
+request have a SQL `NULL` actor.
 
 When [authentication](/user-guide/deployments-administration/authentication/overview.md)
 is enabled, `actor` is the authenticated database user. Without authentication,
 `actor` does not verify who sent the request. MySQL and PostgreSQL record the
-username supplied by the client, while HTTP SQL and gRPC record the default user
+username supplied by the client, while HTTP and gRPC record the default user
 `greptime`.
 
 ## Procedure event columns

--- a/docs/user-guide/deployments-administration/monitoring/events/query-events.md
+++ b/docs/user-guide/deployments-administration/monitoring/events/query-events.md
@@ -54,6 +54,22 @@ cluster. It varies with workload and does not define the configured or
 source-supported types. See [DDL events](/user-guide/deployments-administration/monitoring/events/ddl-events.md)
 for the supported local DDL event types.
 
+## Filter events by actor
+
+Use `actor` to list recent events recorded for a database user:
+
+```sql
+SELECT timestamp, type, actor, json_to_string(payload) AS payload
+FROM greptime_private.events
+WHERE actor = '<username>'
+  AND timestamp >= now() - INTERVAL '1' hour
+ORDER BY timestamp DESC
+LIMIT 20;
+```
+
+See [Event actor](/user-guide/deployments-administration/monitoring/events/event-data-model.md#actor)
+for how GreptimeDB determines this value.
+
 ## Query ADMIN function events
 
 An `admin_function` event records the function name, the current database user,
@@ -81,8 +97,6 @@ it contains an `error`:
 | root  | flush_table         | Succeeded              | {"result":0} |
 | root  | unknown_function     | Failed                 | {"error":"..."} |
 ```
-
-The `actor` value comes from the current protocol session user.
 
 Combine an event type with a database and object name to avoid unrelated rows:
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/monitoring/events/event-data-model.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/monitoring/events/event-data-model.md
@@ -12,7 +12,21 @@ description: 了解 GreptimeDB events 表的数据模型。
 | `type`          | 事件类型，例如 `create_table` 或 `region_migration`。 |
 | `timestamp`     | 记录该行的时间。                                      |
 | `payload`       | 与事件类型相关的 JSON 数据。                          |
+| `actor`         | 记录为操作发起人的数据库用户；事件没有关联用户请求时为 SQL `NULL`。 |
 | `event_context` | 有上下文时，用于描述事件触发原因的 JSON。             |
+
+## 事件发起人（actor） {#actor}
+
+`actor` 表示 GreptimeDB 记录的操作发起用户，可用于查找谁执行了 `ADMIN` 语句，
+或谁提交了 Procedure。
+
+对于 Procedure，`actor` 来自提交该 Procedure 的请求，后续每条生命周期事件都会
+记录相同的 `actor`。没有关联用户请求的事件，其 `actor` 为 SQL `NULL`。
+
+启用[鉴权](/user-guide/deployments-administration/authentication/overview.md)后，
+`actor` 是通过身份验证的数据库用户。未启用鉴权时，`actor` 不能用于确认实际
+调用者：MySQL 和 PostgreSQL 记录客户端提供的用户名，HTTP SQL 和 gRPC 则记录
+默认用户 `greptime`。
 
 ## Procedure 事件列
 
@@ -52,7 +66,6 @@ Procedure 事件还有以下列：
 
 | 列                      | 含义                                                                                                            |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `actor`                 | 执行 `ADMIN` 语句的当前数据库用户。                                                                              |
 | `admin_function_name`   | 执行的管理函数名称。                                                                                             |
 | `admin_function_status` | 执行状态：`Succeeded` 或 `Failed`。                                                                             |
 | `admin_function_output` | JSON 数据。函数成功时包含 `result`，函数失败时包含 `error`。                                                     |

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/monitoring/events/event-data-model.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/monitoring/events/event-data-model.md
@@ -20,12 +20,13 @@ description: 了解 GreptimeDB events 表的数据模型。
 `actor` 表示 GreptimeDB 记录的操作发起用户，可用于查找谁执行了 `ADMIN` 语句，
 或谁提交了 Procedure。
 
-对于 Procedure，`actor` 来自提交该 Procedure 的请求，后续每条生命周期事件都会
-记录相同的 `actor`。没有关联用户请求的事件，其 `actor` 为 SQL `NULL`。
+当一次操作触发 Procedure 时，GreptimeDB 会将数据库用户记录为 `actor`。该
+Procedure 及其启动的子 Procedure 会在整个生命周期内沿用这个值。没有关联用户
+请求的事件，其 `actor` 为 SQL `NULL`。
 
 启用[鉴权](/user-guide/deployments-administration/authentication/overview.md)后，
 `actor` 是通过身份验证的数据库用户。未启用鉴权时，`actor` 不能用于确认实际
-调用者：MySQL 和 PostgreSQL 记录客户端提供的用户名，HTTP SQL 和 gRPC 则记录
+调用者：MySQL 和 PostgreSQL 记录客户端提供的用户名，HTTP 和 gRPC 则记录
 默认用户 `greptime`。
 
 ## Procedure 事件列

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/monitoring/events/query-events.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/monitoring/events/query-events.md
@@ -47,6 +47,21 @@ ORDER BY type;
 该结果仅反映最近一小时内实际出现的事件类型，不能作为已配置或受支持类型的完整清单。
 支持的本地 DDL 事件类型请参阅 [DDL 事件](/user-guide/deployments-administration/monitoring/events/ddl-events.md)。
 
+## 按 actor 筛选事件
+
+使用 `actor` 查询为某个数据库用户记录的最近事件：
+
+```sql
+SELECT timestamp, type, actor, json_to_string(payload) AS payload
+FROM greptime_private.events
+WHERE actor = '<username>'
+  AND timestamp >= now() - INTERVAL '1' hour
+ORDER BY timestamp DESC
+LIMIT 20;
+```
+
+GreptimeDB 如何确定该字段的值，请参阅[事件发起人](/user-guide/deployments-administration/monitoring/events/event-data-model.md#actor)。
+
 ## 查询管理函数事件
 
 `admin_function` 事件记录管理函数名称、当前数据库用户、立即执行状态、输入参数
@@ -73,8 +88,6 @@ LIMIT 20;
 | root  | flush_table         | Succeeded              | {"result":0} |
 | root  | unknown_function     | Failed                 | {"error":"..."} |
 ```
-
-`actor` 的值来自当前协议会话用户。
 
 将事件类型、数据库和对象名称组合，可以避免混入无关事件：
 


### PR DESCRIPTION
## What changed

Document the common `actor` column for ADMIN function and Procedure events. Explain how a Procedure keeps its actor across lifecycle events, how authentication affects the value, and what each protocol records when authentication is disabled.

Add a query example for filtering events by actor.

Closes #2735.

## Scope

- Documentation versions: Nightly
- Languages: English, Chinese

## Verification

- `pnpm build`
- `DOC_LANG=zh pnpm build`
- `DOC_LANG=en pnpm check:links`
- `DOC_LANG=zh pnpm check:links`
- `git diff --check origin/main...HEAD`
- Manually verified Procedure actor values over HTTP SQL, gRPC, MySQL, and PostgreSQL against a local cluster without authentication.
- Manually verified ADMIN event actor values over HTTP SQL, MySQL, and PostgreSQL.
- No navigation update was required because no pages or sidebar entries were added, removed, or moved.

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] I updated navigation when the document structure changed.
