### PR TITLE
docs: make migration guides fail safe

### DIFF
--- a/docs/db-cloud-shared/migrate/_migrate-from-prometheus.md
+++ b/docs/db-cloud-shared/migrate/_migrate-from-prometheus.md
@@ -1,33 +1,56 @@
-GreptimeDB can be used to store time series data for [Prometheus](https://prometheus.io/).
-Additionally, GreptimeDB supports the Prometheus query language via its HTTP API.
-This allows for an easy migration of your Prometheus long-term storage to GreptimeDB.
+GreptimeDB accepts Prometheus Remote Write samples and implements the Prometheus HTTP query API. This supports a staged migration of new samples and compatible PromQL workloads, but it is not a direct import of Prometheus TSDB blocks.
 
-## Data model in difference
+## Check compatibility first
 
-To understand the differences between the data models of Prometheus and GreptimeDB, please refer to the [Data Model](/user-guide/ingest-data/for-observability/prometheus.md#data-model) in the Ingest Data documentation.
+Review the [Prometheus data model mapping](/user-guide/ingest-data/for-observability/prometheus.md#data-model) and inventory:
 
-## Prometheus Remote Write
+- Scrape jobs, external labels, relabeling, and recording rules
+- Alert rules and every PromQL function they use
+- Grafana dashboards, variables, exemplars, and data-source settings
+- Current retention and the historical range that must remain queryable
+
+GreptimeDB supports PromQL through its HTTP API, but that does not guarantee that every rule or dashboard behaves identically. Test critical expressions against the same time range and label set before cutover.
+
+## Send new samples with Remote Write
 
 <InjectContent id="remote-write" content={props.children}/>
 
-## Prometheus HTTP API and PromQL
+Add GreptimeDB as another `remote_write` destination while keeping the existing Prometheus storage and any current remote destination. Remote Write reads samples from the Prometheus WAL; enabling it does not resend the complete historical TSDB.
 
-GreptimeDB supports the Prometheus query language (PromQL) via its HTTP API.
+Monitor the Prometheus remote-write queue while both paths run. In particular, watch pending samples, failed and retried samples, queue lag, CPU, memory, and network saturation. Prometheus can lose unsent remote-write samples after they age out of the WAL, so a continuously failing queue is a data-loss condition, not merely delayed delivery. See the [Prometheus Remote Write tuning guide](https://prometheus.io/docs/practices/remote_write/).
+
+Compare recent data in both systems:
+
+- Series count and label sets for important jobs
+- Minimum and maximum sample timestamps
+- Raw samples for selected series
+- Recording-rule and alert expressions over fixed time ranges
+- Missing-sample behavior during Prometheus or GreptimeDB restarts
+
+## Query with PromQL
+
+GreptimeDB exposes the Prometheus HTTP API for PromQL queries.
+
 <InjectContent id="promql" content={props.children}/>
 
-## Visualize data using Grafana
+Keep the original Prometheus queryable during migration. Run critical instant and range queries against both endpoints with identical `time`, `start`, `end`, and `step` parameters, then compare values, labels, and empty-series behavior.
 
-For developers accustomed to using Grafana for visualizing Prometheus data,
-you can continue to use the same Grafana dashboards to visualize data stored in GreptimeDB.
+## Move Grafana dashboards
+
 <InjectContent id="grafana" content={props.children}/>
 
+Point a copy of the Prometheus data source at GreptimeDB and test dashboards before switching the production data source. Dashboards that use supported PromQL may work unchanged, but differences in labels, unsupported functions, exemplars, or metadata APIs can require edits. Validate alerts separately from dashboard panels.
 
-## Reference
+## Handle existing history
 
-For tutorials and user stories on integrating GreptimeDB with Prometheus, please refer to the following blog posts:
+GreptimeDB does not directly import Prometheus TSDB block directories. Choose one of these approaches:
 
-- [Setting Up GreptimeDB for Long-Term Prometheus Storage](https://greptime.com/blogs/2024-08-09-prometheus-backend-tutorial)
-- [Scale Prometheus - Deploying GreptimeDB Cluster as Long-Term Storage for Prometheus in K8s](https://greptime.com/blogs/2024-10-07-scale-prometheus)
-- [User Story — Why We Switched from Thanos to GreptimeDB for Prometheus Long-Term Storage](https://greptime.com/blogs/2024-10-16-thanos-migration-to-greptimedb)
+- Keep the old Prometheus or long-term store read-only until its required retention window expires.
+- Replay historical samples through a tested Remote Write-compatible tool, preserving original timestamps and labels.
+- Migrate only new samples and keep separate data sources for old and new time ranges during the transition.
 
-If you need a more detailed migration plan or example scripts, please provide the specific table structure and data volume. The [GreptimeDB official community](https://github.com/orgs/GreptimeTeam/discussions) will offer further support. Welcome to join the [Greptime Slack](http://greptime.com/slack).
+Backfill in bounded ranges, record progress, and compare counts and queries after each range. Avoid overlapping an untracked backfill with live Remote Write because duplicates or conflicting samples become difficult to reconcile.
+
+## Cut over
+
+Move read traffic only after live Remote Write is caught up and the critical queries, dashboards, and alerts pass comparison. Keep the old query endpoint and rollback path until the required historical range and an agreed observation window have been covered.

--- a/docs/db-cloud-shared/migrate/migrate-from-influxdb.md
+++ b/docs/db-cloud-shared/migrate/migrate-from-influxdb.md
@@ -24,7 +24,7 @@ Confirm that the column types and primary key columns match your expectations, e
 
 ## Database connection information
 
-Before you begin writing or querying data, it's crucial to comprehend the differences in database connection information between InfluxDB and GreptimeDB.
+Use the following connection mapping when configuring clients:
 
 - **Token**: The InfluxDB API token, used for authentication, aligns with the GreptimeDB authentication. When interacting with GreptimeDB using InfluxDB's client libraries or HTTP API, you can use `<greptimedb_user:greptimedb_password>` as the token.
 - **Organization**: Unlike InfluxDB, GreptimeDB does not require an organization for connection.
@@ -35,8 +35,7 @@ Before you begin writing or querying data, it's crucial to comprehend the differ
 
 ## Ingest data
 
-GreptimeDB is compatible with both v1 and v2 of InfluxDB's line protocol format,
-facilitating a seamless migration from InfluxDB to GreptimeDB.
+GreptimeDB accepts InfluxDB line protocol through v1- and v2-compatible write endpoints.
 
 ### HTTP API
 
@@ -55,16 +54,13 @@ To configure Telegraf, simply add GreptimeDB URL into Telegraf configurations:
 
 ### Client libraries
 
-Writing data to GreptimeDB is a straightforward process when using InfluxDB client libraries.
-Simply include the URL and authentication details in the client configuration.
+InfluxDB client libraries can write to GreptimeDB when their URL, database, and authentication settings point to the compatible endpoint.
 
 For example:
 
 <InjectContent id="write-data-client-libs" content={props.children}/>
 
-In addition to the languages previously mentioned,
-GreptimeDB also accommodates client libraries for other languages supported by InfluxDB.
-You can code in your language of choice by referencing the connection information and code snippets provided earlier.
+Other InfluxDB client libraries can use the same connection mapping. Verify that a client sends line protocol to the supported write endpoint rather than relying on an InfluxDB management or query API.
 
 ## Query data
 
@@ -149,22 +145,22 @@ For more information on PromQL, please refer to the [PromQL](https://prometheus.
 
 ## Migrate data
 
-For a seamless migration of data from InfluxDB to GreptimeDB, you can follow these steps:
+Use an explicit cutoff and validation process:
 
-![Double write to GreptimeDB and InfluxDB](/migrate-influxdb-to-greptimedb.drawio.svg)
-
-1. Write data to both GreptimeDB and InfluxDB to avoid data loss during migration.
-2. Export all historical data from InfluxDB and import the data into GreptimeDB.
+1. Define a source time boundary and start the new write path while recording failures for each destination.
+2. Export and import the historical range before that boundary.
 3. Validate the schema, row counts, time ranges, and critical query results.
 4. Gradually move read traffic to GreptimeDB.
 5. Stop writing to InfluxDB after validation succeeds.
 
 ### Write data to both GreptimeDB and InfluxDB simultaneously
 
-Writing data to both GreptimeDB and InfluxDB simultaneously is a practical strategy to avoid data loss during migration.
+Dual-write can reduce cutover downtime, but the two writes are not atomic.
 By utilizing InfluxDB's [client libraries](#client-libraries),
 you can set up two client instances - one for GreptimeDB and another for InfluxDB.
 For guidance on writing data to GreptimeDB using the InfluxDB line protocol, please refer to the [Ingest Data](#ingest-data) section.
+
+Record failed writes and retry each destination independently. Establish a stable cutoff from source progress rather than wall-clock time alone, because late events can have timestamps before the moment dual-write starts. Reconcile the overlap and any failed-write log before disabling the source path.
 
 If retaining all historical data isn't necessary,
 you can simultaneously write data to both GreptimeDB and InfluxDB for a specific period to accumulate the required recent data.
@@ -194,7 +190,7 @@ influx_inspect export \
 - The `-database` flag specifies the database to be exported.
 - The `-end` flag specifies the end time of the data to be exported.
 Must be in [RFC3339 format](https://datatracker.ietf.org/doc/html/rfc3339), such as `2024-01-01T00:00:00Z`.
-You can use the timestamp when simultaneously writing data to both GreptimeDB and InfluxDB as the end time.
+Use the agreed historical cutoff as the end time. If late writes can arrive before that timestamp, quiesce the source or run a reconciliation export for the affected range.
 - The `-lponly` flag specifies that only the Line Protocol data should be exported.
 - The `-datadir` flag specifies the path to the data directory, as configured in the [InfluxDB data settings](https://docs.influxdata.com/influxdb/v1/administration/config/#data-settings).
 - The `-waldir` flag specifies the path to the WAL directory, as configured in the [InfluxDB data settings](https://docs.influxdata.com/influxdb/v1/administration/config/#data-settings).
@@ -230,7 +226,7 @@ influxd inspect export-lp \
 - The `--bucket-id` flag specifies the bucket ID to be exported.
 - The `--engine-path` flag specifies the path to the engine directory, as configured in the [InfluxDB data settings](https://docs.influxdata.com/influxdb/v2.0/reference/config-options/#engine-path).
 - The `--end` flag specifies the end time of the data to be exported. Must be in [RFC3339 format](https://datatracker.ietf.org/doc/html/rfc3339), such as `2024-01-01T00:00:00Z`.
-You can use the timestamp when simultaneously writing data to both GreptimeDB and InfluxDB as the end time.
+Use the agreed historical cutoff as the end time. If late writes can arrive before that timestamp, quiesce the source or run a reconciliation export for the affected range.
 - The `--output-path` flag specifies the output directory.
 
 The outputs look like the following:
@@ -259,7 +255,7 @@ For large data sets, export and import by measurement and time range, record com
 split -l 100000 -d -a 10 data data.
 # -l [line_count]    Create split files line_count lines in length.
 # -d                 Use a numeric suffix instead of a alphabetic suffix.
-# -a [suffix_length] Use suffix_length letters to form the suffix of the file name.
+# -a [suffix_length] Use suffix_length digits to form the file-name suffix.
 ```
 
 You can import data using the HTTP API as described in the [write data section](#http-api).
@@ -307,5 +303,3 @@ ORDER BY row_count DESC;
 ```
 
 Keep dual writes enabled while gradually moving read traffic. Stop writing to InfluxDB only after these checks and application-level queries produce the expected results.
-
-If you need a more detailed migration plan or example scripts, please provide the specific table structure and data volume. The [GreptimeDB official community](https://github.com/orgs/GreptimeTeam/discussions) will offer further support. Welcome to join the [Greptime Slack](http://greptime.com/slack).

--- a/docs/user-guide/migrate-to-greptimedb/migrate-from-clickhouse.md
+++ b/docs/user-guide/migrate-to-greptimedb/migrate-from-clickhouse.md
@@ -1,244 +1,119 @@
 ---
-keywords: [migrate from ClickHouse, ClickHouse,GreptimeDB,write data, export data, import data,migration]
-description: Step-by-step guide on migrating from ClickHouse to GreptimeDB, including data model adjustments, table structure reconstruction,, exporting and importing data.
+keywords: [migrate from ClickHouse, ClickHouse, CSV, COPY FROM, migration validation]
+description: Redesign a ClickHouse table for GreptimeDB and migrate a bounded data set through CSV or object storage.
 ---
 
 # Migrate from ClickHouse
 
-This guide provides a detailed explanation on how to smoothly migrate your business from ClickHouse to GreptimeDB. It covers pre-migration preparation, data model adjustments, table structure reconstruction, dual-write assurance, and specific methods for data export and import, aiming to achieve a seamless system transition.
+ClickHouse and GreptimeDB use different SQL dialects, table models, indexes, and storage engines. Treat the migration as a schema redesign and data conversion, not as a direct restore of ClickHouse DDL or data files.
 
+## Define the migration boundary
 
-## Pre-Migration Notes
+Choose one of these approaches before exporting data:
 
-- **Compatibility**
-  Although GreptimeDB is SQL protocol compatible, the two databases have fundamental differences in data modeling, index design, and compression mechanisms. Be sure to refer to the [SQL compatibility](/reference/sql/compatibility.md) documentation and official [modeling guidelines](/user-guide/deployments-administration/performance-tuning/design-table.md) to refactor table structures and data flows during migration.
+- Stop source writes during the final export and import.
+- Export an immutable time range and start the new write path at the range boundary.
+- Use a CDC or application dual-write process that records source positions and reconciles failures.
 
-- **Data Model Differences**
-  ClickHouse is a general-purpose big data analytics engine, while GreptimeDB is optimized for time-series, metrics, and log observability scenarios. There are differences in their data models, index systems, and compression algorithms, so it’s important to take these differences and the actual business scenario into account during model design and compatibility considerations.
+Application dual-write is two independent writes, not a cross-database transaction. It reduces cutover downtime only when failures are recorded, retried, and reconciled. Do not assume that enabling two sinks prevents gaps or duplicates.
 
----
+## Redesign the table
 
-## Refactoring Data Model and Table Structure
+Review [SQL compatibility](/reference/sql/compatibility.md), [Table design](/user-guide/deployments-administration/performance-tuning/design-table.md), and [Indexes](/user-guide/manage-data/data-index.md). In particular:
 
-### Time Index
-- ClickHouse tables do not always have a `time index` field. During migration, you need to clearly select the primary time field for your business to serve as the time index and specify it when creating the table in GreptimeDB. For example, typical log or trace print times.
-- The time precision (such as second, millisecond, microsecond, etc.) should be assessed based on real-world requirements and cannot be changed once set.
+- Select one event-time column as the GreptimeDB time index and preserve its time zone and precision during export.
+- Do not copy ClickHouse `ORDER BY` mechanically into a GreptimeDB primary key. Choose primary-key columns from the target filter, grouping, and row-merge semantics.
+- Add inverted, skipping, or full-text indexes only for operators and columns that use them. Cardinality alone does not determine the index type.
+- Translate `PARTITION BY` to GreptimeDB table partitioning only when the target workload needs explicit sharding.
+- Translate ClickHouse TTL expressions to GreptimeDB database or table `ttl` options.
+- Flatten or convert ClickHouse arrays, tuples, maps, aggregate states, and other types that do not have an equivalent target type.
 
-### Primary Key and Wide Table Recommendations
-- Primary Key: Just like the `order by` in ClickHouse without the timestamp column. It’s not recommended to include high-cardinality fields such as log IDs, user IDs or UUIDs to avoid primary key bloat, excessive write amplification, and inefficient queries.
-- Wide Table vs. Multiple Tables: For multiple metrics collected at the same observation point (such as on the same host), it’s better to use a wide table, which improves batch write efficiency and compression ratio.
+For OpenTelemetry logs and traces, prefer GreptimeDB's built-in [log](/user-guide/logs/overview.md) and [trace](/user-guide/traces/overview.md) data models instead of inventing a second incompatible schema.
 
-### Index Planning
-- Inverted Index: Build indexes for low-cardinality columns to improve filter efficiency.
-- Skipping Index:  Use as needed; Used when certain values are sparse or querying specific values that occur infrequently within large datasets.
-- Fulltext Index: Use as needed; Designed for text search operations on string columns; avoid building unnecessary indexes on high-cardinality or highly variable fields.
-- Read [Data Index](/user-guide/manage-data/data-index.md) for more info.
+## Example schema mapping
 
-### Partitioning Table
-ClickHouse supports table partitioning via the `PARTITION BY` syntax. GreptimeDB provides a similar feature with a different syntax; see the [table sharding](/user-guide/deployments-administration/manage-data/table-sharding.md) documentation for details.
+ClickHouse source table:
 
-### TTL
-GreptimeDB supports TTL (Time-to-live) through the table option `ttl`. For more information, please refer to [Manage data retention with TTL policies](/user-guide/manage-data/overview.md#manage-data-retention-with-ttl-policies).
-
-### Example Table
-
-Example ClickHouse table structure:
 ```sql
 CREATE TABLE example (
- timestamp DateTime,
- host String,
- app String,
- metric String,
- value Float64
- ) ENGINE = MergeTree()
- TTL timestamp + INTERVAL 30 DAY
- ORDER BY (timestamp, host, app, metric);
+  timestamp DateTime,
+  host String,
+  app String,
+  metric String,
+  value Float64
+)
+ENGINE = MergeTree
+TTL timestamp + INTERVAL 30 DAY
+ORDER BY (timestamp, host, app, metric);
 ```
 
-Recommended table structure after migrating to GreptimeDB:
+One possible GreptimeDB target is:
+
 ```sql
 CREATE TABLE example (
- `timestamp` TIMESTAMP NOT NULL,
- host STRING,
- app STRING INVERTED INDEX,
- metric STRING INVERTED INDEX,
- `value` DOUBLE,
- PRIMARY KEY (host, app, metric),
- TIME INDEX (`timestamp`)
- ) with(ttl='30d');
+  ts TIMESTAMP(3) NOT NULL,
+  host STRING,
+  app STRING,
+  metric STRING,
+  value DOUBLE,
+  PRIMARY KEY (host, app, metric),
+  TIME INDEX (ts)
+) WITH (ttl = '30d');
 ```
 
-> The choice of primary key and the granularity of the time index should be carefully planned based on your business's data volume and query scenarios. If the host cardinality is high (e.g., hundreds of thousands of monitored hosts), you should remove it from the primary key and consider creating a skipping index for it.
+The target is an example, not a general recommendation. Rename `timestamp` to `ts` during export, and change the primary key or add indexes only after checking actual queries and update semantics.
 
----
+## Export a bounded range
 
-### Migrating Typical Log Tables
+`CSVWithNames` writes a header row. Select and convert columns explicitly so the file matches the target schema. The following command writes the CSV on the client machine and excludes rows at or after the cutover boundary:
 
-> GreptimeDB already provides built-in modeling for otel log ingestion, so please refer to the [official documentation](/user-guide/ingest-data/for-observability/opentelemetry.md#logs).
-
-Common ClickHouse log table structure:
-```sql
-CREATE TABLE logs
- (
- timestamp      DateTime,
- host           String,
- service        String,
- log_level      String,
- log_message    String,
- trace_id       String,
- span_id        String,
- INDEX inv_idx(log_message)  TYPE ngrambf_v1(4, 1024, 1, 0) GRANULARITY 1
- ) ENGINE = MergeTree
- ORDER BY (timestamp, host, service);
+```bash
+clickhouse-client \
+  --host <clickhouse-host> \
+  --query "
+    SELECT
+      timestamp AS ts,
+      host,
+      app,
+      metric,
+      value
+    FROM example
+    WHERE timestamp < toDateTime('2026-08-01 00:00:00', 'UTC')
+    ORDER BY timestamp
+    FORMAT CSVWithNames
+  " > example.csv
 ```
 
-Recommended GreptimeDB table structure:
-- Time index: `timestamp` (precision set based on logging frequency)
-- Primary key: `host`, `service` (fields often used in queries/aggregations)
-- Field columns: `log_message`, `trace_id`, `span_id` (high-cardinality, unique identifiers, or raw content)
+Use the source time zone rather than `UTC` if the ClickHouse `DateTime` column uses another zone. Export large tables in non-overlapping time ranges and record the row count and boundaries of every file.
 
-```sql
-CREATE TABLE logs (
- `timestamp` TIMESTAMP NOT NULL,
- host STRING,
- service STRING,
- log_level STRING,
- log_message STRING FULLTEXT INDEX WITH (
-        backend = 'bloom',
-        analyzer = 'English',
-        case_sensitive = 'false'
-    ),
- trace_id STRING SKIPPING INDEX,
- span_id STRING SKIPPING INDEX,
- PRIMARY KEY (host, service),
- TIME INDEX (`timestamp`)
- );
-```
+## Import into GreptimeDB
 
-**Notes:**
-- `host` and `service` serve as common query filters and are included in the primary key to optimize filtering. If there are very many hosts, you might not want to include `host` in the primary key but instead create a skip index.
-- `log_message` is treated as raw content with a full-text index created. If you want the full-text index to take effect during queries, you also need to adjust your SQL query syntax. Please refer to [the log query documentation](/user-guide/logs/fulltext-search.md) for details
-- Since `trace_id` and `span_id` are mostly high-cardinality fields, it is not recommended to use them in the primary key, but skip indexes have been added.
-
----
-
-### Migrating Typical Traces Tables
-
-> GreptimeDB also provides built-in modeling for otel trace ingestion, please read the [official documentation](/user-guide/ingest-data/for-observability/opentelemetry.md#traces).
-
-Common ClickHouse trace table structure design:
-```sql
-CREATE TABLE traces (
- timestamp DateTime,
- trace_id String,
- span_id String,
- parent_span_id String,
- service String,
- operation String,
- duration UInt64,
- status String,
- tags Map(String, String)
- ) ENGINE = MergeTree()
- ORDER BY (timestamp, trace_id, span_id);
-```
-
-Recommended GreptimeDB table structure:
-- Time index: `timestamp` (e.g., collection/start time)
-- Primary key: `service`, `operation` (commonly filtered/aggregated properties)
-- Field columns: `trace_id`, `span_id`, `parent_span_id`, `duration`, `tags` (high-cardinality or Map type)
+Upload the file to object storage for a distributed GreptimeDB cluster, then run `COPY FROM`. `STRICT_HEADERS` fails before reading data if CSV column names do not match the target table:
 
 ```sql
-CREATE TABLE traces (
- `timestamp` TIMESTAMP NOT NULL,
- service STRING,
- operation STRING,
- `status` STRING,
- trace_id STRING SKIPPING INDEX,
- span_id STRING SKIPPING INDEX,
- parent_span_id STRING SKIPPING INDEX,
- duration DOUBLE,
- tags STRING,    -- If this is structured JSON, either store it as-is or use the pipeline to parse fields
- PRIMARY KEY (service, operation),
- TIME INDEX (`timestamp`)
- );
+COPY example
+FROM 's3://migration-bucket/clickhouse/example.csv'
+WITH (
+  FORMAT = 'CSV',
+  HEADERS = 'true',
+  STRICT_HEADERS = 'true'
+)
+CONNECTION (REGION = 'us-west-2');
 ```
 
-**Notes:**
-- `service` and `operation` serve as primary key, supporting trace scheduling and aggregate queries by service or operations.
-- `trace_id`, `span_id`, and `parent_span_id` use skip indexes but are not part of the primary key.
-- High-cardinality fields are set as fields for efficient writes. For complex properties like `tags`, [JSON storage](/reference/sql/data-types/#json-type-experimental) or string is recommended, and they can be expanded using GreptimeDB’s ETL - [Pipeline](/user-guide/logs/use-custom-pipelines.md) if necessary.
-- Depending on overall business volume, consider whether to partition traces into multiple tables (such as in massive multi-service environments).
+Add the required connection credentials or use the deployment's credential provider. For a standalone deployment, a local path can be used only within the configured `storage.copy_root`; distributed deployments disable local SQL file access. See [COPY FROM](/reference/sql/copy.md#copy-from) and [Migrate local SQL file access](/user-guide/deployments-administration/migrate-local-sql-file-access.md).
 
----
+Keep `SKIP_BAD_RECORDS` disabled during migration. Skipping conversion failures makes source and target counts diverge without identifying which rows were lost.
 
-## Dual-write Strategy for Safe Migration
+## Validate and cut over
 
-During the migration process, to avoid data loss or inconsistent writes, adopt a dual-write approach:
-- The application should write to both ClickHouse and GreptimeDB simultaneously, running the two systems in parallel.
-- Validate and compare data using logs and checks to ensure data consistency. Once the data has been fully validated, you can switch fully over.
+For every exported range, compare:
 
----
+- Source query count and imported row count
+- Minimum and maximum event time
+- Null counts and distinct counts for important dimensions
+- Aggregates grouped by the dimensions and time windows used by the application
+- Sampled rows covering time zones, nullable values, nested-data conversions, and numeric boundaries
+- Rewritten dashboard, alert, and application-query results
 
-## Exporting and Importing Historical Data
-
-1. **Enable dual-write before migration**
-The application should write to both ClickHouse and GreptimeDB. Check for data consistency to reduce the risk of missing data.
-
-2. **Data export from ClickHouse**
-Use ClickHouse’s native command to export data as CSV, TSV, Parquet, or other formats. For example:
-```sh
-clickhouse client --query="SELECT * FROM example INTO OUTFILE 'example.csv' FORMAT CSVWithNames"
-```
-The exported CSV will look like:
-```csv
-"timestamp","host","app","metric","value"
-"2024-04-25 10:00:00","host01","nginx","cpu_usage",12.7
-"2024-04-25 10:00:00","host02","redis","cpu_usage",8.4
-"2024-04-25 10:00:00","host03","postgres","cpu_usage",15.3
-"2024-04-25 10:01:00","host01","nginx","cpu_usage",12.5
-"2024-04-25 10:01:00","host01","nginx","mem_usage",1034.5
-"2024-04-25 10:01:00","host02","redis","mem_usage",876.2
-"2024-04-25 10:01:00","host03","postgres","mem_usage",1145.2
-"2024-04-25 10:02:00","host01","nginx","disk_io",120.3
-"2024-04-25 10:02:00","host02","redis","disk_io",95.1
-"2024-04-25 10:02:00","host03","postgres","disk_io",134.7
-"2024-04-25 10:03:00","host02","redis","mem_usage",874
-"2024-04-25 10:04:00","host03","postgres","cpu_usage",15.1
-```
-
-3. **Data import into GreptimeDB**
-> The table must be created in GreptimeDB before importing data.
-
-GreptimeDB currently supports batch data import via SQL commands or [REST API](/reference/http-endpoints.md#protocol-endpoints). For large datasets, import in batches.
-Use the [`COPY FROM` command](/reference/sql/copy.md#copy-from) to import:
-```sql
-  COPY example FROM "/path/to/example.csv" WITH (FORMAT = 'CSV');
-```
-Alternatively, you can convert the CSV to standard INSERT statements for batch import.
-
----
-
-## Validation and Cutover
-
-- Once the import is complete, use GreptimeDB’s query interface to compare data with ClickHouse for consistency.
-- After data verification and monitoring meet requirements, you can officially switch business writes to GreptimeDB and disable dual-write mode.
-
----
-
-## Frequently Asked Questions and Optimization Tips
-
-### What if SQL/types are incompatible?
-  Before migration, audit all query SQL and rewrite or translate as necessary, referring to the [official documentation](/user-guide/query-data/sql.md) (especially for [log query](/user-guide/logs/fulltext-search.md)) for any incompatible syntax or data types.
-
-### How do I efficiently import very large datasets in batches?
-  For large tables or full historical data, export and import by partition or shard as appropriate. Monitor write speed and import progress closely.
-
-### How should high-cardinality fields be handled?
-  Avoid using high-cardinality fields as primary key. Store them as fields instead, and split into multiple tables if necessary.
-
-### How should wide tables be planned?
-  For each monitoring entity or collection endpoint, consolidate all metrics into a single table. For example, use a `host_metrics` table to store all server statistics.
-
----
-
-If you need a more detailed migration plan or example scripts, please provide the specific table structure and data volume. The [GreptimeDB official community](https://github.com/orgs/GreptimeTeam/discussions) will offer further support. Welcome to join the [Greptime Slack](http://greptime.com/slack).
+Cut over only after all ranges and critical queries pass validation. Keep the ClickHouse source unchanged until the rollback window closes.

--- a/docs/user-guide/migrate-to-greptimedb/migrate-from-influxdb.md
+++ b/docs/user-guide/migrate-to-greptimedb/migrate-from-influxdb.md
@@ -19,9 +19,9 @@ to convert InfluxQL to GreptimeDB SQL and identify semantic differences.
 <TabItem value="InfluxDB line protocol v2" label="InfluxDB line protocol v2">
 
 ```shell
-curl -X POST 'http://<host>:4000/v1/influxdb/api/v2/write?bucket=<db-name>' \
+curl --fail-with-body -X POST 'http://<host>:4000/v1/influxdb/api/v2/write?bucket=<db-name>&precision=ns' \
   -H 'authorization: token <greptime_user:greptimedb_password>' \
-  -d 'census,location=klamath,scientist=anderson bees=23 1566086400000000000'
+  --data-binary 'census,location=klamath,scientist=anderson bees=23 1566086400000000000'
 ```
 
 </TabItem>
@@ -29,8 +29,8 @@ curl -X POST 'http://<host>:4000/v1/influxdb/api/v2/write?bucket=<db-name>' \
 <TabItem value="InfluxDB line protocol v1" label="InfluxDB line protocol v1">
 
 ```shell
-curl 'http://<host>:4000/v1/influxdb/write?db=<db-name>&u=<greptime_user>&p=<greptimedb_password>' \
-  -d 'census,location=klamath,scientist=anderson bees=23 1566086400000000000'
+curl --fail-with-body 'http://<host>:4000/v1/influxdb/write?db=<db-name>&u=<greptime_user>&p=<greptimedb_password>&precision=ns' \
+  --data-binary 'census,location=klamath,scientist=anderson bees=23 1566086400000000000'
 ```
 
 </TabItem>
@@ -71,6 +71,7 @@ const point1 = new Point('temperature')
   .tag('sensor_id', 'TLM01')
   .floatField('value', 24.0)
 writeApi.writePoint(point1)
+await writeApi.close()
 
 ```
 
@@ -98,6 +99,7 @@ write_api = client.write_api(write_options=SYNCHRONOUS)
 
 p = influxdb_client.Point("my_measurement").tag("location", "Prague").field("temperature", 25.3)
 write_api.write(bucket=bucket, org=org, record=p)
+client.close()
 
 ```
 
@@ -117,7 +119,9 @@ p := influxdb2.NewPoint("stat",
     map[string]string{"unit": "temperature"},
     map[string]interface{}{"avg": 24.5, "max": 45},
     time.Now())
-writeAPI.WritePoint(context.Background(), p)
+if err := writeAPI.WritePoint(context.Background(), p); err != nil {
+    log.Fatal(err)
+}
 client.Close()
 
 ```
@@ -183,11 +187,18 @@ Please refer to the [Grafana documentation](/user-guide/integrations/grafana.md)
 <div id="import-data-shell">
 
 ```shell
+set -euo pipefail
+
+: "${GREPTIME_USERNAME:?set GREPTIME_USERNAME}"
+: "${GREPTIME_PASSWORD:?set GREPTIME_PASSWORD}"
+: "${GREPTIME_HOST:?set GREPTIME_HOST}"
+: "${GREPTIME_DB:?set GREPTIME_DB}"
+
 for file in data.*; do
-  curl -i --retry 3 \
-    -X POST "http://${GREPTIME_HOST}:4000/v1/influxdb/write?db=${GREPTIME_DB}&u=${GREPTIME_USERNAME}&p=${GREPTIME_PASSWORD}" \
+  curl --fail-with-body --retry 3 \
+    -X POST "http://${GREPTIME_HOST}:4000/v1/influxdb/api/v2/write?bucket=${GREPTIME_DB}&precision=ns" \
+    -H "Authorization: token ${GREPTIME_USERNAME}:${GREPTIME_PASSWORD}" \
     --data-binary @"${file}"
-  sleep 1
 done
 ```
 

--- a/docs/user-guide/migrate-to-greptimedb/migrate-from-loki.md
+++ b/docs/user-guide/migrate-to-greptimedb/migrate-from-loki.md
@@ -40,7 +40,7 @@ Use the following GreptimeDB-specific headers:
 | --- | --- | --- |
 | `X-Greptime-DB-Name` | No | Target database name. The default is `public`. |
 | `X-Greptime-Log-Table-Name` | No | Target log table name. The default is `loki_logs`. |
-| `Authorization` | Depends on deployment | Basic authentication with Base64-encoded `<username>:<password>`. |
+| `Authorization` | Depends on deployment | `Basic <base64(username:password)>`. Most clients should set this through their Basic Auth option. |
 | `X-Greptime-Pipeline-Name` or `X-Greptime-Log-Pipeline-Name` | No | Pipeline name for parsing Loki entries before insertion. |
 
 GreptimeDB accepts the same Loki push body shapes:
@@ -51,7 +51,7 @@ GreptimeDB accepts the same Loki push body shapes:
 The following JSON request is useful for a quick connectivity check:
 
 ```bash
-curl -X POST "http://localhost:4000/v1/loki/api/v1/push" \
+curl --fail-with-body -X POST "http://localhost:4000/v1/loki/api/v1/push" \
   -H "Content-Type: application/json" \
   -H "X-Greptime-DB-Name: public" \
   -H "X-Greptime-Log-Table-Name: loki_demo_logs" \
@@ -73,6 +73,7 @@ curl -X POST "http://localhost:4000/v1/loki/api/v1/push" \
 ### Dual-write to Loki and GreptimeDB
 
 During migration, write to both Loki and GreptimeDB until you have validated ingestion, retention, dashboards, and alerts.
+The two sinks are independent, so one can accept an entry while the other fails. Monitor and retain each sink's retry queue; dual-write is not an atomic delivery guarantee.
 
 The following Alloy example keeps the existing Loki sink and adds GreptimeDB as a second Loki-compatible sink:
 
@@ -247,7 +248,7 @@ The sample timestamps do not include a time zone. Set `timezone` to the time zon
 Upload the pipeline:
 
 ```bash
-curl -X POST "http://localhost:4000/v1/pipelines/zk_logs" \
+curl --fail-with-body -X POST "http://localhost:4000/v1/pipelines/zk_logs" \
   -F "file=@zk_pipeline.yaml"
 ```
 

--- a/docs/user-guide/migrate-to-greptimedb/migrate-from-mysql.md
+++ b/docs/user-guide/migrate-to-greptimedb/migrate-from-mysql.md
@@ -1,111 +1,80 @@
 ---
-keywords: [migrate from MySQL, create databases, write data, export data, import data]
-description: Step-by-step guide on migrating from MySQL to GreptimeDB, including creating databases, writing data, exporting and importing data.
+keywords: [migrate from MySQL, mysqldump, MySQL protocol, data validation]
+description: Migrate compatible MySQL table data to GreptimeDB with an explicit consistency boundary and validation.
 ---
 
 # Migrate from MySQL
 
-This document will guide you through the migration process from MySQL to GreptimeDB.
+GreptimeDB implements the MySQL wire protocol, not the MySQL storage engine or full SQL dialect. A MySQL schema dump cannot be restored unchanged. Create the GreptimeDB schema first, then move compatible row data.
 
-## Before you start the migration
+## Plan the migration
 
-Please be aware that though GreptimeDB supports the wire protocol of MySQL, it does not mean GreptimeDB implements all
-MySQL's features. You may refer to:
-* The [ANSI Compatibility](/reference/sql/compatibility.md) to see the constraints regarding using SQL in GreptimeDB.
-* The [Data Modeling Guide](/user-guide/deployments-administration/performance-tuning/design-table.md) to create proper table schemas.
-* The [Data Index Guide](/user-guide/manage-data/data-index.md) for index planning.
+Before exporting data:
 
-## Migration steps
+- Check [SQL compatibility](/reference/sql/compatibility.md) and map unsupported MySQL types and expressions.
+- Choose a natural event-time column as the GreptimeDB time index. Do not add an ingestion-time column unless that is the time semantics the application needs.
+- Design primary keys and indexes from the GreptimeDB query workload. A GreptimeDB primary key is not a MySQL uniqueness constraint. See [Table design](/user-guide/deployments-administration/performance-tuning/design-table.md) and [Indexes](/user-guide/manage-data/data-index.md).
+- Decide on an exact migration boundary. A short read-only window is the simplest safe option for a SQL-dump migration.
 
-### Create the databases and tables in GreptimeDB
+Application dual-write is not atomic: one destination can succeed while the other fails. If downtime is unacceptable, use a CDC or dual-write process that records a source position, retries each destination independently, and reconciles missing or conflicting rows before cutover. Merely opening two client connections does not prevent data loss.
 
-Before migrating the data from MySQL, you first need to create the corresponding databases and tables in GreptimeDB.
-GreptimeDB has its own SQL syntax for creating tables, so you cannot directly reuse the table creation SQLs that are produced
-by MySQL.
+## Create the target schema
 
-When you write the table creation SQL for GreptimeDB, it's important to understand
-its "[data model](/user-guide/concepts/data-model.md)" first. Then, please take the following considerations in
-your create table SQL:
+Create the target database and tables in GreptimeDB. Match column names used by the data dump, but translate data types, defaults, generated columns, indexes, and constraints to GreptimeDB syntax.
 
-1. Since the time index column cannot be changed after the table is created, you need to choose the time index column
-   carefully. The time index is best set to the natural timestamp when the data is generated, as it provides the most
-   intuitive way to query the data, and the best query performance. For example, in the IOT scenes, you can use the
-   collection time of sensor data as the time index; or the occurrence time of an event in the observability scenes.
-2. In this migration process, it's not recommend to create another synthetic timestamp, such as a new column created
-   with `DEFAULT current_timestamp()` as the time index column. It's not recommend to use the random timestamp as the
-   time index either.
-3. It's vital to set the most fit timestamp precision for your time index column, too. Like the chosen of time index
-   column, the precision of it cannot be changed as well. Find the most fit timestamp type for your
-   data set [here](/reference/sql/data-types#data-types-compatible-with-mysql-and-postgresql).
-4. Choose a primary key only when it is truly needed. The primary key in GreptimeDB is different from that in MySQL. You should use a primary key only when:
-    * Most queries can benefit from the ordering.
-    * You need to deduplicate (including delete) rows by the primary key and time index.
+The time-index type and precision cannot be changed in place, so test the schema with representative rows before the full import:
 
-    Otherwise, setting a primary key is optional and it may hurt performance. Read [Primary Key](/user-guide/deployments-administration/performance-tuning/design-table.md#primary-key) for details.
-    
-    Finally please refer to "[CREATE](/reference/sql/create.md)" SQL document for more details for choosing the
-right data types and "ttl" or "compaction" options, etc.
-5. Choose proper indexes to speed up queries.
-    * Inverted index: is ideal for filtering by low-cardinality columns and quickly finding rows with specific values.
-    * Skipping index: works well with sparse data.
-    * Fulltext index: enables efficient keyword and pattern search in large text columns.
+```sql
+DESC TABLE db1.foo;
+SHOW CREATE TABLE db1.foo;
+```
 
-    For details and best practices, refer to the [data index](user-guide/manage-data/data-index.md) documentation.
-### Write data to both GreptimeDB and MySQL simultaneously
+## Export row data
 
-Writing data to both GreptimeDB and MySQL simultaneously is a practical strategy to avoid data loss during migration. By
-utilizing MySQL's client libraries (JDBC + a MySQL driver), you can set up two client instances - one for GreptimeDB
-and another for MySQL. For guidance on writing data to GreptimeDB using SQL, please refer to the [Ingest Data](/user-guide/ingest-data/for-iot/sql.md) section.
-
-If retaining all historical data isn't necessary, you can simultaneously write data to both GreptimeDB and MySQL for a
-specific period to accumulate the required recent data. Subsequently, cease writing to MySQL and continue exclusively
-with GreptimeDB. If a complete migration of all historical data is needed, please proceed with the following steps.
-
-### Export data from MySQL
-
-[mysqldump](https://dev.mysql.com/doc/refman/8.4/en/mysqldump.html) is a commonly used tool to export data from MySQL.
-Using it, we can export the data that can be later imported into GreptimeDB directly. For example, if we want to export
-two databases, `db1` and `db2` from MySQL, we can use the following command:
+The following example exports one InnoDB table while source writes are stopped. `--single-transaction` provides a consistent snapshot for transactional tables; it does not make non-transactional tables consistent. `--skip-extended-insert` writes one row per `INSERT`, and the `awk` filter keeps only statements intended for GreptimeDB.
 
 ```bash
-mysqldump -h127.0.0.1 -P3306 -umysql_user -p --compact -cnt --skip-extended-insert --databases db1 db2 > /path/to/output.sql
+set -o pipefail
+
+mysqldump \
+  --host=127.0.0.1 \
+  --port=3306 \
+  --user=mysql_user \
+  --password \
+  --single-transaction \
+  --compact \
+  --no-create-info \
+  --complete-insert \
+  --skip-extended-insert \
+  db1 foo | awk '/^INSERT INTO /' > foo.sql
 ```
 
-Replace the `-h`, `-P` and `-u` flags with the appropriate values for your MySQL server. The `--databases` flag is used
-to specify the databases to be exported. The output will be written to the `/path/to/output.sql` file.
+Export tables separately when they require different cutoff conditions or transformations. Inspect `foo.sql` before import. It should contain only column-qualified `INSERT` statements whose literals and column names are valid in the target schema.
 
-The content in the `/path/to/output.sql` file should be like this:
+## Import into GreptimeDB
 
-```plaintext
-~ ❯ cat /path/to/output.sql
-
-USE `db1`;
-INSERT INTO `foo` (`ts`, `a`, `b`) VALUES (1,'hello',1);
-INSERT INTO ...
-
-USE `db2`;
-INSERT INTO `foo` (`ts`, `a`, `b`) VALUES (2,'greptime',2);
-INSERT INTO ...
-```
-
-### Import data into GreptimeDB
-
-The [MySQL Command-Line Client](https://dev.mysql.com/doc/refman/8.4/en/mysql.html) can be used to import data into
-GreptimeDB. Continuing the above example, say the data is exported to file `/path/to/output.sql`, then we can use the
-following command to import the data into GreptimeDB:
+Use the MySQL client against GreptimeDB's MySQL port, which defaults to `4002`:
 
 ```bash
-mysql -h127.0.0.1 -P4002 -ugreptime_user -p -e "source /path/to/output.sql"
+mysql \
+  --host=127.0.0.1 \
+  --port=4002 \
+  --user=greptime_user \
+  --password \
+  --database=db1 \
+  < foo.sql
 ```
 
-Replace the `-h`, `-P` and `-u` flags with the appropriate values for your GreptimeDB server. The `source` command is
-used to execute the SQL commands in the `/path/to/output.sql` file. Add `-vvv` to see the detailed execution results for
-debugging purpose.
+Do not use the MySQL client's `--force` option: it continues after SQL errors and can leave a partial import looking successful. Capture the command exit status and import logs. For large tables, split the export on stable time or key boundaries and record each completed range.
 
-To summarize, data migration steps can be illustrate as follows:
+## Validate and cut over
 
-![migrate mysql data steps](/migration-mysql.jpg)
+Compare source and target over the same immutable boundary:
 
-After the data migration is completed, you can stop writing data to MySQL and continue using GreptimeDB exclusively!
+- Row count, minimum and maximum timestamp
+- Non-null counts for important fields
+- Counts grouped by business keys or time windows
+- Sampled rows, including nulls, Unicode, binary values, and boundary timestamps
+- Results of application-critical queries
 
-If you need a more detailed migration plan or example scripts, please provide the specific table structure and data volume. The [GreptimeDB official community](https://github.com/orgs/GreptimeTeam/discussions) will offer further support. Welcome to join the [Greptime Slack](http://greptime.com/slack).
+Only switch reads and writes after the import completes without errors and these checks pass. Keep the source unchanged until the rollback window closes.

--- a/docs/user-guide/migrate-to-greptimedb/migrate-from-postgresql.md
+++ b/docs/user-guide/migrate-to-greptimedb/migrate-from-postgresql.md
@@ -1,145 +1,82 @@
 ---
-keywords: [migrate from PostgreSQL, create databases, write data, export data, import data]
-description: Step-by-step guide on migrating from PostgreSQL to GreptimeDB, including creating databases, writing data, exporting and importing data.
+keywords: [migrate from PostgreSQL, pg_dump, psql, PostgreSQL protocol, data validation]
+description: Migrate compatible PostgreSQL table data to GreptimeDB with an explicit consistency boundary and fail-fast import.
 ---
 
 # Migrate from PostgreSQL
 
-This document will guide you through the migration process from PostgreSQL to GreptimeDB.
+GreptimeDB implements the PostgreSQL wire protocol, not the PostgreSQL storage engine or full SQL dialect. A PostgreSQL schema dump can contain DDL, session settings, extensions, constraints, and types that GreptimeDB does not support. Create the GreptimeDB schema first and export only compatible row data.
 
-## Before you start the migration
+## Plan the migration
 
-Please be aware that though GreptimeDB supports the wire protocol of PostgreSQL, it does not mean GreptimeDB implements
-all
-PostgreSQL's features. You may refer to:
-* The [ANSI Compatibility](/reference/sql/compatibility.md) to see the constraints regarding using SQL in GreptimeDB.
-* The [Data Modeling Guide](/user-guide/deployments-administration/performance-tuning/design-table.md) to create proper table schemas.
-* The [Data Index Guide](/user-guide/manage-data/data-index.md) for index planning.
+Before exporting data:
 
+- Check [SQL compatibility](/reference/sql/compatibility.md) and map PostgreSQL-specific types and expressions.
+- Choose a natural event-time column as the GreptimeDB time index and select its precision before creating the table.
+- Design GreptimeDB primary keys and indexes from the target query workload. They do not reproduce PostgreSQL uniqueness or B-tree semantics. See [Table design](/user-guide/deployments-administration/performance-tuning/design-table.md) and [Indexes](/user-guide/manage-data/data-index.md).
+- Define an exact source boundary. A short read-only window is the simplest safe method for this dump-based procedure.
 
-## Migration steps
+Application dual-write is not atomic. If downtime is unacceptable, use CDC or a dual-write process that records a PostgreSQL source position, retries both destinations, and reconciles differences before cutover. Two independent JDBC connections do not provide a cross-database transaction.
 
-### Create the databases and tables in GreptimeDB
+## Create the target schema
 
-Before migrating the data from PostgreSQL, you first need to create the corresponding databases and tables in
-GreptimeDB.
-GreptimeDB has its own SQL syntax for creating tables, so you cannot directly reuse the table creation SQLs that are
-produced
-by PostgreSQL.
+Create the databases and tables in GreptimeDB before importing rows. Translate PostgreSQL defaults, generated columns, arrays, range types, JSON operators, constraints, and indexes where necessary.
 
-When you write the table creation SQL for GreptimeDB, it's important to understand
-its "[data model](/user-guide/concepts/data-model.md)" first. Then, please take the following considerations in
-your create table SQL:
+Test the mapping with representative values and inspect the resulting schema:
 
-1. Since the time index column cannot be changed after the table is created, you need to choose the time index column
-   carefully. The time index is best set to the natural timestamp when the data is generated, as it provides the most
-   intuitive way to query the data, and the best query performance. For example, in the IOT scenes, you can use the
-   collection time of sensor data as the time index; or the occurrence time of an event in the observability scenes.
-2. In this migration process, it's not recommend to create another synthetic timestamp, such as a new column created
-   with `DEFAULT current_timestamp()` as the time index column. It's not recommend to use the random timestamp as the
-   time index either.
-3. It's vital to set the most fit timestamp precision for your time index column, too. Like the chosen of time index
-   column, the precision of it cannot be changed as well. Find the most fit timestamp type for your
-   data set [here](/reference/sql/data-types#data-types-compatible-with-mysql-and-postgresql).
-4. Choose a primary key only when it is truly needed. The primary key in GreptimeDB is different from that in PostgreSQL. You should use a primary key only when:
-    * Most queries can benefit from the ordering.
-    * You need to deduplicate (including delete) rows by the primary key and time index.
-    
-    Otherwise, setting a primary key is optional and it may hurt performance. Read [Primary Key](/user-guide/deployments-administration/performance-tuning/design-table.md#primary-key) for details.
-    
-    Finally please refer to "[CREATE](/reference/sql/create.md)" SQL document for more details for choosing the
-right data types and "ttl" or "compaction" options, etc.
-5. Choose proper indexes to speed up queries.
-    * Inverted index: is ideal for filtering by low-cardinality columns and quickly finding rows with specific values.
-    * Skipping index: works well with sparse data.
-    * Fulltext index: enables efficient keyword and pattern search in large text columns.
+```sql
+DESC TABLE db1.foo;
+SHOW CREATE TABLE db1.foo;
+```
 
-    For details and best practices, refer to the [data index](user-guide/manage-data/data-index.md) documentation.
+## Export row data
 
-### Write data to both GreptimeDB and PostgreSQL simultaneously
-
-Writing data to both GreptimeDB and PostgreSQL simultaneously is a practical strategy to avoid data loss during
-migration. By utilizing PostgreSQL's client libraries (JDBC + a PostgreSQL driver), you can set up two client
-instances - one for GreptimeDB and another for PostgreSQL. For guidance on writing data to GreptimeDB using SQL, please
-refer to the [Ingest Data](/user-guide/ingest-data/for-iot/sql.md) section.
-
-If retaining all historical data isn't necessary, you can simultaneously write data to both GreptimeDB and PostgreSQL
-for a specific period to accumulate the required recent data. Subsequently, cease writing to PostgreSQL and continue
-exclusively with GreptimeDB. If a complete migration of all historical data is needed, please proceed with the following
-steps.
-
-### Export data from PostgreSQL
-
-[pg_dump](https://www.postgresql.org/docs/current/app-pgdump.html) is a commonly used tool to export data from
-PostgreSQL. Using it, we can export the data that can be later imported into GreptimeDB directly. For example, if we
-want to export schemas whose names start with `db` in the database `postgres` from PostgreSQL, we can use the following
-command:
+`pg_dump --column-inserts` is intended for moving data to a non-PostgreSQL database, but its output also contains PostgreSQL-specific setup statements. The following example exports one table while source writes are stopped and keeps only column-qualified `INSERT` statements:
 
 ```bash
-pg_dump -h127.0.0.1 -p5432 -Upostgres -ax --column-inserts --no-comments -n 'db*' postgres | grep -v "^SE" > /path/to/output.sql
+set -o pipefail
+
+pg_dump \
+  --host=127.0.0.1 \
+  --port=5432 \
+  --username=postgres \
+  --data-only \
+  --column-inserts \
+  --no-owner \
+  --no-privileges \
+  --table='db1.foo' \
+  postgres | awk '/^INSERT INTO /' > foo.sql
 ```
 
-Replace the `-h`, `-p` and `-U` flags with the appropriate values for your PostgreSQL server. The `-n` flag is used to
-specify the schemas to be exported. And the database `postgres` is at the end of the `pg_dump` command line. Note that we pipe the `pg_dump` output through a special
-`grep`, to remove some unnecessary `SET` or `SELECT` lines. The final output will be written to the
-`/path/to/output.sql` file.
+This allowlist is intentional. The previous pattern of removing every line beginning with `SE` was unsafe because broad prefix filtering can discard valid content. Inspect `foo.sql` and transform unsupported literals or types before import.
 
-The content in the `/path/to/output.sql` file should be like this:
+For large tables, export bounded ranges with an ETL query or tool rather than creating one unbounded SQL file. Record every completed boundary so retries do not silently duplicate or skip rows.
 
-```plaintext
-~ ❯ cat /path/to/output.sql
+## Import into GreptimeDB
 
---
--- PostgreSQL database dump
---
-
--- Dumped from database version 16.4 (Debian 16.4-1.pgdg120+1)
--- Dumped by pg_dump version 16.4
-
-
---
--- Data for Name: foo; Type: TABLE DATA; Schema: db1; Owner: postgres
---
-
-INSERT INTO db1.foo (ts, a) VALUES ('2024-10-31 00:00:00', 1);
-INSERT INTO db1.foo (ts, a) VALUES ('2024-10-31 00:00:01', 2);
-INSERT INTO db1.foo (ts, a) VALUES ('2024-10-31 00:00:01', 3);
-INSERT INTO ...
-
-
---
--- Data for Name: foo; Type: TABLE DATA; Schema: db2; Owner: postgres
---
-
-INSERT INTO db2.foo (ts, b) VALUES ('2024-10-31 00:00:00', '1');
-INSERT INTO db2.foo (ts, b) VALUES ('2024-10-31 00:00:01', '2');
-INSERT INTO db2.foo (ts, b) VALUES ('2024-10-31 00:00:01', '3');
-INSERT INTO ...
-
-
---
--- PostgreSQL database dump complete
---
-```
-
-### Import data into GreptimeDB
-
-The [psql -- PostgreSQL interactive terminal](https://www.postgresql.org/docs/current/app-psql.html) can be used to
-import data into GreptimeDB. Continuing the above example, say the data is exported to file `/path/to/output.sql`, then
-we can use the following command to import the data into GreptimeDB:
+Use `psql` against GreptimeDB's PostgreSQL port, which defaults to `4003`. `-X` ignores local `psqlrc` settings, and `ON_ERROR_STOP` makes the command fail on the first SQL error:
 
 ```bash
-psql -h127.0.0.1 -p4003 -d public -f /path/to/output.sql
+psql \
+  -X \
+  --set ON_ERROR_STOP=1 \
+  --host=127.0.0.1 \
+  --port=4003 \
+  --username=greptime_user \
+  --dbname=public \
+  --file=foo.sql
 ```
 
-Replace the `-h` and `-p` flags with the appropriate values for your GreptimeDB server. The `-d` of the psql command is used to specify the database and cannot be omitted. The value `public` of `-d` is the default database used by GreptimeDB. You can also add `-a` to the end to see every
-executed line, or `-s` for entering the single-step mode.
+Do not remove `ON_ERROR_STOP`. Continuing after a failed row can produce a partial import without a clear failure boundary. Capture the exit status and import log.
 
-To summarize, data migration steps can be illustrate as follows:
+## Validate and cut over
 
-![migrate postgresql data steps](/migration-postgresql.jpg)
+Compare PostgreSQL and GreptimeDB over the same immutable source boundary:
 
-After the data migration is completed, you can stop writing data to PostgreSQL and continue using GreptimeDB
-exclusively!
+- Row count, minimum and maximum timestamp
+- Non-null counts and distinct counts for important dimensions
+- Counts grouped by business keys or time windows
+- Sampled rows covering nulls, time zones, numeric boundaries, Unicode, JSON, and binary values
+- Results of application-critical queries after SQL translation
 
-If you need a more detailed migration plan or example scripts, please provide the specific table structure and data volume. The [GreptimeDB official community](https://github.com/orgs/GreptimeTeam/discussions) will offer further support. Welcome to join the [Greptime Slack](http://greptime.com/slack).
+Switch traffic only after the import finishes without errors and the checks pass. Keep the PostgreSQL source unchanged until the rollback window closes.

--- a/docs/user-guide/migrate-to-greptimedb/migrate-from-prometheus.md
+++ b/docs/user-guide/migrate-to-greptimedb/migrate-from-prometheus.md
@@ -23,7 +23,7 @@ For detailed information on querying data in GreptimeDB using Prometheus query l
 
 <div id="grafana">
 
-To add GreptimeDB as a Prometheus data source in Grafana, please refer to the [Grafana](/user-guide/integrations/grafana.md#prometheus-data-source) documentation.
+To add GreptimeDB as a Prometheus data source in Grafana, follow the [Grafana data-source configuration](/user-guide/integrations/grafana.md#prometheus-data-source).
 
 </div>
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/db-cloud-shared/migrate/_migrate-from-prometheus.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/db-cloud-shared/migrate/_migrate-from-prometheus.md
@@ -1,31 +1,56 @@
-GreptimeDB 可以用来存储 [Prometheus](https://prometheus.io/) 的时间序列数据。
-此外，GreptimeDB 通过其 HTTP API 支持 Prometheus 查询语言。
-这可以使你轻松将 Prometheus 的 long-term storage 切换到 GreptimeDB。
+GreptimeDB 可以接收 Prometheus Remote Write Sample，并实现 Prometheus HTTP Query API。这些能力支持逐步迁移新增 Sample 和兼容的 PromQL Workload，但不能直接导入 Prometheus TSDB Block。
 
-## 数据模型的区别
+## 先检查兼容性
 
-要了解 Prometheus 和 GreptimeDB 数据模型之间的差异，请参阅 Ingest Data 文档中的[数据模型](/user-guide/ingest-data/for-observability/prometheus.md#data-model)部分。
+检查 [Prometheus 数据模型映射](/user-guide/ingest-data/for-observability/prometheus.md#数据模型)，并梳理：
 
-## Prometheus Remote Write
+- Scrape Job、External Label、Relabeling 和 Recording Rule
+- Alert Rule 及其使用的全部 PromQL 函数
+- Grafana Dashboard、Variable、Exemplar 和 Data Source 设置
+- 当前保留时间，以及迁移后仍需查询的历史范围
+
+GreptimeDB 通过 HTTP API 支持 PromQL，但这不保证每条 Rule 或 Dashboard 的行为完全一致。切换前，应使用相同的时间范围和 Label 集合测试关键表达式。
+
+## 使用 Remote Write 发送新增 Sample
 
 <InjectContent id="remote-write" content={props.children}/>
 
-## Prometheus HTTP API 与 PromQL
+在保留 Prometheus 本地存储和现有 Remote Destination 的同时，把 GreptimeDB 添加为另一个 `remote_write` 目标。Remote Write 从 Prometheus WAL 读取 Sample；启用后不会重新发送完整的历史 TSDB 数据。
 
-GreptimeDB 通过其 HTTP API 支持 Prometheus 查询语言 (PromQL)。
+双路径运行期间监控 Prometheus Remote Write Queue，重点观察待发送 Sample、失败和重试 Sample、Queue Lag、CPU、内存和网络饱和度。未发送 Sample 超出 WAL 保留范围后可能丢失，因此持续失败的 Queue 是数据丢失风险，而不只是发送延迟。参见 [Prometheus Remote Write 调优指南](https://prometheus.io/docs/practices/remote_write/)。
+
+对比两个系统中的近期数据：
+
+- 重要 Job 的 Series 数量和 Label 集合
+- 最小和最大 Sample 时间戳
+- 选定 Series 的原始 Sample
+- 固定时间范围内的 Recording Rule 和 Alert 表达式
+- Prometheus 或 GreptimeDB 重启期间的缺失 Sample 情况
+
+## 使用 PromQL 查询
+
+GreptimeDB 通过 Prometheus HTTP API 提供 PromQL 查询。
+
 <InjectContent id="promql" content={props.children}/>
 
-## 使用 Grafana 可视化数据
+迁移期间保持原 Prometheus 可查询。使用相同的 `time`、`start`、`end` 和 `step` 参数分别执行关键 Instant Query 和 Range Query，再比较数值、Label 和空 Series 行为。
 
-对于习惯使用 Grafana 可视化 Prometheus 数据的开发人员，你可以继续使用相同的 Grafana 仪表板来可视化存储在 GreptimeDB 中的数据。
+## 迁移 Grafana Dashboard
+
 <InjectContent id="grafana" content={props.children}/>
 
-## 参考阅读
+先复制一份 Prometheus Data Source 并指向 GreptimeDB，完成 Dashboard 测试后再切换生产 Data Source。使用兼容 PromQL 的 Dashboard 可能无需修改，但 Label 差异、不支持的函数、Exemplar 或 Metadata API 都可能需要调整。Alert 应与 Dashboard Panel 分开验证。
 
-请参考以下博客文章查看 GreptimeDB 与 Prometheus 的集成教程及用户故事：
+## 处理已有历史数据
 
-- [如何配置 GreptimeDB 作为 Prometheus 的长期存储](https://greptime.com/blogs/2024-08-09-prometheus-backend-tutorial)
-- [Scale Prometheus：K8s 部署 GreptimeDB 集群作为 Prometheus 长期存储](https://greptime.com/blogs/2024-10-07-scale-prometheus)
-- [「用户故事」从 Thanos 到 GreptimeDB，我们实现了 Prometheus 高效长期存储](https://greptime.com/blogs/2024-10-16-thanos-migration-to-greptimedb)
+GreptimeDB 不能直接导入 Prometheus TSDB Block 目录。可以选择：
 
-如果您需要更详细的迁移方案或示例脚本，请提供具体的表结构和数据量信息。[GreptimeDB 官方社区](https://github.com/orgs/GreptimeTeam/discussions)将为您提供进一步的支持。欢迎加入 [Greptime Slack](http://greptime.com/slack) 社区交流。
+- 保持旧 Prometheus 或长期存储只读，直到所需历史保留窗口结束。
+- 使用经过测试的 Remote Write 兼容工具重放历史 Sample，并保留原始时间戳和 Label。
+- 只迁移新增 Sample，在过渡期间为新旧时间范围保留不同 Data Source。
+
+按有限时间范围回填，记录进度，并在每个范围完成后比较数量和查询结果。不要让没有进度记录的历史回填与实时 Remote Write 重叠，否则重复或冲突 Sample 很难对账。
+
+## 切换
+
+只有实时 Remote Write 已追平，而且关键查询、Dashboard 和 Alert 均通过对比后，才能切换读流量。在覆盖所需历史范围和约定观察期之前，保留旧查询 Endpoint 和回滚路径。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/db-cloud-shared/migrate/migrate-from-influxdb.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/db-cloud-shared/migrate/migrate-from-influxdb.md
@@ -24,7 +24,7 @@ SHOW CREATE TABLE measurement_name;
 
 ## 数据库连接信息
 
-在写入或查询数据之前，需要了解 InfluxDB 和 GreptimeDB 之间的数据库连接信息的差异。
+配置 Client 时使用以下连接信息映射：
 
 - **Token**：InfluxDB API 中的 token 用于身份验证，与 GreptimeDB 身份验证相同。
   当使用 InfluxDB 的客户端库或 HTTP API 与 GreptimeDB 交互时，你可以使用 `<greptimedb_user:greptimedb_password>` 作为 token。
@@ -38,8 +38,7 @@ SHOW CREATE TABLE measurement_name;
 
 ## 写入数据
 
-GreptimeDB 兼容 InfluxDB 的行协议格式，包括 v1 和 v2。
-这意味着你可以轻松地从 InfluxDB 迁移到 GreptimeDB。
+GreptimeDB 通过兼容 v1 和 v2 的写入 Endpoint 接收 InfluxDB Line Protocol。
 
 ### HTTP API
 
@@ -60,15 +59,13 @@ GreptimeDB 支持 InfluxDB 行协议也意味着 GreptimeDB 与 Telegraf 兼容�
 
 ### 客户端库
 
-使用 InfluxDB 客户端库写入数据到 GreptimeDB 非常直接且简单。
-你只需在客户端配置中包含 URL 和身份验证信息。
+InfluxDB Client Library 的 URL、Database 和认证设置指向兼容 Endpoint 后，可以向 GreptimeDB 写入数据。
 
 例如：
 
 <InjectContent id="write-data-client-libs" content={props.children}/>
 
-除了上述语言之外，GreptimeDB 还支持其他 InfluxDB 支持的客户端库。
-你可以通过参考上面提供的连接信息代码片段，使用你喜欢的语言编写代码。
+其他 InfluxDB Client Library 可以使用相同的连接信息映射。应确认 Client 向受支持的写入 Endpoint 发送 Line Protocol，而不是依赖 InfluxDB Management 或 Query API。
 
 ## 查询数据
 
@@ -152,21 +149,21 @@ max_over_time(monitor{__field__="cpu"}[1h])
 
 ## 迁移数据
 
-你可以通过以下步骤实现从 InfluxDB 到 GreptimeDB 的数据无缝迁移：
+迁移应使用明确的截止边界和校验流程：
 
-![Double write to GreptimeDB and InfluxDB](/migrate-influxdb-to-greptimedb.drawio.svg)
-
-1. 同时将数据写入 GreptimeDB 和 InfluxDB，以避免迁移过程中的数据丢失。
-2. 从 InfluxDB 导出所有历史数据，并将数据导入 GreptimeDB。
+1. 定义源端时间边界，启动新的写入路径，并分别记录每个目标的写入失败。
+2. 导出并导入该边界之前的历史范围。
 3. 验证表结构、行数、时间范围和关键查询结果。
 4. 将读流量逐步切换到 GreptimeDB。
 5. 验证通过后停止向 InfluxDB 写入数据。
 
 ### 双写 GreptimeDB 和 InfluxDB
 
-将数据双写 GreptimeDB 和 InfluxDB 是迁移过程中防止数据丢失的有效策略。
+双写可以降低切换停机时间，但两次写入不具备原子性。
 当使用 InfluxDB 的[客户端库](#client-libraries)时，你可以建立两个客户端实例，一个用于 GreptimeDB，另一个用于 InfluxDB。
 有关如何使用 InfluxDB 行协议将数据写入 GreptimeDB 的操作，请参考[写入数据](#write-data)部分。
+
+应分别记录和重试每个目标的失败写入。截止位置应根据稳定的源端进度确定，不能只使用开始双写时的系统时间，因为迟到事件的时间戳可能早于双写开始时间。停用源端写入前，对账重叠范围和全部失败记录。
 
 如果无需保留所有历史数据，
 你可以双写一段时间以积累所需的最新数据，
@@ -185,7 +182,7 @@ mkdir -p /path/to/export
 
 ```shell
 influx_inspect export \
-  -database <db-name> \ 
+  -database <db-name> \
   -end <end-time> \
   -lponly \
   -datadir /var/lib/influxdb/data \
@@ -196,7 +193,7 @@ influx_inspect export \
 - `-database` 指定要导出的数据库。
 - `-end` 指定要导出的数据的结束时间。
 必须是[RFC3339 格式](https://datatracker.ietf.org/doc/html/rfc3339)，例如 `2024-01-01T00:00:00Z`。
-你可以使用同时写入 GreptimeDB 和 InfluxDB 时的时间戳作为结束时间。
+使用约定的历史截止点作为结束时间。如果迟到写入可能落在该时间戳之前，应暂停源端写入，或者对受影响范围再次导出并对账。
 - `-lponly` 指定只导出行协议数据。
 - `-datadir` 指定数据目录的路径，请见[InfluxDB 数据设置](https://docs.influxdata.com/influxdb/v1/administration/config/#data-settings)中的配置。
 - `-waldir` 指定 WAL 目录的路径，请见[InfluxDB 数据设置](https://docs.influxdata.com/influxdb/v1/administration/config/#data-settings)中的配置。
@@ -233,7 +230,7 @@ influxd inspect export-lp \
 - `--engine-path` 指定引擎目录的路径，请见[InfluxDB 数据设置](https://docs.influxdata.com/influxdb/v2.0/reference/config-options/#engine-path)中的配置。
 - `--end` 指定要导出的数据的结束时间。
 必须是[RFC3339 格式](https://datatracker.ietf.org/doc/html/rfc3339)，例如 `2024-01-01T00:00:00Z`。
-你可以使用同时写入 GreptimeDB 和 InfluxDB 时的时间戳作为结束时间。
+使用约定的历史截止点作为结束时间。如果迟到写入可能落在该时间戳之前，应暂停源端写入，或者对受影响范围再次导出并对账。
 - `--output-path` 指定输出目录。
 
 命令行的执行结果类似如下：
@@ -262,7 +259,7 @@ cpu,cpu=cpu-total,host=bogon usage_iowait=0 1714375710000000000
 split -l 100000 -d -a 10 data data.
 # -l [line_count]    创建长度为 line_count 行的拆分文件。
 # -d                 使用数字后缀而不是字母后缀。
-# -a [suffix_length] 使用 suffix_length 个字母来形成文件名的后缀。
+# -a [suffix_length] 使用 suffix_length 位数字作为文件名后缀。
 ```
 
 你可以使用 HTTP API 导入数据，如[写入数据](#写入数据)部分所述。
@@ -310,5 +307,3 @@ ORDER BY row_count DESC;
 ```
 
 逐步切换读流量期间应保持双写。只有上述检查和应用关键查询均符合预期后，才能停止向 InfluxDB 写入数据。
-
-如果您需要更详细的迁移方案或示例脚本，请提供具体的表结构和数据量信息。[GreptimeDB 官方社区](https://github.com/orgs/GreptimeTeam/discussions)将为您提供进一步的支持。欢迎加入 [Greptime Slack](http://greptime.com/slack) 社区交流。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/migrate-to-greptimedb/migrate-from-clickhouse.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/migrate-to-greptimedb/migrate-from-clickhouse.md
@@ -1,245 +1,119 @@
 ---
-keywords: [从 ClickHouse 迁移, ClickHouse, GreptimeDB, 写入数据, 导出数据, 导入数据, 数据迁移]
-description: 分步指南，指导如何从 ClickHouse 迁移到 GreptimeDB，包括数据模型调整、表结构重建、数据导出与导入等操作。
+keywords: [从 ClickHouse 迁移, ClickHouse, CSV, COPY FROM, 迁移校验]
+description: 为 GreptimeDB 重新设计 ClickHouse 表，并通过 CSV 或对象存储迁移有明确边界的数据集。
 ---
 
 # 从 ClickHouse 迁移
 
-本指南详细介绍如何将业务平滑迁移自 ClickHouse 到 GreptimeDB，涵盖迁移前的准备、数据模型调整、表结构重构、双写保障以及数据导出与导入的具体方法，帮助实现系统的无缝切换。
+ClickHouse 和 GreptimeDB 使用不同的 SQL 方言、表模型、索引和存储引擎。迁移时应重新设计 Schema 并转换数据，不能直接恢复 ClickHouse DDL 或数据文件。
 
-## 迁移前须知
+## 定义迁移边界
 
-- **兼容性**
-  虽然 GreptimeDB 支持 SQL 协议，但与 ClickHouse 在数据建模、索引设计和压缩机制等方面存在根本差异。请查阅 [SQL 兼容性](/reference/sql/compatibility.md) 文档以及官方[建模建议](/user-guide/deployments-administration/performance-tuning/design-table.md)，在迁移过程中重构表结构与数据流。
+导出前选择一种方式：
 
-- **数据模型差异**
-  ClickHouse 属于通用大数据分析引擎，GreptimeDB 则重点优化时序、指标及日志可观测场景。两者在数据模型、索引体系与压缩算法等方面均有差别，模型设计时需充分考虑业务场景及兼容性。
+- 最终导出和导入期间停止源端写入。
+- 导出一个不可变的时间范围，并从该范围边界开始使用新的写入路径。
+- 使用能够记录源端位置并对账失败记录的 CDC 或应用双写流程。
 
----
+应用双写是两次独立写入，不是跨数据库事务。只有记录、重试并对账失败时，双写才能降低切换停机时间。不能假设配置两个 Sink 就不会产生缺口或重复数据。
 
-## 重新设计数据模型与表结构
+## 重新设计表结构
 
-### 时间索引
-- ClickHouse 的表未必有 time index 字段，迁移时需明确选择业务主要的时间字段作为时间索引，并在 GreptimeDB 建表时指定，如日志记录时间/链路追踪时间等。
-- 时间精度（秒、毫秒、微秒等）应按实际需求选定，且一旦设定不可更改。
+先阅读 [SQL 兼容性](/reference/sql/compatibility.md)、[表结构设计](/user-guide/deployments-administration/performance-tuning/design-table.md)和[索引](/user-guide/manage-data/data-index.md)。重点处理以下差异：
 
-### 主键与宽表建议
-- 主键：类似 ClickHouse 的 `order by`，去掉时间戳列；但不建议包含 log_id、user_id 或 UUID 等高基数字段，以避免主键膨胀、写放大和低效查询。
-- 宽表 vs 多表：同一个观测点采集多种指标时建议采用宽表，有助于提升批量写入效率和压缩比。
+- 选择一个事件时间列作为 GreptimeDB Time Index，并在导出过程中保留其时区和精度。
+- 不要把 ClickHouse `ORDER BY` 机械复制为 GreptimeDB 主键。应根据目标端过滤、分组和行合并语义选择主键列。
+- 只有查询 Operator 和列适用时才添加倒排、跳数或全文索引。不能只根据基数决定索引类型。
+- 只有目标负载确实需要显式分片时，才把 ClickHouse `PARTITION BY` 转换为 GreptimeDB 表分区。
+- 把 ClickHouse TTL 表达式转换为 GreptimeDB Database 或 Table 的 `ttl` 选项。
+- 展开或转换 ClickHouse Array、Tuple、Map、Aggregate State 以及其他没有等价目标类型的数据。
 
-### 索引规划
-- 倒排索引：为低基数列建立索引，提高筛选效率。
-- 跳数索引：按需使用，适用于稀疏值或大表中偶尔查询的特定值。
-- 全文索引：按需使用，适用于字符串字段的文本检索，避免在高基数或高变动字段上建立无用索引。
-- 更多信息详见[数据索引](/user-guide/manage-data/data-index.md)。
+迁移 OpenTelemetry 日志和 Trace 时，优先使用 GreptimeDB 内置的[日志](/user-guide/logs/overview.md)和 [Trace](/user-guide/traces/overview.md) 数据模型，不要另建一套不兼容的 Schema。
 
-### 表分区
-ClickHouse 通过 `PARTITION BY` 语法支持分区，GreptimeDB 提供类似能力，语法不同，请参阅[表分片](/user-guide/deployments-administration/manage-data/table-sharding.md)文档。
+## 表结构映射示例
 
-### TTL
-GreptimeDB 支持通过表选项 `ttl` 设置生命周期，详见[使用 TTL 策略管理数据存储](/user-guide/manage-data/overview.md#使用-ttl-策略保留数据)。
+ClickHouse 源表：
 
-### 表结构举例
-
-ClickHouse 表：
 ```sql
 CREATE TABLE example (
- timestamp DateTime,
- host String,
- app String,
- metric String,
- value Float64
-) ENGINE = MergeTree()
+  timestamp DateTime,
+  host String,
+  app String,
+  metric String,
+  value Float64
+)
+ENGINE = MergeTree
 TTL timestamp + INTERVAL 30 DAY
 ORDER BY (timestamp, host, app, metric);
-````
+```
 
-GreptimeDB 推荐表结构：
+一种 GreptimeDB 目标表结构是：
 
 ```sql
 CREATE TABLE example (
- `timestamp` TIMESTAMP NOT NULL,
- host STRING,
- app STRING INVERTED INDEX,
- metric STRING INVERTED INDEX,
- `value` DOUBLE,
- PRIMARY KEY (host, app, metric),
- TIME INDEX (`timestamp`)
-) with(ttl='30d');
+  ts TIMESTAMP(3) NOT NULL,
+  host STRING,
+  app STRING,
+  metric STRING,
+  value DOUBLE,
+  PRIMARY KEY (host, app, metric),
+  TIME INDEX (ts)
+) WITH (ttl = '30d');
 ```
 
-> 主键及时间索引的选型应结合业务数据量及查询场景慎重设计。如果 host 基数很大（如百万级监控主机），可不做主键，改为跳数索引。
+这只是映射示例，不是通用建议。导出时把 `timestamp` 重命名为 `ts`；只有检查实际查询和更新语义后，才能确定主键或添加索引。
 
-### 典型日志表迁移
+## 导出有界数据
 
-> GreptimeDB 已内置 otel 日志建模方案，操作详见[官方文档](/user-guide/ingest-data/for-observability/opentelemetry.md#logs)。
+`CSVWithNames` 会写入 Header。显式选择并转换列，确保文件与目标 Schema 一致。下面的命令在 Client 所在机器写入 CSV，并排除切换边界及之后的数据：
 
-ClickHouse 日志表结构：
+```bash
+clickhouse-client \
+  --host <clickhouse-host> \
+  --query "
+    SELECT
+      timestamp AS ts,
+      host,
+      app,
+      metric,
+      value
+    FROM example
+    WHERE timestamp < toDateTime('2026-08-01 00:00:00', 'UTC')
+    ORDER BY timestamp
+    FORMAT CSVWithNames
+  " > example.csv
+```
+
+如果 ClickHouse `DateTime` 列使用其他时区，应使用源端时区而不是 `UTC`。大表应按互不重叠的时间范围导出，并记录每个文件的行数和边界。
+
+## 导入 GreptimeDB
+
+分布式 GreptimeDB 集群应先把文件上传到对象存储，再执行 `COPY FROM`。如果 CSV 列名与目标表不一致，`STRICT_HEADERS` 会在读取数据前失败：
 
 ```sql
-CREATE TABLE logs
- (
- timestamp      DateTime,
- host           String,
- service        String,
- log_level      String,
- log_message    String,
- trace_id       String,
- span_id        String,
- INDEX inv_idx(log_message)  TYPE ngrambf_v1(4, 1024, 1, 0) GRANULARITY 1
- ) ENGINE = MergeTree
- ORDER BY (timestamp, host, service);
+COPY example
+FROM 's3://migration-bucket/clickhouse/example.csv'
+WITH (
+  FORMAT = 'CSV',
+  HEADERS = 'true',
+  STRICT_HEADERS = 'true'
+)
+CONNECTION (REGION = 'us-west-2');
 ```
 
-推荐的 GreptimeDB 表结构：
+按需添加连接凭证，或者使用部署环境的 Credential Provider。Standalone 只能访问 `storage.copy_root` 内的本地路径；分布式部署禁用本地 SQL 文件访问。参见 [COPY FROM](/reference/sql/copy.md#copy-from)和[迁移本地 SQL 文件访问](/user-guide/deployments-administration/migrate-local-sql-file-access.md)。
 
--   时间索引：`timestamp`（根据日志频率选定精度）
--   主键：`host`, `service`（常用过滤/聚合字段）
--   字段列：`log_message`, `trace_id`, `span_id`（高基数、唯一标识或原始内容）
+迁移期间保持 `SKIP_BAD_RECORDS` 关闭。跳过转换失败的记录会让源端和目标端行数出现差异，而且无法确认丢失了哪些行。
 
-```sql
-CREATE TABLE logs (
- `timestamp` TIMESTAMP NOT NULL,
- host STRING,
- service STRING,
- log_level STRING,
- log_message STRING FULLTEXT INDEX WITH (
-        backend = 'bloom',
-        analyzer = 'English',
-        case_sensitive = 'false'
-    ),
- trace_id STRING SKIPPING INDEX,
- span_id STRING SKIPPING INDEX,
- PRIMARY KEY (host, service),
- TIME INDEX (`timestamp`)
-);
-```
+## 校验并切换
 
-**说明：**
+对每个导出范围比较：
 
--   `host` 和 `service` 作为常用过滤项列入主键，如主机数量非常多，可移出主键，改为跳数索引。
--   `log_message` 作为原始文本内容建立全文索引。**若要全文索引生效，查询时 SQL 语法也需调整，详见[日志检索文档](/user-guide/logs/fulltext-search.md)**。
--   `trace_id` 和 `span_id` 通常为高基数字段，建议仅做跳数索引。
+- 源端查询行数和已导入行数
+- 最小和最大事件时间
+- 重要维度的 NULL 数量和去重数量
+- 按应用实际使用的维度和时间窗口计算的聚合结果
+- 覆盖时区、Nullable 值、嵌套数据转换和数值边界的抽样数据
+- 改写后的 Dashboard、Alert 和应用查询结果
 
-
-### 典型链路表迁移
-
-> GreptimeDB 已内置 otel 链路建模方案，详见[官方文档](/user-guide/ingest-data/for-observability/opentelemetry.md#traces)。
-
-ClickHouse 链路表结构设计：
-
-```sql
-CREATE TABLE traces (
- timestamp DateTime,
- trace_id String,
- span_id String,
- parent_span_id String,
- service String,
- operation String,
- duration UInt64,
- status String,
- tags Map(String, String)
-) ENGINE = MergeTree()
-ORDER BY (timestamp, trace_id, span_id);
-```
-
-GreptimeDB 推荐表结构：
-
--   时间索引：`timestamp`（采集/起始时间）
--   主键：`service`, `operation`（常用过滤/聚合属性）
--   字段列：`trace_id`, `span_id`, `parent_span_id`, `duration`, `tags`（高基数或 Map 字段）
-
-```sql
-CREATE TABLE traces (
- `timestamp` TIMESTAMP NOT NULL,
- service STRING,
- operation STRING,
- `status` STRING,
- trace_id STRING SKIPPING INDEX,
- span_id STRING SKIPPING INDEX,
- parent_span_id STRING SKIPPING INDEX,
- duration DOUBLE,
- tags STRING,    -- 如为结构化 JSON 可原样存储，必要时用 Pipeline 展开字段
- PRIMARY KEY (service, operation),
- TIME INDEX (`timestamp`)
-);
-```
-
-**说明：**
-
--   `service` 与 `operation` 作为主键，便于链路调度和按服务聚合。
--   `trace_id`、`span_id`、`parent_span_id` 用跳数索引，不作为主键。
--   高基数字段仅作普通字段，便于写入效率；`tags` 推荐用字符串或 json，复杂属性可结合 [ETL Pipeline](/user-guide/logs/use-custom-pipelines.md) 展开。
--   若业务量极大可考虑多表分区（如多服务场景区分）。
-
-
-双写保障迁移策略
---------
-
-迁移期间，为避免数据丢失和写入不一致，建议采用双写：
-
--   应用需同时写入 ClickHouse 和 GreptimeDB，双系统并行。
--   通过日志和校验对比数据，可保证一致性，数据无误后再切换全部流量。
-
-历史数据导出与导入
----------
-
-1.  **迁移前开启双写** 应用同时写入 ClickHouse 和 GreptimeDB，校验数据一致性，减少数据缺失风险。
-    
-2.  **从 ClickHouse 导出数据** 利用 ClickHouse 命令将数据导出为 CSV、TSV、Parquet 等格式样例：
-    
-
-```sh
-clickhouse client --query="SELECT * FROM example INTO OUTFILE 'example.csv' FORMAT CSVWithNames"
-```
-
-导出的 CSV 内容类似：
-
-```csv
-"timestamp","host","app","metric","value"
-"2024-04-25 10:00:00","host01","nginx","cpu_usage",12.7
-"2024-04-25 10:00:00","host02","redis","cpu_usage",8.4
-...
-```
-
-3.  **导入数据到 GreptimeDB**
-
-> 需先在 GreptimeDB 创建好目标表。
-
-支持 SQL 命令批量导入，或用 [REST API](/reference/http-endpoints.md#协议端点) 分批导入大数据量。 可用 [`COPY FROM` 命令](/reference/sql/copy.md#copy-from)：
-
-```sql
-  COPY example FROM "/path/to/example.csv" WITH (FORMAT = 'CSV');
-```
-
-或转换为标准 INSERT 语句分批导入。
-
-
-验证与流量切换
--------
-
--   导入完成后，使用 GreptimeDB 查询接口与 ClickHouse 进行数据对比。
--   校验数据及监控无误后，可正式切换业务写入到 GreptimeDB，并关闭双写。
-
-
-常见问题与优化建议
----------
-
-### SQL/类型不兼容怎么办？
-
-迁移前需梳理所有查询 SQL 并按官方文档 ([SQL 查询](/user-guide/query-data/sql.md)、[日志检索](/user-guide/logs/fulltext-search.md)) 重写或翻译不兼容语法和类型。
-
-### 如何高效批量导入大规模数据？
-
-大表或历史全量数据建议分分区/分片导出导入，并密切监控速度和进度。
-
-### 高基数字段如何处理？
-
-避免作为主键，直接存为字段，必要时分表拆分。
-
-### 宽表如何规划？
-
-每个监控对象（采集端）建议聚合到单表，如 `host_metrics` 专表存储服务器所有指标。
-
-
-如果您需要更详细的迁移方案或示例脚本，请提供具体表结构和数据量信息。[GreptimeDB 官方社区](https://github.com/orgs/GreptimeTeam/discussions)将为您提供进一步支持。欢迎加入 [Greptime Slack](http://greptime.com/slack) 交流。
+所有范围和关键查询均通过校验后才能切换。回滚窗口结束前保持 ClickHouse 源端数据不变。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/migrate-to-greptimedb/migrate-from-influxdb.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/migrate-to-greptimedb/migrate-from-influxdb.md
@@ -3,7 +3,7 @@ keywords: [InfluxDB 迁移, 数据迁移, HTTP API, 数据写入, 客户端库]
 description: 指导用户从 InfluxDB 迁移到 GreptimeDB，包括使用 HTTP API 和客户端库写入数据的示例。
 ---
 
-import DocTemplate from '../../db-cloud-shared/migrate/migrate-from-influxdb.md' 
+import DocTemplate from '../../db-cloud-shared/migrate/migrate-from-influxdb.md'
 
 # 从 InfluxDB 迁移
 
@@ -19,9 +19,9 @@ import DocTemplate from '../../db-cloud-shared/migrate/migrate-from-influxdb.md'
 <TabItem value="InfluxDB line protocol v2" label="InfluxDB line protocol v2">
 
 ```shell
-curl -X POST 'http://<host>:4000/v1/influxdb/api/v2/write?bucket=<db-name>' \
+curl --fail-with-body -X POST 'http://<host>:4000/v1/influxdb/api/v2/write?bucket=<db-name>&precision=ns' \
   -H 'authorization: token <greptime_user:greptimedb_password>' \
-  -d 'census,location=klamath,scientist=anderson bees=23 1566086400000000000'
+  --data-binary 'census,location=klamath,scientist=anderson bees=23 1566086400000000000'
 ```
 
 </TabItem>
@@ -29,8 +29,8 @@ curl -X POST 'http://<host>:4000/v1/influxdb/api/v2/write?bucket=<db-name>' \
 <TabItem value="InfluxDB line protocol v1" label="InfluxDB line protocol v1">
 
 ```shell
-curl 'http://<host>:4000/v1/influxdb/write?db=<db-name>&u=<greptime_user>&p=<greptimedb_password>' \
-  -d 'census,location=klamath,scientist=anderson bees=23 1566086400000000000'
+curl --fail-with-body 'http://<host>:4000/v1/influxdb/write?db=<db-name>&u=<greptime_user>&p=<greptimedb_password>&precision=ns' \
+  --data-binary 'census,location=klamath,scientist=anderson bees=23 1566086400000000000'
 ```
 
 </TabItem>
@@ -70,6 +70,7 @@ const point1 = new Point('temperature')
   .tag('sensor_id', 'TLM01')
   .floatField('value', 24.0)
 writeApi.writePoint(point1)
+await writeApi.close()
 
 ```
 
@@ -98,6 +99,7 @@ write_api = client.write_api(write_options=SYNCHRONOUS)
 
 p = influxdb_client.Point("my_measurement").tag("location", "Prague").field("temperature", 25.3)
 write_api.write(bucket=bucket, org=org, record=p)
+client.close()
 
 ```
 
@@ -117,7 +119,9 @@ p := influxdb2.NewPoint("stat",
     map[string]string{"unit": "temperature"},
     map[string]interface{}{"avg": 24.5, "max": 45},
     time.Now())
-writeAPI.WritePoint(context.Background(), p)
+if err := writeAPI.WritePoint(context.Background(), p); err != nil {
+    log.Fatal(err)
+}
 client.Close()
 
 ```
@@ -186,11 +190,18 @@ $writeApi->write($point);
 
 
 ```shell
+set -euo pipefail
+
+: "${GREPTIME_USERNAME:?set GREPTIME_USERNAME}"
+: "${GREPTIME_PASSWORD:?set GREPTIME_PASSWORD}"
+: "${GREPTIME_HOST:?set GREPTIME_HOST}"
+: "${GREPTIME_DB:?set GREPTIME_DB}"
+
 for file in data.*; do
-  curl -i --retry 3 \
-    -X POST "http://${GREPTIME_HOST}:4000/v1/influxdb/write?db=${GREPTIME_DB}&u=${GREPTIME_USERNAME}&p=${GREPTIME_PASSWORD}" \
+  curl --fail-with-body --retry 3 \
+    -X POST "http://${GREPTIME_HOST}:4000/v1/influxdb/api/v2/write?bucket=${GREPTIME_DB}&precision=ns" \
+    -H "Authorization: token ${GREPTIME_USERNAME}:${GREPTIME_PASSWORD}" \
     --data-binary @"${file}"
-  sleep 1
 done
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/migrate-to-greptimedb/migrate-from-loki.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/migrate-to-greptimedb/migrate-from-loki.md
@@ -40,7 +40,7 @@ http{s}://<host>:4000/v1/loki/api/v1/push
 | --- | --- | --- |
 | `X-Greptime-DB-Name` | 否 | 目标数据库名，默认值为 `public`。 |
 | `X-Greptime-Log-Table-Name` | 否 | 目标日志表名，默认值为 `loki_logs`。 |
-| `Authorization` | 取决于部署 | 使用 Base64 编码的 `<username>:<password>` 进行 Basic 认证。 |
+| `Authorization` | 取决于部署 | `Basic <base64(username:password)>`。通常应通过 Client 的 Basic Auth 选项设置。 |
 | `X-Greptime-Pipeline-Name` 或 `X-Greptime-Log-Pipeline-Name` | 否 | 在写入前用于解析 Loki 条目的 Pipeline 名称。 |
 
 GreptimeDB 接受与 Loki 相同的 Push 请求体格式：
@@ -51,7 +51,7 @@ GreptimeDB 接受与 Loki 相同的 Push 请求体格式：
 以下 JSON 请求可用于快速检查连通性：
 
 ```bash
-curl -X POST "http://localhost:4000/v1/loki/api/v1/push" \
+curl --fail-with-body -X POST "http://localhost:4000/v1/loki/api/v1/push" \
   -H "Content-Type: application/json" \
   -H "X-Greptime-DB-Name: public" \
   -H "X-Greptime-Log-Table-Name: loki_demo_logs" \
@@ -73,6 +73,7 @@ curl -X POST "http://localhost:4000/v1/loki/api/v1/push" \
 ### 双写 Loki 和 GreptimeDB
 
 迁移期间，请同时写入 Loki 和 GreptimeDB，直到完成写入、保留策略、仪表盘和告警验证。
+两个 Sink 相互独立，一个 Sink 接收成功时另一个可能失败。应监控并保留各自的重试 Queue；双写不提供原子投递保证。
 
 以下 Alloy 示例保留现有 Loki sink，并新增一个 GreptimeDB Loki 兼容 sink：
 
@@ -247,7 +248,7 @@ transform:
 上传 Pipeline：
 
 ```bash
-curl -X POST "http://localhost:4000/v1/pipelines/zk_logs" \
+curl --fail-with-body -X POST "http://localhost:4000/v1/pipelines/zk_logs" \
   -F "file=@zk_pipeline.yaml"
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/migrate-to-greptimedb/migrate-from-mysql.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/migrate-to-greptimedb/migrate-from-mysql.md
@@ -1,103 +1,80 @@
 ---
-keywords: [MySQL 迁移, 数据迁移, 数据库创建, 数据导出, 数据导入]
-description: 指导用户从 MySQL 迁移到 GreptimeDB，包括创建数据库和表、双写策略、数据导出和导入等步骤。
+keywords: [MySQL 迁移, mysqldump, MySQL 协议, 数据校验]
+description: 使用明确的一致性边界和校验流程，把兼容的 MySQL 表数据迁移到 GreptimeDB。
 ---
 
 # 从 MySQL 迁移
 
-本文档将指引您完成从 MySQL 迁移到 GreptimeDB。
+GreptimeDB 实现了 MySQL Wire Protocol，但不是 MySQL 存储引擎，也不支持完整的 MySQL SQL 方言。因此不能直接恢复 MySQL Schema Dump；应先在 GreptimeDB 中创建表结构，再迁移兼容的行数据。
 
-## 在开始迁移之前
+## 规划迁移
 
-请注意，尽管 GreptimeDB 支持 MySQL 的协议，并不意味着 GreptimeDB 实现了 MySQL
-的所有功能。你可以参考
-- [ANSI 兼容性](/reference/sql/compatibility.md)查看在 GreptimeDB 中使用 SQL 的约束。
-- [数据建模指南](/user-guide/deployments-administration/performance-tuning/design-table.md)创建合适的表结构。
-- [数据索引指南](/user-guide/manage-data/data-index.md)用于索引规划。
+导出数据前：
 
-## 迁移步骤
+- 检查 [SQL 兼容性](/reference/sql/compatibility.md)，转换 GreptimeDB 不支持的 MySQL 类型和表达式。
+- 选择自然的事件时间作为 GreptimeDB Time Index。只有业务语义确实是写入时间时，才应另建写入时间列。
+- 根据 GreptimeDB 的查询负载设计主键和索引。GreptimeDB 主键不是 MySQL 唯一性约束。参见[表结构设计](/user-guide/deployments-administration/performance-tuning/design-table.md)和[索引](/user-guide/manage-data/data-index.md)。
+- 明确迁移的一致性边界。对于 SQL Dump 迁移，短暂停止源端写入是最简单且可靠的方式。
 
-### 在 GreptimeDB 中创建数据库和表
+应用双写不具备原子性：一个目标写入成功时，另一个目标可能失败。如果不能停机，应使用能够记录源端位置的 CDC 或双写流程，对每个目标独立重试，并在切换前对账缺失或冲突的数据。仅创建两个客户端连接不能防止数据丢失。
 
-在从 MySQL 迁移数据之前，你首先需要在 GreptimeDB 中创建相应的数据库和表。
-由于 GreptimeDB 有自己的 SQL 语法用于创建表，因此你不能直接重用 MySQL 生成的建表 SQL。
+## 创建目标表结构
 
-当你为 GreptimeDB 编写创建表的 SQL 时，首先请了解其“[数据模型](/user-guide/concepts/data-model.md)”。然后，在创建表的
-SQL 中请考虑以下几点：
+在 GreptimeDB 中创建目标数据库和表。列名应与数据 Dump 一致，但数据类型、默认值、生成列、索引和约束必须转换为 GreptimeDB 语法。
 
-1. 由于 time index 列在表创建后无法更改，所以你需要仔细选择 time index
-   列。时间索引最好设置为数据生成时的自然时间戳，因为它提供了查询数据的最直观方式，以及最佳的查询性能。例如，在 IOT
-   场景中，你可以使用传感器采集数据时的时间作为 time index；或者在可观测场景中使用事件的发生时间。
-2. 不建议在此迁移过程中另造一个时间戳用作时间索引，例如使用 `DEFAULT current_timestamp()` 创建的新列。也不建议使用具有随机时间戳的列。
-3. 选择合适的 time index 精度也至关重要。和 time index 的选择一样，一旦表创建完毕，time index
-   的精度就无法变更了。请根据你的数据集在[这里](/reference/sql/data-types.md#与-mysql-和-postgresql-兼容的数据类型)找到最适合的时间戳类型。
-4. 仅在真正需要时才选择主键。GreptimeDB 中的主键与 MySQL 中的主键不同。仅在以下情况下才应使用主键：
-    - 大部分查询可以受益于排序。
-    - 您需要通过主键和时间索引来删除重复行（包括删除）。 通常会被查询。标签列中的值是附加到收集源的标签，通常用于描述这些源的特定特征。标签列会被索引，从而使对它们的查询具有高性能。
-    
-    否则，设置主键是可选的，并且可能会损害性能。阅读[主键](/user-guide/deployments-administration/performance-tuning/design-table.md#主键)了解详情。
-    
-    最后，请参阅“[CREATE](/reference/sql/create.md)” SQL 文档，了解有关选择合适的数据类型和“ttl”或“compaction”选项等的更多详细信息。
-    
-5.  选择合适的索引以加快查询速度。
-    - 倒排索引：非常适合按低基数列进行过滤，并快速查找具有特定值的行。
-    - 跳数索引：适用于稀疏数据。
-    - 全文索引：可以在大型文本列中实现高效的关键字和模式搜索。
-    
-    有关详细信息和最佳实践，请参阅[数据索引](/user-guide/manage-data/data-index.md) 文档。
+Time Index 的类型和精度不能原地修改。完整导入前先用有代表性的行验证表结构：
 
-### 双写 GreptimeDB 和 MySQL
+```sql
+DESC TABLE db1.foo;
+SHOW CREATE TABLE db1.foo;
+```
 
-双写 GreptimeDB 和 MySQL 是迁移过程中防止数据丢失的有效策略。通过使用 MySQL 的客户端库（JDBC + 某个 MySQL
-驱动），你可以建立两个客户端实例 —— 一个用于 GreptimeDB，另一个用于 MySQL。有关如何使用 SQL 将数据写入
-GreptimeDB，请参考[写入数据](/user-guide/ingest-data/for-iot/sql.md)部分。
+## 导出行数据
 
-若无需保留所有历史数据，你可以双写一段时间以积累业务所需的最新数据，然后停止向 MySQL 写入数据并仅使用
-GreptimeDB。如果需要完整迁移所有历史数据，请按照接下来的步骤操作。
-
-### 从 MySQL 导出数据
-
-[mysqldump](https://dev.mysql.com/doc/refman/8.4/en/mysqldump.html) 是一个常用的、从 MySQL 导出数据的工具。使用
-mysqldump，我们可以从 MySQL 中导出后续可直接导入到 GreptimeDB 的数据。例如，如果我们想要从 MySQL 导出两个数据库 `db1` 和
-`db2`，我们可以使用以下命令：
+下面的示例在停止源端写入后导出一张 InnoDB 表。`--single-transaction` 可以为事务表提供一致性快照，但不能保证非事务表的一致性。`--skip-extended-insert` 让每一行使用一条 `INSERT`，`awk` 只保留计划导入 GreptimeDB 的语句。
 
 ```bash
-mysqldump -h127.0.0.1 -P3306 -umysql_user -p --compact -cnt --skip-extended-insert --databases db1 db2 > /path/to/output.sql
+set -o pipefail
+
+mysqldump \
+  --host=127.0.0.1 \
+  --port=3306 \
+  --user=mysql_user \
+  --password \
+  --single-transaction \
+  --compact \
+  --no-create-info \
+  --complete-insert \
+  --skip-extended-insert \
+  db1 foo | awk '/^INSERT INTO /' > foo.sql
 ```
 
-替换 `-h`、`-P` 和 `-u` 参数为 MySQL 服务的正确值。`--databases` 参数用于指定要导出的数据库。输出将写入
-`/path/to/output.sql` 文件。
+如果不同表需要不同的截止条件或数据转换，应分别导出。导入前检查 `foo.sql`：其中应只包含带列名的 `INSERT`，并确认字面量和列名适用于目标表。
 
-`/path/to/output.sql` 文件应该具有如下内容：
+## 导入 GreptimeDB
 
-```plaintext
-~ ❯ cat /path/to/output.sql
-
-USE `db1`;
-INSERT INTO `foo` (`ts`, `a`, `b`) VALUES (1,'hello',1);
-INSERT INTO ...
-
-USE `db2`;
-INSERT INTO `foo` (`ts`, `a`, `b`) VALUES (2,'greptime',2);
-INSERT INTO ...
-```
-
-### 将数据导入 GreptimeDB
-
-[MySQL Command-Line Client](https://dev.mysql.com/doc/refman/8.4/en/mysql.html) 可用于将数据导入
-GreptimeDB。继续上面的示例，假设数据导出到文件 `/path/to/output.sql`，那么我们可以使用以下命令将数据导入 GreptimeDB：
+使用 MySQL Client 连接 GreptimeDB 的 MySQL 端口，默认端口为 `4002`：
 
 ```bash
-mysql -h127.0.0.1 -P4002 -ugreptime_user -p -e "source /path/to/output.sql"
+mysql \
+  --host=127.0.0.1 \
+  --port=4002 \
+  --user=greptime_user \
+  --password \
+  --database=db1 \
+  < foo.sql
 ```
 
-替换 `-h`、`-P` 和 `-u` 参数为你的 GreptimeDB 服务的值。`source` 命令用于执行 `/path/to/output.sql` 文件中的 SQL
-命令。若需要进行 debug，添加 `-vvv` 以查看详细的执行结果。
+不要使用 MySQL Client 的 `--force` 参数；该参数会在 SQL 出错后继续执行，可能让部分导入看起来像成功完成。应保存命令退出状态和导入日志。大表应按照稳定的时间或 Key 边界拆分，并记录每个已完成范围。
 
-总结一下，数据迁移步骤如下图所示：
+## 校验并切换
 
-![migrate mysql data steps](/migration-mysql.jpg)
+在同一个不可变数据范围内比较源端和目标端：
 
-数据迁移完成后，你可以停止向 MySQL 写入数据，并继续使用 GreptimeDB！
+- 行数、最小和最大时间戳
+- 重要字段的非空数量
+- 按业务 Key 或时间窗口统计的行数
+- 抽样数据，包括 NULL、Unicode、二进制值和边界时间戳
+- 应用关键查询的结果
 
-如果您需要更详细的迁移方案或示例脚本，请提供具体的表结构和数据量信息。[GreptimeDB 官方社区](https://github.com/orgs/GreptimeTeam/discussions)将为您提供进一步的支持。欢迎加入 [Greptime Slack](http://greptime.com/slack) 社区交流。
+只有导入没有报错且上述校验通过后，才能切换读写流量。回滚窗口结束前保持源端数据不变。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/migrate-to-greptimedb/migrate-from-postgresql.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/migrate-to-greptimedb/migrate-from-postgresql.md
@@ -1,127 +1,82 @@
 ---
-keywords: [PostgreSQL 迁移, 数据迁移, 数据库创建, 数据导出, 数据导入]
-description: 指导用户从 PostgreSQL 迁移到 GreptimeDB，包括创建数据库和表、双写策略、数据导出和导入等步骤。
+keywords: [PostgreSQL 迁移, pg_dump, psql, PostgreSQL 协议, 数据校验]
+description: 使用明确的一致性边界和遇错即停的导入流程，把兼容的 PostgreSQL 表数据迁移到 GreptimeDB。
 ---
 
 # 从 PostgreSQL 迁移
 
-本文档将指引您完成从 PostgreSQL 迁移到 GreptimeDB。
+GreptimeDB 实现了 PostgreSQL Wire Protocol，但不是 PostgreSQL 存储引擎，也不支持完整的 PostgreSQL SQL 方言。PostgreSQL Schema Dump 可能包含 GreptimeDB 不支持的 DDL、Session 设置、Extension、约束和数据类型。应先在 GreptimeDB 中创建表结构，只导出兼容的行数据。
 
-## 在开始迁移之前
+## 规划迁移
 
-请注意，尽管 GreptimeDB 支持 PostgreSQL 的协议，并不意味着 GreptimeDB 实现了 PostgreSQL
-的所有功能。你可以参考
-- [ANSI 兼容性](/reference/sql/compatibility.md)查看在 GreptimeDB 中使用 SQL 的约束。
-- [数据建模指南](/user-guide/deployments-administration/performance-tuning/design-table.md)创建合适的表结构。
-- [数据索引指南](/user-guide/manage-data/data-index.md)用于索引规划。
+导出数据前：
 
-## 迁移步骤
+- 检查 [SQL 兼容性](/reference/sql/compatibility.md)，转换 PostgreSQL 特有的数据类型和表达式。
+- 选择自然的事件时间作为 GreptimeDB Time Index，并在建表前确定时间精度。
+- 根据目标查询负载设计 GreptimeDB 主键和索引。它们不会复现 PostgreSQL 的唯一性或 B-tree 语义。参见[表结构设计](/user-guide/deployments-administration/performance-tuning/design-table.md)和[索引](/user-guide/manage-data/data-index.md)。
+- 明确源端一致性边界。对于这种 Dump 迁移，短暂停止源端写入是最简单且可靠的方式。
 
-### 在 GreptimeDB 中创建数据库和表
+应用双写不具备原子性。如果不能停机，应使用能够记录 PostgreSQL 源端位置的 CDC 或双写流程，对两个目标进行重试，并在切换前完成差异对账。两个独立 JDBC 连接不能提供跨数据库事务。
 
-在从 PostgreSQL 迁移数据之前，你首先需要在 GreptimeDB 中创建相应的数据库和表。
-由于 GreptimeDB 有自己的 SQL 语法用于创建表，因此你不能直接重用 PostgreSQL 生成的建表 SQL。
+## 创建目标表结构
 
-当你为 GreptimeDB 编写创建表的 SQL 时，首先请了解其“[数据模型](/user-guide/concepts/data-model.md)”。然后，在创建表的
-SQL 中请考虑以下几点：
+导入行数据前，先在 GreptimeDB 中创建数据库和表。根据需要转换 PostgreSQL 默认值、生成列、Array、Range Type、JSON Operator、约束和索引。
 
-1. 由于 time index 列在表创建后无法更改，所以你需要仔细选择 time index
-   列。时间索引最好设置为数据生成时的自然时间戳，因为它提供了查询数据的最直观方式，以及最佳的查询性能。例如，在 IOT
-   场景中，你可以使用传感器采集数据时的时间作为 time index；或者在可观测场景中使用事件的发生时间。
-2. 不建议在此迁移过程中另造一个时间戳用作时间索引，例如使用 `DEFAULT current_timestamp()` 创建的新列。也不建议使用具有随机时间戳的列。
-3. 选择合适的 time index 精度也至关重要。和 time index 的选择一样，一旦表创建完毕，time index
-   的精度就无法变更了。请根据你的数据集在[这里](/reference/sql/data-types.md#与-mysql-和-postgresql-兼容的数据类型)找到最适合的时间戳类型。
-4.  仅在真正需要时才选择主键。GreptimeDB 中的主键与 PosgreSQL 中的主键不同。仅在以下情况下才应使用主键：
-    - 大部分查询可以受益于排序。
-    - 您需要通过主键和时间索引来删除重复行（包括删除）。 通常会被查询。标签列中的值是附加到收集源的标签，通常用于描述这些源的特定特征。标签列会被索引，从而使对它们的查询具有高性能。
-    
-    否则，设置主键是可选的，并且可能会损害性能。阅读[主键](/user-guide/deployments-administration/performance-tuning/design-table.md#主键)了解详情。
-    
-    最后，请参阅“[CREATE](/reference/sql/create.md)” SQL 文档，了解有关选择合适的数据类型和“ttl”或“compaction”选项等的更多详细信息。
-    
-5.  选择合适的索引以加快查询速度。
-    - 倒排索引：非常适合按低基数列进行过滤，并快速查找具有特定值的行。
-    - 跳数索引：适用于稀疏数据。
-    - 全文索引：可以在大型文本列中实现高效的关键字和模式搜索。
-    
-    有关详细信息和最佳实践，请参阅[数据索引](/user-guide/manage-data/data-index.md) 文档。
+使用有代表性的值测试映射，并检查最终表结构：
 
-### 双写 GreptimeDB 和 PostgreSQL
+```sql
+DESC TABLE db1.foo;
+SHOW CREATE TABLE db1.foo;
+```
 
-双写 GreptimeDB 和 PostgreSQL 是迁移过程中防止数据丢失的有效策略。通过使用 PostgreSQL 的客户端库（JDBC + 某个 PostgreSQL
-驱动），你可以建立两个客户端实例 —— 一个用于 GreptimeDB，另一个用于 PostgreSQL。有关如何使用 SQL 将数据写入
-GreptimeDB，请参考[写入数据](/user-guide/ingest-data/for-iot/sql.md)部分。
+## 导出行数据
 
-若无需保留所有历史数据，你可以双写一段时间以积累业务所需的最新数据，然后停止向 PostgreSQL 写入数据并仅使用
-GreptimeDB。如果需要完整迁移所有历史数据，请按照接下来的步骤操作。
-
-### 从 PostgreSQL 导出数据
-
-[pg_dump](https://www.postgresql.org/docs/current/app-pgdump.html) 是一个常用的、从 PostgreSQL 导出数据的工具。使用
-pg_dump，我们可以从 PostgreSQL 中导出后续可直接导入到 GreptimeDB 的数据。例如，如果我们想要从 PostgreSQL 的 database
-`postgres` 中导出以 `db` 开头的 schema，我们可以使用以下命令：
+`pg_dump --column-inserts` 适合向非 PostgreSQL 数据库迁移数据，但输出中仍包含 PostgreSQL 特有的初始化语句。下面的示例在停止源端写入后导出一张表，并且只保留带列名的 `INSERT`：
 
 ```bash
-pg_dump -h127.0.0.1 -p5432 -Upostgres -ax --column-inserts -n 'db*' postgres | grep -v "^SE" > /path/to/output.sql
+set -o pipefail
+
+pg_dump \
+  --host=127.0.0.1 \
+  --port=5432 \
+  --username=postgres \
+  --data-only \
+  --column-inserts \
+  --no-owner \
+  --no-privileges \
+  --table='db1.foo' \
+  postgres | awk '/^INSERT INTO /' > foo.sql
 ```
 
-替换 `-h`、`-p` 和 `-U` 参数为 PostgreSQL 服务的正确值。`-n` 参数用于指定要导出的 schema。数据库 `postgres` 被放在了 `pg_dump` 命令的最后。注意这里我们将
-pg_dump 的输出经过了一个特殊的 `grep` 命令以过滤掉不需要的 `SET` 和 `SELECT` 行。最终输出将写入 `/path/to/output.sql`
-文件。
+这里有意使用 Allowlist。旧示例删除所有以 `SE` 开头的行，前缀范围过大，可能丢弃有效内容。导入前检查 `foo.sql`，并转换 GreptimeDB 不支持的字面量或数据类型。
 
-`/path/to/output.sql` 文件应该具有如下内容：
+对于大表，应使用 ETL 查询或工具按有限范围导出，而不是生成一个没有边界的 SQL 文件。记录每个已完成范围，避免重试时静默重复或跳过数据。
 
-```plaintext
-~ ❯ cat /path/to/output.sql
+## 导入 GreptimeDB
 
---
--- PostgreSQL database dump
---
-
--- Dumped from database version 16.4 (Debian 16.4-1.pgdg120+1)
--- Dumped by pg_dump version 16.4
-
-
---
--- Data for Name: foo; Type: TABLE DATA; Schema: db1; Owner: postgres
---
-
-INSERT INTO db1.foo (ts, a) VALUES ('2024-10-31 00:00:00', 1);
-INSERT INTO db1.foo (ts, a) VALUES ('2024-10-31 00:00:01', 2);
-INSERT INTO db1.foo (ts, a) VALUES ('2024-10-31 00:00:01', 3);
-INSERT INTO ...
-
-
---
--- Data for Name: foo; Type: TABLE DATA; Schema: db2; Owner: postgres
---
-
-INSERT INTO db2.foo (ts, b) VALUES ('2024-10-31 00:00:00', '1');
-INSERT INTO db2.foo (ts, b) VALUES ('2024-10-31 00:00:01', '2');
-INSERT INTO db2.foo (ts, b) VALUES ('2024-10-31 00:00:01', '3');
-INSERT INTO ...
-
-
---
--- PostgreSQL database dump complete
---
-```
-
-### 将数据导入 GreptimeDB
-
-”[psql -- PostgreSQL interactive terminal](https://www.postgresql.org/docs/current/app-psql.html)“可用于将数据导入
-GreptimeDB。继续上面的示例，假设数据导出到文件 `/path/to/output.sql`，那么我们可以使用以下命令将数据导入 GreptimeDB：
+使用 `psql` 连接 GreptimeDB 的 PostgreSQL 端口，默认端口为 `4003`。`-X` 会忽略本地 `psqlrc` 设置，`ON_ERROR_STOP` 使命令遇到第一条 SQL 错误即失败：
 
 ```bash
-psql -h127.0.0.1 -p4003 -d public -f /path/to/output.sql
+psql \
+  -X \
+  --set ON_ERROR_STOP=1 \
+  --host=127.0.0.1 \
+  --port=4003 \
+  --username=greptime_user \
+  --dbname=public \
+  --file=foo.sql
 ```
 
-替换 `-h` 和 `-p` 参数为你的 GreptimeDB 服务的值。psql 命令中的 `-d` 参数用于指定数据库，该参数不能省略，`-d` 的值 `public` 是 GreptimeDB 默认使用的数据库。你还可以添加 `-a` 以查看详细的执行结果，或使用 `-s` 进入单步执行模式。
+不要移除 `ON_ERROR_STOP`。发生错误后继续执行，会产生没有明确失败边界的部分导入。应保存命令退出状态和导入日志。
 
-总结一下，数据迁移步骤如下图所示：
+## 校验并切换
 
-![migrate postgresql data steps](/migration-postgresql.jpg)
+在同一个不可变源端范围内比较 PostgreSQL 和 GreptimeDB：
 
-数据迁移完成后，你可以停止向 PostgreSQL 写入数据，并继续使用 GreptimeDB！
+- 行数、最小和最大时间戳
+- 重要维度的非空数量和去重数量
+- 按业务 Key 或时间窗口统计的行数
+- 覆盖 NULL、时区、数值边界、Unicode、JSON 和二进制值的抽样数据
+- 完成 SQL 改写后的应用关键查询结果
 
-如果您需要更详细的迁移方案或示例脚本，请提供具体的表结构和数据量信息。[GreptimeDB 官方社区](https://github.com/orgs/GreptimeTeam/discussions)将为您提供进一步的支持。欢迎加入 [Greptime Slack](http://greptime.com/slack) 社区交流。
+只有导入没有报错且上述校验通过后，才能切换流量。回滚窗口结束前保持 PostgreSQL 源端数据不变。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/migrate-to-greptimedb/migrate-from-prometheus.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/migrate-to-greptimedb/migrate-from-prometheus.md
@@ -3,7 +3,7 @@ keywords: [Prometheus 迁移, 数据迁移, 监控数据, 数据导入, 数据�
 description: 介绍从 Prometheus 迁移到 GreptimeDB 的步骤和注意事项。
 ---
 
-import DocTemplate from '../../db-cloud-shared/migrate/_migrate-from-prometheus.md' 
+import DocTemplate from '../../db-cloud-shared/migrate/_migrate-from-prometheus.md'
 
 # 从 Prometheus 迁移
 
@@ -23,7 +23,7 @@ import DocTemplate from '../../db-cloud-shared/migrate/_migrate-from-prometheus.
 
 <div id="grafana">
 
-要在 Grafana 中将 GreptimeDB 添加为 Prometheus 数据源，请参阅 [Grafana](/user-guide/integrations/grafana#prometheus-数据源) 的集成文档。
+在 Grafana 中把 GreptimeDB 添加为 Prometheus Data Source，参见 [Grafana Data Source 配置](/user-guide/integrations/grafana.md#prometheus-数据源)。
 
 </div>
 


### PR DESCRIPTION
## What changed

- Replace unsafe MySQL, PostgreSQL, and ClickHouse copy pipelines with bounded, fail-fast workflows.
- Document migration cutoffs, non-atomic dual writes, late-arriving data, and reconciliation requirements.
- Clarify that Prometheus Remote Write forwards new samples but does not migrate historical TSDB data.
- Add error handling to InfluxDB and Loki examples and remove an unsupported migration diagram.
- Rewrite the matching Chinese guides.

## Scope

- Documentation versions: Nightly
- Languages: English, Chinese

## Verification

- `git diff --check`
- `DOCS_LINK_CHECK=true pnpm build`
- `DOC_LANG=zh DOCS_LINK_CHECK=true pnpm build`
- Checked GreptimeDB endpoints and examples against upstream source at `d7f1233f775d54380318d6ad9ff62504a7cbcff1`.
- Checked migration-tool behavior against the official MySQL, PostgreSQL, ClickHouse, InfluxDB, Prometheus, and Grafana Alloy documentation.

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] I updated navigation when the document structure changed.
