### PR TITLE
docs: split Kafka deployment and Remote WAL guidance

### DIFF
--- a/docs/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md
+++ b/docs/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md
@@ -83,9 +83,20 @@ extraConfig: |
   log.flush.interval.ms=1000
   log.retention.hours=4
   log.roll.hours=3
-  log.retention.bytes=250000000
   log.segment.bytes=1073741824
 ```
+
+:::warning Retention settings when this cluster backs Remote WAL
+`log.retention.hours=4` is a testing value. Kafka deletes a segment as soon as
+any retention condition matches, so a retention window shorter than your longest
+flush, failure, or manual-recovery window can remove WAL that GreptimeDB has not
+replayed yet.
+
+Do not add a size-based retention such as `log.retention.bytes` to topics used
+for Remote WAL. See [Required Settings and
+Limitations](/user-guide/deployments-administration/wal/remote-wal/configuration.md#required-settings-and-limitations)
+for the full set of constraints.
+:::
 
 ## Installing Kafka Cluster
 
@@ -166,7 +177,7 @@ kafka-broker-1       1/1     Running   0          8m2s
 kafka-broker-2       1/1     Running   0          8m1s
 kafka-controller-0   1/1     Running   0          8m3s
 kafka-controller-1   1/1     Running   0          8m2s
-kafka-controller-0   1/1     Running   0          8m1s
+kafka-controller-2   1/1     Running   0          8m1s
 ```
 </details>
 

--- a/docs/user-guide/deployments-administration/wal/remote-wal/manage-kafka.md
+++ b/docs/user-guide/deployments-administration/wal/remote-wal/manage-kafka.md
@@ -1,103 +1,26 @@
 ---
 keywords: [Kafka, kubernetes, helm, GreptimeDB, remote WAL, installation, configuration, management]
-description: This guide describes how to install and manage Kafka cluster.
+description: How a Kafka cluster is used as GreptimeDB Remote WAL storage, and where to find its deployment and configuration requirements.
 ---
 # Manage Kafka
 
-The GreptimeDB cluster uses Kafka as the [Remote WAL](/user-guide/deployments-administration/wal/remote-wal/configuration.md) storage. This guide describes how to manage Kafka cluster. This guide will use Bitnami's Kafka Helm [chart](https://github.com/bitnami/charts/tree/main/bitnami/kafka) as an example.
+When [Remote WAL](/user-guide/deployments-administration/wal/remote-wal/configuration.md) is enabled, the GreptimeDB cluster writes its write-ahead log to Kafka instead of local disks. Datanodes append WAL entries to Kafka topics, and Metasrv prunes entries that every region has already flushed to object storage.
 
-## Prerequisites
+This means the Kafka cluster holds data that has not been persisted anywhere else yet. Treat it as a stateful dependency of the database, not as a transport buffer.
 
