### PR TITLE
docs: fix backup and recovery safety guidance

### DIFF
--- a/docs/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md
+++ b/docs/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md
@@ -81,9 +81,7 @@ extraConfig: |
   log.dirs=/bitnami/kafka/data
   log.flush.interval.messages=10000
   log.flush.interval.ms=1000
-  log.retention.hours=4
   log.roll.hours=3
-  log.retention.bytes=250000000
   log.segment.bytes=1073741824
 ```
 

--- a/docs/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md
+++ b/docs/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md
@@ -81,7 +81,9 @@ extraConfig: |
   log.dirs=/bitnami/kafka/data
   log.flush.interval.messages=10000
   log.flush.interval.ms=1000
+  log.retention.hours=4
   log.roll.hours=3
+  log.retention.bytes=250000000
   log.segment.bytes=1073741824
 ```
 

--- a/docs/user-guide/deployments-administration/disaster-recovery/back-up-&-restore-data.md
+++ b/docs/user-guide/deployments-administration/disaster-recovery/back-up-&-restore-data.md
@@ -83,7 +83,7 @@ greptime cli data export --addr localhost:4000 \
 greptime cli data export \
     --addr localhost:4000 \
     --output-dir /tmp/backup/greptimedb \
-    --database '{my_database_name}'
+    --database <DATABASE_NAME>
 ```
 
 ## Import Operations
@@ -122,7 +122,7 @@ greptime cli data import \
 greptime cli data import \
     --addr localhost:4000 \
     --input-dir /tmp/backup/greptimedb \
-    --database '{my_database_name}'
+    --database <DATABASE_NAME>
 ```
 
 ## Best Practices

--- a/docs/user-guide/deployments-administration/maintenance/sequence-management.md
+++ b/docs/user-guide/deployments-administration/maintenance/sequence-management.md
@@ -34,10 +34,12 @@ You can get or set the `next table ID` using Metasrv's HTTP interface at the fol
 
 To safely update the `next table ID`, follow this step-by-step process:
 
-1. **Enable cluster recovery mode** - This prevents new table creation during the update process. See [Cluster Recovery Mode](/user-guide/deployments-administration/maintenance/recovery-mode.md) for more details.
-2. **Set the next table ID** - Use the HTTP interface to set the `next table ID`.
-3. **Restart metasrv nodes** - This ensures the new `next table ID` is properly applied.
-4. **Disable cluster recovery mode** - Resume normal cluster operations.
+1. **Pause the Procedure Manager** - This rejects new DDL procedures while allowing running procedures to finish. See [Prevent Metadata Changes](/user-guide/deployments-administration/maintenance/prevent-metadata-changes.md).
+2. **Enable cluster recovery mode** - The `set-next-id` endpoint only accepts changes while recovery mode is enabled. See [Cluster Recovery Mode](/user-guide/deployments-administration/maintenance/recovery-mode.md).
+3. **Set the next table ID** - Use the HTTP interface to set the `next table ID`.
+4. **Restart Metasrv nodes** - This ensures the new `next table ID` is properly applied.
+5. **Disable cluster recovery mode**.
+6. **Resume the Procedure Manager** to allow metadata changes again.
 
 Set the `next table ID` by sending a POST request to the `/admin/sequence/table/set-next-id` endpoint:
 

--- a/docs/user-guide/deployments-administration/manage-metadata/restore-backup.md
+++ b/docs/user-guide/deployments-administration/manage-metadata/restore-backup.md
@@ -5,7 +5,7 @@ description: Guide for backing up, restoring, and migrating GreptimeDB metadata 
 
 # Backup and Restore, Migrate
 
-GreptimeDB provides metadata backup and restore capabilities through its CLI tool. This functionality supports all major metadata storage backends including etcd, MySQL, and PostgreSQL. For detailed instructions on using these features, refer to the [Backup and Restore](/user-guide/deployments-administration/disaster-recovery/back-up-&-restore-data.md) guide.
+GreptimeDB provides metadata backup and restore capabilities through its CLI tool. This functionality supports all major metadata storage backends including etcd, MySQL, and PostgreSQL. For detailed command instructions, refer to the [Metadata Backup and Restore](/user-guide/deployments-administration/disaster-recovery/back-up-&-restore-meta-data.md) guide.
 
 ## Backup
 
@@ -35,4 +35,3 @@ Migrate metadata from one metadata storage to another.
 1. Backup the metadata from the source storage.
 2. Restore the metadata to the target storage.
 3. Restart the whole GreptimeDB cluster(all components) to apply the restored metadata.
-

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/disaster-recovery/back-up-&-restore-data.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/disaster-recovery/back-up-&-restore-data.md
@@ -83,7 +83,7 @@ greptime cli data export --addr localhost:4000 \
 greptime cli data export \
     --addr localhost:4000 \
     --output-dir /tmp/backup/greptimedb \
-    --database '{my_database_name}'
+    --database <DATABASE_NAME>
 ```
 
 ## 导入操作
@@ -122,7 +122,7 @@ greptime cli data import \
 greptime cli data import \
     --addr localhost:4000 \
     --input-dir /tmp/backup/greptimedb \
-    --database '{my_database_name}'
+    --database <DATABASE_NAME>
 ```
 
 ## 最佳实践

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/maintenance/sequence-management.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/maintenance/sequence-management.md
@@ -34,10 +34,12 @@ description: 介绍如何维护和更新 GreptimeDB 集群中的资源标识（I
 
 要安全地更新`待分配的表 ID`，请按照以下步骤操作：
 
-1. **启用集群恢复模式** - 这可以防止在更新过程中创建新表。详情请参阅[集群恢复模式](/user-guide/deployments-administration/maintenance/recovery-mode.md)。
-2. **设置待分配的表 ID** - 通过 HTTP 接口设置`待分配的表 ID`。
-3. **重启 metasrv 节点** - 这确保新的`待分配的表 ID`被正确设置。
-4. **禁用集群恢复模式** - 恢复正常的集群操作。
+1. **暂停 Procedure Manager** - 拒绝新的 DDL procedure，并允许正在执行的 procedure 完成。详情请参阅[阻止元数据变更](/user-guide/deployments-administration/maintenance/prevent-metadata-changes.md)。
+2. **启用集群恢复模式** - `set-next-id` 接口仅在恢复模式下接受变更。详情请参阅[集群恢复模式](/user-guide/deployments-administration/maintenance/recovery-mode.md)。
+3. **设置待分配的表 ID** - 通过 HTTP 接口设置`待分配的表 ID`。
+4. **重启 Metasrv 节点** - 这确保新的`待分配的表 ID`被正确设置。
+5. **禁用集群恢复模式**。
+6. **恢复 Procedure Manager**，重新允许元数据变更。
 
 通过发送 POST 请求到 `/admin/sequence/table/set-next-id` 端点设置`待分配的表 ID`：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/manage-metadata/restore-backup.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/manage-metadata/restore-backup.md
@@ -5,7 +5,7 @@
 
 # 备份、恢复和迁移
 
-GreptimeDB 通过其 CLI 工具提供元数据备份和恢复功能。该功能支持所有主要的元数据存储后端，包括 etcd、MySQL 和 PostgreSQL。有关使用这些功能的详细说明，请参阅[备份和恢复](/user-guide/deployments-administration/disaster-recovery/back-up-&-restore-data.md)指南。
+GreptimeDB 通过其 CLI 工具提供元数据备份和恢复功能。该功能支持所有主要的元数据存储后端，包括 etcd、MySQL 和 PostgreSQL。有关详细命令，请参阅[元数据备份和恢复](/user-guide/deployments-administration/disaster-recovery/back-up-&-restore-meta-data.md)指南。
 
 ## 备份
 


### PR DESCRIPTION
## What changed

- pause the Procedure Manager before changing the next table ID while retaining the required recovery mode
- fix database placeholders in export/import commands
- point metadata restore guidance to the metadata backup procedure
- apply the fixes to both English and Simplified Chinese Nightly docs

## Scope

- Documentation versions: Nightly
- Languages: English, Simplified Chinese
- Sidebar-visible documents only

## Verification

- `git diff --check`
- `DOC_LANG=en DOCS_LINK_CHECK=true corepack pnpm exec docusaurus build`
- `DOC_LANG=zh DOCS_LINK_CHECK=true corepack pnpm exec docusaurus build`
- verified the table ID recovery requirements against the current Metasrv admin handler

The Chinese build emits existing image-decoding warnings for several Draw.io SVG files; the build succeeds and this PR does not modify those files.

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] I updated navigation when the document structure changed.