-- [Kubernetes](https://kubernetes.io/docs/setup/) >= v1.23
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) >= v1.18.0
-- [Helm](https://helm.sh/docs/intro/install/) >= v3.0.0
+## Deploy the Kafka cluster
 
-## Install
+Follow [Deploying Kafka Cluster](/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md) for installation, verification, monitoring, and uninstallation with the Bitnami Kafka Helm chart.
 
-Save the following configuration as a file `kafka.yaml`:
+## Requirements for Remote WAL
 
-```yaml
-global:
-  security:
-    allowInsecureImages: true
+Before pointing GreptimeDB at the cluster, review [Required Settings and Limitations](/user-guide/deployments-administration/wal/remote-wal/configuration.md#required-settings-and-limitations). It covers the retention policy, the Kafka permissions Datanode needs, and the relationship between `max_batch_bytes` and Kafka's maximum message size.
 
-image:
-  registry: docker.io
-  repository: greptime/kafka
-  tag: 3.9.0-debian-12-r12
+Getting the retention policy wrong is the most common way to lose data here: Kafka deletes segments on its own schedule, and a WAL entry deleted before GreptimeDB replays it cannot be recovered.
 
-controller:
-  replicaCount: 3
+## Connect GreptimeDB to Kafka
 
-  resources:
-    requests:
-      cpu: 2
-      memory: 2Gi
-    limits:
-      cpu: 2
-      memory: 2Gi
+To configure the GreptimeDB cluster itself, see:
 
-  persistence:
-    enabled: true
-    size: 200Gi
-
-broker:
-  replicaCount: 3
-
-  resources:
-    requests:
-      cpu: 2
-      memory: 2Gi
-    limits:
-      cpu: 2
-      memory: 2Gi
-
-  persistence:
-    enabled: true
-    size: 200Gi
-
-listeners:
-  client:
-    # When deploying on production environment, you normally want to use a more secure protocol like SASL.
-    # Please refer to the chart's docs for the "how-to": https://artifacthub.io/packages/helm/bitnami/kafka#enable-security-for-kafka
-    # Here for the sake of example's simplicity, we use plaintext (no authentications).
-    protocol: plaintext
-```
-
-Install Kafka cluster:
-
-```bash
-helm upgrade --install kafka \
-    oci://registry-1.docker.io/bitnamicharts/kafka \
-    --values kafka.yaml \
-    --version 32.4.3 \
-    --create-namespace \
-    -n kafka-cluster
-```
-
-Wait for Kafka cluster to be ready:
-
-```bash
-kubectl wait --for=condition=ready pod \
-    -l app.kubernetes.io/instance=kafka \
-    -n kafka-cluster \
-```
-
-Check the status of the Kafka cluster:
-
-```bash
-kubectl get pods -n kafka-cluster
-```
-
-<details>
-  <summary>Expected Output</summary>
-```bash
-NAME                 READY   STATUS    RESTARTS   AGE
-kafka-controller-0   1/1     Running   0          64s
-kafka-controller-1   1/1     Running   0          64s
-kafka-controller-2   1/1     Running   0          64s
-kafka-broker-0       1/1     Running   0          63s
-kafka-broker-1       1/1     Running   0          62s
-kafka-broker-2       1/1     Running   0          61s
-```
-</details>
+- [Remote WAL Configuration](/user-guide/deployments-administration/wal/remote-wal/configuration.md) for the Metasrv and Datanode `[wal]` options, including topic creation, WAL pruning, and Kafka authentication.
+- [Configure Remote WAL](/user-guide/deployments-administration/deploy-on-kubernetes/configure-remote-wal.md) for a complete Helm chart example on Kubernetes.

--- a/docs/user-guide/deployments-administration/wal/remote-wal/manage-kafka.md
+++ b/docs/user-guide/deployments-administration/wal/remote-wal/manage-kafka.md
@@ -4,9 +4,9 @@ description: How a Kafka cluster is used as GreptimeDB Remote WAL storage, and w
 ---
 # Manage Kafka
 
-When [Remote WAL](/user-guide/deployments-administration/wal/remote-wal/configuration.md) is enabled, the GreptimeDB cluster writes its write-ahead log to Kafka instead of local disks. Datanodes append WAL entries to Kafka topics, and Metasrv prunes entries that every region has already flushed to object storage.
+When [Remote WAL](/user-guide/deployments-administration/wal/remote-wal/configuration.md) is enabled, the GreptimeDB cluster writes its write-ahead log to Kafka instead of local disks. Datanodes append WAL entries to Kafka topics, and Metasrv prunes entries that are no longer needed for recovery.
 
-This means the Kafka cluster holds data that has not been persisted anywhere else yet. Treat it as a stateful dependency of the database, not as a transport buffer.
+Until a region flushes to object storage, Kafka may hold the only durable copy of those writes. Treat it as a stateful dependency of the database, not as a transport buffer.
 
 ## Deploy the Kafka cluster
 

--- a/docs/user-guide/deployments-administration/wal/remote-wal/manage-kafka.md
+++ b/docs/user-guide/deployments-administration/wal/remote-wal/manage-kafka.md
@@ -2,25 +2,12 @@
 keywords: [Kafka, kubernetes, helm, GreptimeDB, remote WAL, installation, configuration, management]
 description: How a Kafka cluster is used as GreptimeDB Remote WAL storage, and where to find its deployment and configuration requirements.
 ---
-# Manage Kafka
+# Kafka
 
-When [Remote WAL](/user-guide/deployments-administration/wal/remote-wal/configuration.md) is enabled, the GreptimeDB cluster writes its write-ahead log to Kafka instead of local disks. Datanodes append WAL entries to Kafka topics, and Metasrv prunes entries that are no longer needed for recovery.
+When [Remote WAL](/user-guide/deployments-administration/wal/overview.md#remote-wal) is enabled, the GreptimeDB cluster writes its write-ahead log to Kafka instead of local disks. Datanodes append WAL entries to Kafka topics, and Metasrv prunes entries that are no longer needed for recovery.
 
-Until a region flushes to object storage, Kafka may hold the only durable copy of those writes. Treat it as a stateful dependency of the database, not as a transport buffer.
+Until a region flushes to object storage, Kafka may hold the only durable copy of those writes. Treat it as a stateful dependency of the database, not as a transport buffer. Getting the retention policy wrong is the most common way to lose data here: Kafka deletes segments on its own schedule, and a WAL entry deleted before GreptimeDB replays it cannot be recovered.
 
-## Deploy the Kafka cluster
-
-Follow [Deploying Kafka Cluster](/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md) for installation, verification, monitoring, and uninstallation with the Bitnami Kafka Helm chart.
-
-## Requirements for Remote WAL
-
-Before pointing GreptimeDB at the cluster, review [Required Settings and Limitations](/user-guide/deployments-administration/wal/remote-wal/configuration.md#required-settings-and-limitations). It covers the retention policy, the Kafka permissions Datanode needs, and the relationship between `max_batch_bytes` and Kafka's maximum message size.
-
-Getting the retention policy wrong is the most common way to lose data here: Kafka deletes segments on its own schedule, and a WAL entry deleted before GreptimeDB replays it cannot be recovered.
-
-## Connect GreptimeDB to Kafka
-
-To configure the GreptimeDB cluster itself, see:
-
-- [Remote WAL Configuration](/user-guide/deployments-administration/wal/remote-wal/configuration.md) for the Metasrv and Datanode `[wal]` options, including topic creation, WAL pruning, and Kafka authentication.
-- [Configure Remote WAL](/user-guide/deployments-administration/deploy-on-kubernetes/configure-remote-wal.md) for a complete Helm chart example on Kubernetes.
+- [Deploying Kafka Cluster](/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md) — installation, verification, monitoring, and uninstallation with the Bitnami Kafka Helm chart.
+- [Remote WAL Configuration](/user-guide/deployments-administration/wal/remote-wal/configuration.md) — the Metasrv and Datanode `[wal]` options, plus the [required settings and limitations](/user-guide/deployments-administration/wal/remote-wal/configuration.md#required-settings-and-limitations) the Kafka cluster must satisfy.
+- [Configure Remote WAL](/user-guide/deployments-administration/deploy-on-kubernetes/configure-remote-wal.md) — a complete Helm chart example on Kubernetes.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md
@@ -83,9 +83,16 @@ extraConfig: |
   log.flush.interval.ms=1000
   log.retention.hours=4
   log.roll.hours=3
-  log.retention.bytes=250000000
   log.segment.bytes=1073741824
 ```
+
+:::warning 该集群用于 Remote WAL 时的保留策略
+`log.retention.hours=4` 是测试值。Kafka 只要命中任一保留条件就会删除 segment，
+保留窗口短于最长的 flush、故障或人工处置窗口时，会删掉 GreptimeDB 尚未回放的 WAL。
+
+用于 Remote WAL 的 topic 不要配置 `log.retention.bytes` 这类基于大小的保留策略。
+完整限制见 [注意事项与限制](/user-guide/deployments-administration/wal/remote-wal/configuration.md#注意事项与限制)。
+:::
 
 ## 安装 Kafka 集群
 
@@ -166,7 +173,7 @@ kafka-broker-1       1/1     Running   0          8m2s
 kafka-broker-2       1/1     Running   0          8m1s
 kafka-controller-0   1/1     Running   0          8m3s
 kafka-controller-1   1/1     Running   0          8m2s
-kafka-controller-0   1/1     Running   0          8m1s
+kafka-controller-2   1/1     Running   0          8m1s
 ```
 </details>
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/wal/remote-wal/manage-kafka.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/wal/remote-wal/manage-kafka.md
@@ -5,9 +5,9 @@ description: 介绍 Kafka 集群在 GreptimeDB Remote WAL 中的作用，以及�
 
 # 管理 Kafka
 
-启用 [Remote WAL](/user-guide/deployments-administration/wal/remote-wal/configuration.md) 后，GreptimeDB 集群不再把预写日志写到本地磁盘，而是写入 Kafka。Datanode 向 Kafka topic 追加 WAL entry，Metasrv 负责清理所有 region 都已 flush 到对象存储的部分。
+启用 [Remote WAL](/user-guide/deployments-administration/wal/remote-wal/configuration.md) 后，GreptimeDB 集群不再把预写日志写到本地磁盘，而是写入 Kafka。Datanode 向 Kafka topic 追加 WAL entry，Metasrv 负责清理恢复时不再需要的 entry。
 
-也就是说，Kafka 集群里存放着尚未持久化到别处的数据。它是数据库的有状态依赖，不是传输层的缓冲区。
+在 region flush 到对象存储之前，Kafka 可能是这些写入唯一的持久副本。它是数据库的有状态依赖，不是传输层的缓冲区。
 
 ## 部署 Kafka 集群
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/wal/remote-wal/manage-kafka.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/wal/remote-wal/manage-kafka.md
@@ -3,25 +3,12 @@ keywords: [Kafka, kubernetes, helm, GreptimeDB, remote WAL, 安装, 配置, 管�
 description: 介绍 Kafka 集群在 GreptimeDB Remote WAL 中的作用，以及部署和配置要求的查阅位置。
 ---
 
-# 管理 Kafka
+# Kafka
 
-启用 [Remote WAL](/user-guide/deployments-administration/wal/remote-wal/configuration.md) 后，GreptimeDB 集群不再把预写日志写到本地磁盘，而是写入 Kafka。Datanode 向 Kafka topic 追加 WAL entry，Metasrv 负责清理恢复时不再需要的 entry。
+启用 [Remote WAL](/user-guide/deployments-administration/wal/overview.md#remote-wal) 后，GreptimeDB 集群不再把预写日志写到本地磁盘，而是写入 Kafka。Datanode 向 Kafka topic 追加 WAL entry，Metasrv 负责清理恢复时不再需要的 entry。
 
-在 region flush 到对象存储之前，Kafka 可能是这些写入唯一的持久副本。它是数据库的有状态依赖，不是传输层的缓冲区。
+在 region flush 到对象存储之前，Kafka 可能是这些写入唯一的持久副本。它是数据库的有状态依赖，不是传输层的缓冲区。保留策略配错是这里最常见的数据丢失原因：Kafka 按自己的规则删除 segment，而 WAL entry 一旦在 GreptimeDB 回放之前被删除就无法恢复。
 
-## 部署 Kafka 集群
-
-安装、验证、监控和卸载步骤见[部署 Kafka 集群](/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md)，使用 Bitnami 提供的 Kafka Helm chart。
-
-## Remote WAL 对 Kafka 的要求
-
-在把 GreptimeDB 指向该集群之前，请先阅读[注意事项与限制](/user-guide/deployments-administration/wal/remote-wal/configuration.md#注意事项与限制)，其中说明了保留策略、Datanode 所需的 Kafka 权限，以及 `max_batch_bytes` 与 Kafka 最大消息大小的关系。
-
-保留策略配错是这里最常见的数据丢失原因：Kafka 按自己的规则删除 segment，而 WAL entry 一旦在 GreptimeDB 回放之前被删除就无法恢复。
-
-## 将 GreptimeDB 接入 Kafka
-
-配置 GreptimeDB 侧请参考：
-
-- [Remote WAL 配置](/user-guide/deployments-administration/wal/remote-wal/configuration.md)：Metasrv 和 Datanode 的 `[wal]` 配置项，包含 topic 自动创建、WAL 清理和 Kafka 认证。
-- [配置 Remote WAL](/user-guide/deployments-administration/deploy-on-kubernetes/configure-remote-wal.md)：Kubernetes 上完整的 Helm chart 示例。
+- [部署 Kafka 集群](/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md) —— 使用 Bitnami Kafka Helm chart 的安装、验证、监控和卸载步骤。
+- [Remote WAL 配置](/user-guide/deployments-administration/wal/remote-wal/configuration.md) —— Metasrv 和 Datanode 的 `[wal]` 配置项，以及 Kafka 集群必须满足的[注意事项与限制](/user-guide/deployments-administration/wal/remote-wal/configuration.md#注意事项与限制)。
+- [配置 Remote WAL](/user-guide/deployments-administration/deploy-on-kubernetes/configure-remote-wal.md) —— Kubernetes 上完整的 Helm chart 示例。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/wal/remote-wal/manage-kafka.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/wal/remote-wal/manage-kafka.md
@@ -1,110 +1,27 @@
 ---
 keywords: [Kafka, kubernetes, helm, GreptimeDB, remote WAL, 安装, 配置, 管理]
-description: 本指南介绍如何安装和管理 Kafka 集群。
+description: 介绍 Kafka 集群在 GreptimeDB Remote WAL 中的作用，以及部署和配置要求的查阅位置。
 ---
 
 # 管理 Kafka
 
-GreptimeDB 集群在启用 [Remote WAL](/user-guide/deployments-administration/wal/remote-wal/configuration.md) 时，会使用 Kafka 作为 WAL 存储。本文介绍如何部署和管理 Kafka 集群，使用的是 Bitnami 提供的 Kafka Helm [chart](https://github.com/bitnami/charts/tree/main/bitnami/kafka)。
+启用 [Remote WAL](/user-guide/deployments-administration/wal/remote-wal/configuration.md) 后，GreptimeDB 集群不再把预写日志写到本地磁盘，而是写入 Kafka。Datanode 向 Kafka topic 追加 WAL entry，Metasrv 负责清理所有 region 都已 flush 到对象存储的部分。
 
-## 先决条件
+也就是说，Kafka 集群里存放着尚未持久化到别处的数据。它是数据库的有状态依赖，不是传输层的缓冲区。
 
-- [Kubernetes](https://kubernetes.io/docs/setup/) >= v1.23
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) >= v1.18.0
-- [Helm](https://helm.sh/docs/intro/install/) >= v3.0.0
+## 部署 Kafka 集群
 
-## 安装
+安装、验证、监控和卸载步骤见[部署 Kafka 集群](/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md)，使用 Bitnami 提供的 Kafka Helm chart。
 
-将以下内容保存为配置文件 `kafka.yaml`：
+## Remote WAL 对 Kafka 的要求
 
-```yaml
-global:
-  security:
-    allowInsecureImages: true
+在把 GreptimeDB 指向该集群之前，请先阅读[注意事项与限制](/user-guide/deployments-administration/wal/remote-wal/configuration.md#注意事项与限制)，其中说明了保留策略、Datanode 所需的 Kafka 权限，以及 `max_batch_bytes` 与 Kafka 最大消息大小的关系。
 
-image:
-  registry: docker.io
-  repository: greptime/kafka
-  tag: 3.9.0-debian-12-r12
+保留策略配错是这里最常见的数据丢失原因：Kafka 按自己的规则删除 segment，而 WAL entry 一旦在 GreptimeDB 回放之前被删除就无法恢复。
 
-controller:
-  replicaCount: 3
+## 将 GreptimeDB 接入 Kafka
 
-  resources:
-    requests:
-      cpu: 2
-      memory: 2Gi
-    limits:
-      cpu: 2
-      memory: 2Gi
+配置 GreptimeDB 侧请参考：
 
-  persistence:
-    enabled: true
-    size: 200Gi
-
-broker:
-  replicaCount: 3
-
-  resources:
-    requests:
-      cpu: 2
-      memory: 2Gi
-    limits:
-      cpu: 2
-      memory: 2Gi
-
-  persistence:
-    enabled: true
-    size: 200Gi
-
-listeners:
-  client:
-    # 部署到生产环境时，通常会使用一个更安全的协议，例如 SASL。
-    # 请参考 chart 的文档获取配置方法：https://artifacthub.io/packages/helm/bitnami/kafka#enable-security-for-kafka
-    # 此处为了例子的简单，我们使用 plaintext 协议（无权限验证）。
-    protocol: plaintext
-```
-
-安装 Kafka 集群：
-
-```bash
-helm upgrade --install kafka \
-    oci://registry-1.docker.io/bitnamicharts/kafka \
-    --values kafka.yaml \
-    --version 32.4.3 \
-    --create-namespace \
-    -n kafka-cluster
-```
-
-等待 Kafka 集群启动完成：
-
-```bash
-kubectl wait --for=condition=ready pod \
-    -l app.kubernetes.io/instance=kafka \
-    -n kafka-cluster
-```
-
-
-```bash
-kubectl get pods -n kafka-cluster
-```
-
-检查 Kafka 集群状态：
-
-```bash
-kubectl get pods -n kafka-cluster
-```
-
-
-<details>
-  <summary>Expected Output</summary>
-```bash
-NAME                 READY   STATUS    RESTARTS   AGE
-kafka-controller-0   1/1     Running   0          64s
-kafka-controller-1   1/1     Running   0          64s
-kafka-controller-2   1/1     Running   0          64s
-kafka-broker-0       1/1     Running   0          63s
-kafka-broker-1       1/1     Running   0          62s
-kafka-broker-2       1/1     Running   0          61s
-```
-</details>
+- [Remote WAL 配置](/user-guide/deployments-administration/wal/remote-wal/configuration.md)：Metasrv 和 Datanode 的 `[wal]` 配置项，包含 topic 自动创建、WAL 清理和 Kafka 认证。
+- [配置 Remote WAL](/user-guide/deployments-administration/deploy-on-kubernetes/configure-remote-wal.md)：Kubernetes 上完整的 Helm chart 示例。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md
@@ -83,9 +83,16 @@ extraConfig: |
   log.flush.interval.ms=1000
   log.retention.hours=4
   log.roll.hours=3
-  log.retention.bytes=250000000
   log.segment.bytes=1073741824
 ```
+
+:::warning 该集群用于 Remote WAL 时的保留策略
+`log.retention.hours=4` 是测试值。Kafka 只要命中任一保留条件就会删除 segment，
+保留窗口短于最长的 flush、故障或人工处置窗口时，会删掉 GreptimeDB 尚未回放的 WAL。
+
+用于 Remote WAL 的 topic 不要配置 `log.retention.bytes` 这类基于大小的保留策略。
+完整限制见 [注意事项与限制](/user-guide/deployments-administration/wal/remote-wal/configuration.md#注意事项与限制)。
+:::
 
 ## 安装 Kafka 集群
 
@@ -166,7 +173,7 @@ kafka-broker-1       1/1     Running   0          8m2s
 kafka-broker-2       1/1     Running   0          8m1s
 kafka-controller-0   1/1     Running   0          8m3s
 kafka-controller-1   1/1     Running   0          8m2s
-kafka-controller-0   1/1     Running   0          8m1s
+kafka-controller-2   1/1     Running   0          8m1s
 ```
 </details>
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/deployments-administration/wal/remote-wal/manage-kafka.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/deployments-administration/wal/remote-wal/manage-kafka.md
@@ -1,110 +1,14 @@
 ---
 keywords: [Kafka, kubernetes, helm, GreptimeDB, remote WAL, 安装, 配置, 管理]
-description: 本指南介绍如何安装和管理 Kafka 集群。
+description: 介绍 Kafka 集群在 GreptimeDB Remote WAL 中的作用，以及部署和配置要求的查阅位置。
 ---
 
-# 管理 Kafka
+# Kafka
 
-GreptimeDB 集群在启用 [Remote WAL](/user-guide/deployments-administration/wal/remote-wal/configuration.md) 时，会使用 Kafka 作为 WAL 存储。本文介绍如何部署和管理 Kafka 集群，使用的是 Bitnami 提供的 Kafka Helm [chart](https://github.com/bitnami/charts/tree/main/bitnami/kafka)。
+启用 [Remote WAL](/user-guide/deployments-administration/wal/overview.md#remote-wal) 后，GreptimeDB 集群不再把预写日志写到本地磁盘，而是写入 Kafka。Datanode 向 Kafka topic 追加 WAL entry，Metasrv 负责清理恢复时不再需要的 entry。
 
-## 先决条件
+在 region flush 到对象存储之前，Kafka 可能是这些写入唯一的持久副本。它是数据库的有状态依赖，不是传输层的缓冲区。保留策略配错是这里最常见的数据丢失原因：Kafka 按自己的规则删除 segment，而 WAL entry 一旦在 GreptimeDB 回放之前被删除就无法恢复。
 
-- [Kubernetes](https://kubernetes.io/docs/setup/) >= v1.23
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) >= v1.18.0
-- [Helm](https://helm.sh/docs/intro/install/) >= v3.0.0
-
-## 安装
-
-将以下内容保存为配置文件 `kafka.yaml`：
-
-```yaml
-global:
-  security:
-    allowInsecureImages: true
-
-image:
-  registry: docker.io
-  repository: greptime/kafka
-  tag: 3.9.0-debian-12-r12
-
-controller:
-  replicaCount: 3
-
-  resources:
-    requests:
-      cpu: 2
-      memory: 2Gi
-    limits:
-      cpu: 2
-      memory: 2Gi
-
-  persistence:
-    enabled: true
-    size: 200Gi
-
-broker:
-  replicaCount: 3
-
-  resources:
-    requests:
-      cpu: 2
-      memory: 2Gi
-    limits:
-      cpu: 2
-      memory: 2Gi
-
-  persistence:
-    enabled: true
-    size: 200Gi
-
-listeners:
-  client:
-    # 部署到生产环境时，通常会使用一个更安全的协议，例如 SASL。
-    # 请参考 chart 的文档获取配置方法：https://artifacthub.io/packages/helm/bitnami/kafka#enable-security-for-kafka
-    # 此处为了例子的简单，我们使用 plaintext 协议（无权限验证）。
-    protocol: plaintext
-```
-
-安装 Kafka 集群：
-
-```bash
-helm upgrade --install kafka \
-    oci://registry-1.docker.io/bitnamicharts/kafka \
-    --values kafka.yaml \
-    --version 32.4.3 \
-    --create-namespace \
-    -n kafka-cluster
-```
-
-等待 Kafka 集群启动完成：
-
-```bash
-kubectl wait --for=condition=ready pod \
-    -l app.kubernetes.io/instance=kafka \
-    -n kafka-cluster
-```
-
-
-```bash
-kubectl get pods -n kafka-cluster
-```
-
-检查 Kafka 集群状态：
-
-```bash
-kubectl get pods -n kafka-cluster
-```
-
-
-<details>
-  <summary>Expected Output</summary>
-```bash
-NAME                 READY   STATUS    RESTARTS   AGE
-kafka-controller-0   1/1     Running   0          64s
-kafka-controller-1   1/1     Running   0          64s
-kafka-controller-2   1/1     Running   0          64s
-kafka-broker-0       1/1     Running   0          63s
-kafka-broker-1       1/1     Running   0          62s
-kafka-broker-2       1/1     Running   0          61s
-```
-</details>
+- [部署 Kafka 集群](/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md) —— 使用 Bitnami Kafka Helm chart 的安装、验证、监控和卸载步骤。
+- [Remote WAL 配置](/user-guide/deployments-administration/wal/remote-wal/configuration.md) —— Metasrv 和 Datanode 的 `[wal]` 配置项，以及 Kafka 集群必须满足的[注意事项与限制](/user-guide/deployments-administration/wal/remote-wal/configuration.md#注意事项与限制)。
+- [配置 Remote WAL](/user-guide/deployments-administration/deploy-on-kubernetes/configure-remote-wal.md) —— Kubernetes 上完整的 Helm chart 示例。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md
@@ -83,9 +83,16 @@ extraConfig: |
   log.flush.interval.ms=1000
   log.retention.hours=4
   log.roll.hours=3
-  log.retention.bytes=250000000
   log.segment.bytes=1073741824
 ```
+
+:::warning 该集群用于 Remote WAL 时的保留策略
+`log.retention.hours=4` 是测试值。Kafka 只要命中任一保留条件就会删除 segment，
+保留窗口短于最长的 flush、故障或人工处置窗口时，会删掉 GreptimeDB 尚未回放的 WAL。
+
+用于 Remote WAL 的 topic 不要配置 `log.retention.bytes` 这类基于大小的保留策略。
+完整限制见 [注意事项与限制](/user-guide/deployments-administration/wal/remote-wal/configuration.md#注意事项与限制)。
+:::
 
 ## 安装 Kafka 集群
 
@@ -166,7 +173,7 @@ kafka-broker-1       1/1     Running   0          8m2s
 kafka-broker-2       1/1     Running   0          8m1s
 kafka-controller-0   1/1     Running   0          8m3s
 kafka-controller-1   1/1     Running   0          8m2s
-kafka-controller-0   1/1     Running   0          8m1s
+kafka-controller-2   1/1     Running   0          8m1s
 ```
 </details>
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/wal/remote-wal/manage-kafka.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/wal/remote-wal/manage-kafka.md
@@ -1,110 +1,14 @@
 ---
 keywords: [Kafka, kubernetes, helm, GreptimeDB, remote WAL, 安装, 配置, 管理]
-description: 本指南介绍如何安装和管理 Kafka 集群。
+description: 介绍 Kafka 集群在 GreptimeDB Remote WAL 中的作用，以及部署和配置要求的查阅位置。
 ---
 
-# 管理 Kafka
+# Kafka
 
-GreptimeDB 集群在启用 [Remote WAL](/user-guide/deployments-administration/wal/remote-wal/configuration.md) 时，会使用 Kafka 作为 WAL 存储。本文介绍如何部署和管理 Kafka 集群，使用的是 Bitnami 提供的 Kafka Helm [chart](https://github.com/bitnami/charts/tree/main/bitnami/kafka)。
+启用 [Remote WAL](/user-guide/deployments-administration/wal/overview.md#remote-wal) 后，GreptimeDB 集群不再把预写日志写到本地磁盘，而是写入 Kafka。Datanode 向 Kafka topic 追加 WAL entry，Metasrv 负责清理恢复时不再需要的 entry。
 
-## 先决条件
+在 region flush 到对象存储之前，Kafka 可能是这些写入唯一的持久副本。它是数据库的有状态依赖，不是传输层的缓冲区。保留策略配错是这里最常见的数据丢失原因：Kafka 按自己的规则删除 segment，而 WAL entry 一旦在 GreptimeDB 回放之前被删除就无法恢复。
 
-- [Kubernetes](https://kubernetes.io/docs/setup/) >= v1.23
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) >= v1.18.0
-- [Helm](https://helm.sh/docs/intro/install/) >= v3.0.0
-
-## 安装
-
-将以下内容保存为配置文件 `kafka.yaml`：
-
-```yaml
-global:
-  security:
-    allowInsecureImages: true
-
-image:
-  registry: docker.io
-  repository: greptime/kafka
-  tag: 3.9.0-debian-12-r12
-
-controller:
-  replicaCount: 3
-
-  resources:
-    requests:
-      cpu: 2
-      memory: 2Gi
-    limits:
-      cpu: 2
-      memory: 2Gi
-
-  persistence:
-    enabled: true
-    size: 200Gi
-
-broker:
-  replicaCount: 3
-
-  resources:
-    requests:
-      cpu: 2
-      memory: 2Gi
-    limits:
-      cpu: 2
-      memory: 2Gi
-
-  persistence:
-    enabled: true
-    size: 200Gi
-
-listeners:
-  client:
-    # 部署到生产环境时，通常会使用一个更安全的协议，例如 SASL。
-    # 请参考 chart 的文档获取配置方法：https://artifacthub.io/packages/helm/bitnami/kafka#enable-security-for-kafka
-    # 此处为了例子的简单，我们使用 plaintext 协议（无权限验证）。
-    protocol: plaintext
-```
-
-安装 Kafka 集群：
-
-```bash
-helm upgrade --install kafka \
-    oci://registry-1.docker.io/bitnamicharts/kafka \
-    --values kafka.yaml \
-    --version 32.4.3 \
-    --create-namespace \
-    -n kafka-cluster
-```
-
-等待 Kafka 集群启动完成：
-
-```bash
-kubectl wait --for=condition=ready pod \
-    -l app.kubernetes.io/instance=kafka \
-    -n kafka-cluster
-```
-
-
-```bash
-kubectl get pods -n kafka-cluster
-```
-
-检查 Kafka 集群状态：
-
-```bash
-kubectl get pods -n kafka-cluster
-```
-
-
-<details>
-  <summary>Expected Output</summary>
-```bash
-NAME                 READY   STATUS    RESTARTS   AGE
-kafka-controller-0   1/1     Running   0          64s
-kafka-controller-1   1/1     Running   0          64s
-kafka-controller-2   1/1     Running   0          64s
-kafka-broker-0       1/1     Running   0          63s
-kafka-broker-1       1/1     Running   0          62s
-kafka-broker-2       1/1     Running   0          61s
-```
-</details>
+- [部署 Kafka 集群](/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md) —— 使用 Bitnami Kafka Helm chart 的安装、验证、监控和卸载步骤。
+- [Remote WAL 配置](/user-guide/deployments-administration/wal/remote-wal/configuration.md) —— Metasrv 和 Datanode 的 `[wal]` 配置项，以及 Kafka 集群必须满足的[注意事项与限制](/user-guide/deployments-administration/wal/remote-wal/configuration.md#注意事项与限制)。
+- [配置 Remote WAL](/user-guide/deployments-administration/deploy-on-kubernetes/configure-remote-wal.md) —— Kubernetes 上完整的 Helm chart 示例。

--- a/versioned_docs/version-1.1/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md
+++ b/versioned_docs/version-1.1/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md
@@ -83,9 +83,20 @@ extraConfig: |
   log.flush.interval.ms=1000
   log.retention.hours=4
   log.roll.hours=3
-  log.retention.bytes=250000000
   log.segment.bytes=1073741824
 ```
+
+:::warning Retention settings when this cluster backs Remote WAL
+`log.retention.hours=4` is a testing value. Kafka deletes a segment as soon as
+any retention condition matches, so a retention window shorter than your longest
+flush, failure, or manual-recovery window can remove WAL that GreptimeDB has not
+replayed yet.
+
+Do not add a size-based retention such as `log.retention.bytes` to topics used
+for Remote WAL. See [Required Settings and
+Limitations](/user-guide/deployments-administration/wal/remote-wal/configuration.md#required-settings-and-limitations)
+for the full set of constraints.
+:::
 
 ## Installing Kafka Cluster
 
@@ -166,7 +177,7 @@ kafka-broker-1       1/1     Running   0          8m2s
 kafka-broker-2       1/1     Running   0          8m1s
 kafka-controller-0   1/1     Running   0          8m3s
 kafka-controller-1   1/1     Running   0          8m2s
-kafka-controller-0   1/1     Running   0          8m1s
+kafka-controller-2   1/1     Running   0          8m1s
 ```
 </details>
 

--- a/versioned_docs/version-1.1/user-guide/deployments-administration/wal/remote-wal/manage-kafka.md
+++ b/versioned_docs/version-1.1/user-guide/deployments-administration/wal/remote-wal/manage-kafka.md
@@ -1,103 +1,13 @@
 ---
 keywords: [Kafka, kubernetes, helm, GreptimeDB, remote WAL, installation, configuration, management]
-description: This guide describes how to install and manage Kafka cluster.
+description: How a Kafka cluster is used as GreptimeDB Remote WAL storage, and where to find its deployment and configuration requirements.
 ---
-# Manage Kafka
+# Kafka
 
-The GreptimeDB cluster uses Kafka as the [Remote WAL](/user-guide/deployments-administration/wal/remote-wal/configuration.md) storage. This guide describes how to manage Kafka cluster. This guide will use Bitnami's Kafka Helm [chart](https://github.com/bitnami/charts/tree/main/bitnami/kafka) as an example.
+When [Remote WAL](/user-guide/deployments-administration/wal/overview.md#remote-wal) is enabled, the GreptimeDB cluster writes its write-ahead log to Kafka instead of local disks. Datanodes append WAL entries to Kafka topics, and Metasrv prunes entries that are no longer needed for recovery.
 
-## Prerequisites
+Until a region flushes to object storage, Kafka may hold the only durable copy of those writes. Treat it as a stateful dependency of the database, not as a transport buffer. Getting the retention policy wrong is the most common way to lose data here: Kafka deletes segments on its own schedule, and a WAL entry deleted before GreptimeDB replays it cannot be recovered.
 
-- [Kubernetes](https://kubernetes.io/docs/setup/) >= v1.23
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) >= v1.18.0
-- [Helm](https://helm.sh/docs/intro/install/) >= v3.0.0
-
-## Install
-
-Save the following configuration as a file `kafka.yaml`:
-
-```yaml
-global:
-  security:
-    allowInsecureImages: true
-
-image:
-  registry: docker.io
-  repository: greptime/kafka
-  tag: 3.9.0-debian-12-r12
-
-controller:
-  replicaCount: 3
-
-  resources:
-    requests:
-      cpu: 2
-      memory: 2Gi
-    limits:
-      cpu: 2
-      memory: 2Gi
-
-  persistence:
-    enabled: true
-    size: 200Gi
-
-broker:
-  replicaCount: 3
-
-  resources:
-    requests:
-      cpu: 2
-      memory: 2Gi
-    limits:
-      cpu: 2
-      memory: 2Gi
-
-  persistence:
-    enabled: true
-    size: 200Gi
-
-listeners:
-  client:
-    # When deploying on production environment, you normally want to use a more secure protocol like SASL.
-    # Please refer to the chart's docs for the "how-to": https://artifacthub.io/packages/helm/bitnami/kafka#enable-security-for-kafka
-    # Here for the sake of example's simplicity, we use plaintext (no authentications).
-    protocol: plaintext
-```
-
-Install Kafka cluster:
-
-```bash
-helm upgrade --install kafka \
-    oci://registry-1.docker.io/bitnamicharts/kafka \
-    --values kafka.yaml \
-    --version 32.4.3 \
-    --create-namespace \
-    -n kafka-cluster
-```
-
-Wait for Kafka cluster to be ready:
-
-```bash
-kubectl wait --for=condition=ready pod \
-    -l app.kubernetes.io/instance=kafka \
-    -n kafka-cluster \
-```
-
-Check the status of the Kafka cluster:
-
-```bash
-kubectl get pods -n kafka-cluster
-```
-
-<details>
-  <summary>Expected Output</summary>
-```bash
-NAME                 READY   STATUS    RESTARTS   AGE
-kafka-controller-0   1/1     Running   0          64s
-kafka-controller-1   1/1     Running   0          64s
-kafka-controller-2   1/1     Running   0          64s
-kafka-broker-0       1/1     Running   0          63s
-kafka-broker-1       1/1     Running   0          62s
-kafka-broker-2       1/1     Running   0          61s
-```
-</details>
+- [Deploying Kafka Cluster](/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md) — installation, verification, monitoring, and uninstallation with the Bitnami Kafka Helm chart.
+- [Remote WAL Configuration](/user-guide/deployments-administration/wal/remote-wal/configuration.md) — the Metasrv and Datanode `[wal]` options, plus the [required settings and limitations](/user-guide/deployments-administration/wal/remote-wal/configuration.md#required-settings-and-limitations) the Kafka cluster must satisfy.
+- [Configure Remote WAL](/user-guide/deployments-administration/deploy-on-kubernetes/configure-remote-wal.md) — a complete Helm chart example on Kubernetes.

--- a/versioned_docs/version-1.2/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md
+++ b/versioned_docs/version-1.2/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md
@@ -83,9 +83,20 @@ extraConfig: |
   log.flush.interval.ms=1000
   log.retention.hours=4
   log.roll.hours=3
-  log.retention.bytes=250000000
   log.segment.bytes=1073741824
 ```
+
+:::warning Retention settings when this cluster backs Remote WAL
+`log.retention.hours=4` is a testing value. Kafka deletes a segment as soon as
+any retention condition matches, so a retention window shorter than your longest
+flush, failure, or manual-recovery window can remove WAL that GreptimeDB has not
+replayed yet.
+
+Do not add a size-based retention such as `log.retention.bytes` to topics used
+for Remote WAL. See [Required Settings and
+Limitations](/user-guide/deployments-administration/wal/remote-wal/configuration.md#required-settings-and-limitations)
+for the full set of constraints.
+:::
 
 ## Installing Kafka Cluster
 
@@ -166,7 +177,7 @@ kafka-broker-1       1/1     Running   0          8m2s
 kafka-broker-2       1/1     Running   0          8m1s
 kafka-controller-0   1/1     Running   0          8m3s
 kafka-controller-1   1/1     Running   0          8m2s
-kafka-controller-0   1/1     Running   0          8m1s
+kafka-controller-2   1/1     Running   0          8m1s
 ```
 </details>
 

--- a/versioned_docs/version-1.2/user-guide/deployments-administration/wal/remote-wal/manage-kafka.md
+++ b/versioned_docs/version-1.2/user-guide/deployments-administration/wal/remote-wal/manage-kafka.md
@@ -1,103 +1,13 @@
 ---
 keywords: [Kafka, kubernetes, helm, GreptimeDB, remote WAL, installation, configuration, management]
-description: This guide describes how to install and manage Kafka cluster.
+description: How a Kafka cluster is used as GreptimeDB Remote WAL storage, and where to find its deployment and configuration requirements.
 ---
-# Manage Kafka
+# Kafka
 
-The GreptimeDB cluster uses Kafka as the [Remote WAL](/user-guide/deployments-administration/wal/remote-wal/configuration.md) storage. This guide describes how to manage Kafka cluster. This guide will use Bitnami's Kafka Helm [chart](https://github.com/bitnami/charts/tree/main/bitnami/kafka) as an example.
+When [Remote WAL](/user-guide/deployments-administration/wal/overview.md#remote-wal) is enabled, the GreptimeDB cluster writes its write-ahead log to Kafka instead of local disks. Datanodes append WAL entries to Kafka topics, and Metasrv prunes entries that are no longer needed for recovery.
 
-## Prerequisites
+Until a region flushes to object storage, Kafka may hold the only durable copy of those writes. Treat it as a stateful dependency of the database, not as a transport buffer. Getting the retention policy wrong is the most common way to lose data here: Kafka deletes segments on its own schedule, and a WAL entry deleted before GreptimeDB replays it cannot be recovered.
 
-- [Kubernetes](https://kubernetes.io/docs/setup/) >= v1.23
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) >= v1.18.0
-- [Helm](https://helm.sh/docs/intro/install/) >= v3.0.0
-
-## Install
-
-Save the following configuration as a file `kafka.yaml`:
-
-```yaml
-global:
-  security:
-    allowInsecureImages: true
-
-image:
-  registry: docker.io
-  repository: greptime/kafka
-  tag: 3.9.0-debian-12-r12
-
-controller:
-  replicaCount: 3
-
-  resources:
-    requests:
-      cpu: 2
-      memory: 2Gi
-    limits:
-      cpu: 2
-      memory: 2Gi
-
-  persistence:
-    enabled: true
-    size: 200Gi
-
-broker:
-  replicaCount: 3
-
-  resources:
-    requests:
-      cpu: 2
-      memory: 2Gi
-    limits:
-      cpu: 2
-      memory: 2Gi
-
-  persistence:
-    enabled: true
-    size: 200Gi
-
-listeners:
-  client:
-    # When deploying on production environment, you normally want to use a more secure protocol like SASL.
-    # Please refer to the chart's docs for the "how-to": https://artifacthub.io/packages/helm/bitnami/kafka#enable-security-for-kafka
-    # Here for the sake of example's simplicity, we use plaintext (no authentications).
-    protocol: plaintext
-```
-
-Install Kafka cluster:
-
-```bash
-helm upgrade --install kafka \
-    oci://registry-1.docker.io/bitnamicharts/kafka \
-    --values kafka.yaml \
-    --version 32.4.3 \
-    --create-namespace \
-    -n kafka-cluster
-```
-
-Wait for Kafka cluster to be ready:
-
-```bash
-kubectl wait --for=condition=ready pod \
-    -l app.kubernetes.io/instance=kafka \
-    -n kafka-cluster \
-```
-
-Check the status of the Kafka cluster:
-
-```bash
-kubectl get pods -n kafka-cluster
-```
-
-<details>
-  <summary>Expected Output</summary>
-```bash
-NAME                 READY   STATUS    RESTARTS   AGE
-kafka-controller-0   1/1     Running   0          64s
-kafka-controller-1   1/1     Running   0          64s
-kafka-controller-2   1/1     Running   0          64s
-kafka-broker-0       1/1     Running   0          63s
-kafka-broker-1       1/1     Running   0          62s
-kafka-broker-2       1/1     Running   0          61s
-```
-</details>
+- [Deploying Kafka Cluster](/user-guide/deployments-administration/deploy-on-kubernetes/deploy-kafka.md) — installation, verification, monitoring, and uninstallation with the Bitnami Kafka Helm chart.
+- [Remote WAL Configuration](/user-guide/deployments-administration/wal/remote-wal/configuration.md) — the Metasrv and Datanode `[wal]` options, plus the [required settings and limitations](/user-guide/deployments-administration/wal/remote-wal/configuration.md#required-settings-and-limitations) the Kafka cluster must satisfy.
+- [Configure Remote WAL](/user-guide/deployments-administration/deploy-on-kubernetes/configure-remote-wal.md) — a complete Helm chart example on Kubernetes.


### PR DESCRIPTION
## What changed

`deploy-kafka.md` and `wal/remote-wal/manage-kafka.md` both covered Helm installation, verification and Remote WAL endpoints, but with different chart versions (31.0.0 vs 32.4.3), image tags (`-r1` vs `-r12`), namespaces and resource sizing. Neither page read as authoritative.

- `deploy-kafka.md` stays the installation guide (install, verify, monitoring, Grafana dashboard, uninstall).
- `manage-kafka.md` becomes the Remote WAL perspective: what Kafka holds in this setup, and links to deployment, requirements and GreptimeDB-side configuration. It no longer repeats the install steps.
- Removed `log.retention.bytes=250000000` from the example `extraConfig`, and annotated `log.retention.hours=4` as a testing value. `wal/remote-wal/configuration.md` already states that Remote WAL topics must not use size-based retention; Kafka deletes a segment as soon as any retention condition matches, which can remove WAL that GreptimeDB has not replayed. `overwrite_entry_start_id = true` does not protect against this — it advances the read position to the earliest available offset and skips the deleted entries.
- Fixed a duplicated `kafka-controller-0` in the expected `kubectl get pod` output.

No version numbers were changed. Chart 31.0.0 has appVersion 3.9.0, which matches the image `deploy-kafka.md` pins. The mismatched pairing was `manage-kafka.md`'s chart 32.4.3 (appVersion 4.0.0) with a 3.9.0 image; it goes away with the install section.

Both URLs stay live — the repository has no client-redirects plugin, so neither page could be deleted.

## Scope

- Documentation versions: Nightly, 1.2, 1.1
- Languages: English, Chinese

## Verification

```
git diff --check
DOC_LANG=en pnpm check:links
DOC_LANG=zh pnpm check:links
```

Both link checks pass. `onBrokenAnchors` is `throw` under `DOCS_LINK_CHECK`, so the two new cross-page anchors are validated. Also confirmed against the build output that both `deploy-kafka` and `manage-kafka` still emit `index.html`, and that the Chinese `configuration` page really carries `id="注意事项与限制"`.

## Known item

`manage-kafka.md` previously set `global.security.allowInsecureImages: true`; `deploy-kafka.md` does not. Chart 31.0.0 (released 2024-11-12) predates the Bitnami image guard, so it likely does not need the key — but `deploy-kafka.md`'s expected output shows `Substituted images detected`, which comes from that feature. Not resolved here; it needs a real `helm install` to confirm. Flagging rather than guessing.

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] I updated navigation when the document structure changed. Both pages keep their existing sidebar placement — `manage-kafka` under Remote WAL, `deploy-kafka` reachable from the Kubernetes overview and enterprise installation pages — so no navigation change was needed.