### PR TITLE
docs: correct deployment resource names and integration prerequisites

### DIFF
--- a/docs/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/docs/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -325,9 +325,13 @@ objectStorage:
     endpoint: ""
 ```
 
-#### Using AWS EKS Pod Identity for S3
+<AnchorAlias id="using-aws-eks-pod-identity-for-s3" />
 
-Instead of providing static access keys, you can use [AWS EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) (IAM Roles for Service Accounts) to grant S3 access to GreptimeDB. This approach is more secure as it eliminates the need to manage long-lived credentials.
+#### Using IAM Roles for Service Accounts (IRSA) for S3
+
+Instead of providing static access keys, you can use [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) (IRSA) to grant S3 access to GreptimeDB. This approach is more secure as it eliminates the need to manage long-lived credentials.
+
+IRSA and [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) are two different mechanisms. The configuration below is IRSA: it annotates the service account with the role ARN. Pod Identity instead requires a pod identity association and no such annotation.
 
 First, configure the datanode service account with the IAM role annotation. Only the datanode reads from and writes to S3:
 
@@ -358,7 +362,7 @@ objectStorage:
 ```
 
 :::note
-When using EKS Pod Identity, omit the `objectStorage.credentials` section entirely. The datanode pods will automatically obtain temporary credentials through the IAM role associated with the service account.
+When using IRSA, omit the `objectStorage.credentials` section entirely. The datanode pods will automatically obtain temporary credentials through the IAM role associated with the service account.
 :::
 
 #### Google Cloud Storage

--- a/docs/user-guide/deployments-administration/deploy-on-kubernetes/deploy-minio.md
+++ b/docs/user-guide/deployments-administration/deploy-on-kubernetes/deploy-minio.md
@@ -49,7 +49,25 @@ persistence:
   size: 100Gi
 ```
 
-The root credentials are deliberately absent from this file. Helm reads a values file as plain YAML and does not expand shell variables in it, so a `${MINIO_ROOT_USER}` placeholder would be installed verbatim. Pass them on the command line as shown below, or keep them out of your shell history entirely by creating a Secret and setting `auth.existingSecret` along with `auth.rootUserSecretKey` and `auth.rootPasswordSecretKey`.
+The root credentials are deliberately absent from this file. Helm reads a values file as plain YAML and does not expand shell variables in it, so a `${MINIO_ROOT_USER}` placeholder would be installed verbatim.
+
+Create a Secret and point the chart at it instead. Avoid `--set-string` for the password: Helm splits that value on commas itself, so a password containing one fails to parse no matter how the shell quotes it.
+
+```bash
+kubectl create namespace minio
+kubectl -n minio create secret generic minio-root-credentials \
+  --from-literal=root-user="$MINIO_ROOT_USER" \
+  --from-literal=root-password="$MINIO_ROOT_PASSWORD"
+```
+
+Then reference it from `minio-values.yaml`:
+
+```yaml
+auth:
+  existingSecret: minio-root-credentials
+  rootUserSecretKey: root-user
+  rootPasswordSecretKey: root-password
+```
 
 These root credentials are for administering MinIO and signing in to its console. GreptimeDB does not use them — it connects with a separate Access Key that you create in [Generating Access Key](#generating-access-key), which you can scope with its own permission policy.
 
@@ -62,9 +80,7 @@ helm upgrade \
   --install minio oci://registry-1.docker.io/bitnamicharts/minio \
   --create-namespace \
   --version 16.0.10 \
-  -n minio --values minio-values.yaml \
-  --set-string auth.rootUser="$MINIO_ROOT_USER" \
-  --set-string auth.rootPassword="$MINIO_ROOT_PASSWORD"
+  -n minio --values minio-values.yaml
 ```
 
 <details>
@@ -153,7 +169,7 @@ kubectl port-forward -n minio svc/minio 9001:9001
 
 2. Open your browser: http://localhost:9001/login
 
-3. Log in with the root credentials you supplied at install time.
+3. Log in with the root credentials held in the `minio-root-credentials` Secret.
 
 ![MinIO login](/minio-login-page.png)
 

--- a/docs/user-guide/deployments-administration/deploy-on-kubernetes/deploy-minio.md
+++ b/docs/user-guide/deployments-administration/deploy-on-kubernetes/deploy-minio.md
@@ -27,10 +27,6 @@ image:
   repository: greptime/minio
   tag: 2025.4.22-debian-12-r1
 
-auth:
-  rootUser: ${MINIO_ROOT_USER}
-  rootPassword: ${MINIO_ROOT_PASSWORD}
-
 resources:
   requests:
     cpu: 500m
@@ -53,7 +49,9 @@ persistence:
   size: 100Gi
 ```
 
-`auth.rootUser` and `auth.rootPassword` are the MinIO root credentials, and GreptimeDB uses them to reach the bucket. Supply them from your own secret store rather than committing them to `minio-values.yaml` — for example with `--set` at install time, or by pointing the chart at an existing Secret through `auth.existingSecret`.
+The root credentials are deliberately absent from this file. Helm reads a values file as plain YAML and does not expand shell variables in it, so a `${MINIO_ROOT_USER}` placeholder would be installed verbatim. Pass them on the command line as shown below, or keep them out of your shell history entirely by creating a Secret and setting `auth.existingSecret` along with `auth.rootUserSecretKey` and `auth.rootPasswordSecretKey`.
+
+These root credentials are for administering MinIO and signing in to its console. GreptimeDB does not use them — it connects with a separate Access Key that you create in [Generating Access Key](#generating-access-key), which you can scope with its own permission policy.
 
 ## Installing MinIO Cluster
 
@@ -64,7 +62,9 @@ helm upgrade \
   --install minio oci://registry-1.docker.io/bitnamicharts/minio \
   --create-namespace \
   --version 16.0.10 \
-  -n minio --values minio-values.yaml
+  -n minio --values minio-values.yaml \
+  --set-string auth.rootUser="$MINIO_ROOT_USER" \
+  --set-string auth.rootPassword="$MINIO_ROOT_PASSWORD"
 ```
 
 <details>
@@ -153,7 +153,7 @@ kubectl port-forward -n minio svc/minio 9001:9001
 
 2. Open your browser: http://localhost:9001/login
 
-3. Log in using the credentials set in the configuration file, that is the values of `auth.rootUser` and `auth.rootPassword`.
+3. Log in with the root credentials you supplied at install time.
 
 ![MinIO login](/minio-login-page.png)
 

--- a/docs/user-guide/deployments-administration/deploy-on-kubernetes/deploy-minio.md
+++ b/docs/user-guide/deployments-administration/deploy-on-kubernetes/deploy-minio.md
@@ -28,8 +28,8 @@ image:
   tag: 2025.4.22-debian-12-r1
 
 auth:
-  rootUser: greptimedbadmin
-  rootPassword: "greptimedbadmin"  
+  rootUser: ${MINIO_ROOT_USER}
+  rootPassword: ${MINIO_ROOT_PASSWORD}
 
 resources:
   requests:
@@ -52,6 +52,8 @@ persistence:
   storageClass: null
   size: 100Gi
 ```
+
+`auth.rootUser` and `auth.rootPassword` are the MinIO root credentials, and GreptimeDB uses them to reach the bucket. Supply them from your own secret store rather than committing them to `minio-values.yaml` — for example with `--set` at install time, or by pointing the chart at an existing Secret through `auth.existingSecret`.
 
 ## Installing MinIO Cluster
 
@@ -87,7 +89,7 @@ Did you know there are enterprise versions of the Bitnami catalog? For enhanced 
 
 ** Please be patient while the chart is being deployed **
 
-MinIO&reg; can be accessed via port  on the following DNS name from within your cluster:
+MinIO&reg; can be accessed via port 9000 on the following DNS name from within your cluster:
 
 minio.minio.svc.cluster.local
 
@@ -151,9 +153,7 @@ kubectl port-forward -n minio svc/minio 9001:9001
 
 2. Open your browser: http://localhost:9001/login
 
-3. Log in using the credentials set in the configuration file:
-- username: `greptimedbadmin`
-- password: `greptimedbadmin`
+3. Log in using the credentials set in the configuration file, that is the values of `auth.rootUser` and `auth.rootPassword`.
 
 ![MinIO login](/minio-login-page.png)
 
@@ -208,8 +208,8 @@ objectStorage:
 
 # Monitoring
 
-- Install Prometheus Operator (e.g: [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack))。
-- Install podmonitor CRD。
+- Install Prometheus Operator (e.g: [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)).
+- Install the ServiceMonitor CRD.
 
 To monitor the MinIO cluster, you need to have a monitoring system (such as Prometheus and Grafana) deployed in advance. Then add the following content to minio-values.yaml and re-run the command to update the MinIO configuration:
 

--- a/docs/user-guide/deployments-administration/monitoring/cluster-monitoring-deployment.md
+++ b/docs/user-guide/deployments-administration/monitoring/cluster-monitoring-deployment.md
@@ -120,7 +120,7 @@ This deploys a `GreptimeDBStandalone` resource named `${cluster-name}-monitor` t
 kubectl get greptimedbstandalones.greptime.io ${cluster-name}-monitor -n ${namespace}
 ```
 
-The workloads it creates — Service, StatefulSet and Pods — are named `${cluster-name}-monitor-standalone`, not after the resource itself. You can use the following addresses to access monitoring data:
+The Service and StatefulSet it creates are named `${cluster-name}-monitor-standalone`, and the Pods add the usual StatefulSet ordinal, for example `${cluster-name}-monitor-standalone-0`. You can use the following addresses to access monitoring data:
 
 - **Prometheus metrics**: `http://${cluster-name}-monitor-standalone.${namespace}.svc.cluster.local:4000/v1/prometheus`
 - **SQL logs**: `${cluster-name}-monitor-standalone.${namespace}.svc.cluster.local:4002`. By default, cluster logs are stored in the `public._gt_logs` table.

--- a/docs/user-guide/deployments-administration/monitoring/cluster-monitoring-deployment.md
+++ b/docs/user-guide/deployments-administration/monitoring/cluster-monitoring-deployment.md
@@ -114,13 +114,13 @@ monitoring:
   enabled: true
 ```
 
-This deploys a GreptimeDB Standalone instance named `${cluster-name}-monitoring` to collect metrics and logs. You can verify the deployment with:
+This deploys a `GreptimeDBStandalone` resource named `${cluster-name}-monitor` to collect metrics and logs. You can verify the deployment with:
 
 ```bash
-kubectl get greptimedbstandalones.greptime.io ${cluster-name}-monitoring -n ${namespace}
+kubectl get greptimedbstandalones.greptime.io ${cluster-name}-monitor -n ${namespace}
 ```
 
-The GreptimeDB Standalone instance exposes services using `${cluster-name}-monitoring-standalone` as the Kubernetes Service name. You can use the following addresses to access monitoring data:
+The workloads it creates — Service, StatefulSet and Pods — are named `${cluster-name}-monitor-standalone`, not after the resource itself. You can use the following addresses to access monitoring data:
 
 - **Prometheus metrics**: `http://${cluster-name}-monitor-standalone.${namespace}.svc.cluster.local:4000/v1/prometheus`
 - **SQL logs**: `${cluster-name}-monitor-standalone.${namespace}.svc.cluster.local:4002`. By default, cluster logs are stored in the `public._gt_logs` table.
@@ -287,12 +287,12 @@ Navigate to the `Dashboards` section to explore the pre-configured dashboards fo
 ## Cleanup the PVCs
 
 :::danger
-The cleanup operation will remove the metadata and data of the GreptimeDB cluster. Please make sure you have backed up the data before proceeding.
+This removes the collected metrics and logs stored by the monitoring standalone instance. It does not touch the data of the GreptimeDB cluster itself, but the monitoring history is not recoverable afterwards.
 :::
 To uninstall the GreptimeDB cluster, please refer to the [Cleanup GreptimeDB Cluster](/user-guide/deployments-administration/deploy-on-kubernetes/deploy-greptimedb-cluster.md#cleanup) documentation.
 
 To clean up the Persistent Volume Claims (PVCs) used by the GreptimeDB standalone monitoring instance, delete the PVCs using the following command:
 
 ```bash
-kubectl -n default delete pvc -l app.greptime.io/component=${cluster-name}-monitor-standalone
+kubectl -n ${namespace} delete pvc -l app.greptime.io/component=${cluster-name}-monitor-standalone
 ```

--- a/docs/user-guide/integrations/grafana.md
+++ b/docs/user-guide/integrations/grafana.md
@@ -131,7 +131,7 @@ Select the `Traces` query type when you want to query distributed tracing data.
 | **Operation Name Column** | Default value: `span_name`                                                                            |
 | **Start Time Column** | Default value: `timestamp`                                                                              |
 | **Duration Time Column** | Default value: `duration_nano`                                                                          |
-| **Duration Unit** | Default value: `nano_seconds`                                                                           |
+| **Duration Unit** | Default value: `nanoseconds`                                                                           |
 | **Tags Column** | Multiple selections allowed. Corresponds to columns starting with `span_attributes` (e.g., `span_attributes.http.method`). |
 | **Service Tags Column** | Multiple selections allowed. Corresponds to columns starting with `resource_attributes` (e.g., `resource_attributes.host.name`). |
 

--- a/docs/user-guide/integrations/mindsdb.md
+++ b/docs/user-guide/integrations/mindsdb.md
@@ -9,8 +9,15 @@ description: Guide on configuring GreptimeDB as a data source in MindsDB for mac
 enables developers to easily incorporate advanced machine learning capabilities
 with existing databases.
 
-Your GreptimeDB instance work out of box as using GreptimeDB extension with
-MindsDB. You can configure GreptimeDB as a data source in MindsDB using MySQL protocol:
+MindsDB reaches GreptimeDB through the MySQL protocol using its GreptimeDB handler.
+
+The handler ships as a [community handler](https://github.com/mindsdb/community-handlers/tree/main/community_handlers/greptimedb_handler), and community handlers are disabled by default. Enable them before creating the data source, then restart MindsDB:
+
+```bash
+export MINDSDB_COMMUNITY_HANDLERS=true
+```
+
+Once enabled, configure GreptimeDB as a data source:
 
 ```sql
 CREATE DATABASE greptime_datasource

--- a/docs/user-guide/integrations/perses.md
+++ b/docs/user-guide/integrations/perses.md
@@ -127,7 +127,13 @@ See [PromQL](/user-guide/query-data/promql.md) for query syntax.
 
 ## Migrate Grafana dashboards
 
-GreptimeDB is compatible with the Prometheus ecosystem. You can import existing Grafana dashboards into Perses with the [Perses migration tool](https://perses.dev/perses/docs/migration/). After migration, map PromQL panels to the **Prometheus** datasource pointing at GreptimeDB. Variables, gauges, and time series panels from dashboards such as Node Exporter should work without changes to the queries.
+GreptimeDB is compatible with the Prometheus ecosystem. You can import existing Grafana dashboards into Perses with the [Perses migration tool](https://perses.dev/perses/docs/migration/). After migration, map PromQL panels to the **Prometheus** datasource pointing at GreptimeDB.
+
+The migration is best-effort, so review the result rather than assuming it is complete:
+
+- Only dashboards are migrated. Alerts, users and other Grafana resources are not.
+- Upstream supports Grafana 9.0.0 through 11.x. Outside that range the migration is not guaranteed to work.
+- Perses does not implement every Grafana plugin. Panels and variables it cannot map are replaced with static placeholders, which you then have to rebuild by hand.
 
 ## Next steps
 

--- a/docs/user-guide/integrations/superset.md
+++ b/docs/user-guide/integrations/superset.md
@@ -14,7 +14,9 @@ follow this guide.
 ### Running Superset with Docker Compose
 
 [Docker compose](https://superset.apache.org/docs/installation/docker-compose)
-is the recommended way to run Superset. To add GreptimeDB extension, create a
+is the quickest way to try Superset locally. Upstream states it does not support
+or recommend the `docker compose` constructs for production use, so treat this
+path as evaluation only. To add GreptimeDB extension, create a
 `requirements-local.txt` file in `docker/` of Superset codebase.
 
 Add GreptimeDB dependency in `requirements-local.txt`:
@@ -38,6 +40,13 @@ to the same environment.
 ```bash
 pip install greptimedb-sqlalchemy
 ```
+
+:::note SQLAlchemy version
+`greptimedb-sqlalchemy` currently requires SQLAlchemy 1.x. Superset 6.1.0 and
+earlier pin SQLAlchemy 1.4, so the two are compatible today. Superset's main
+branch has moved to SQLAlchemy 2.0, so a later Superset release will need a
+dialect that supports 2.0 first.
+:::
 
 ## Add GreptimeDB as database
 

--- a/docs/user-guide/integrations/superset.md
+++ b/docs/user-guide/integrations/superset.md
@@ -42,10 +42,11 @@ pip install greptimedb-sqlalchemy
 ```
 
 :::note SQLAlchemy version
-`greptimedb-sqlalchemy` currently requires SQLAlchemy 1.x. Superset 6.1.0 and
-earlier pin SQLAlchemy 1.4, so the two are compatible today. Superset's main
-branch has moved to SQLAlchemy 2.0, so a later Superset release will need a
-dialect that supports 2.0 first.
+`greptimedb-sqlalchemy` requires `sqlalchemy>=1.4,<2`. Superset 6.1.0, the
+current release, pins SQLAlchemy 1.4.54 and works with it. Superset's main
+branch has moved to SQLAlchemy 2.0, so a later release will need a dialect that
+supports 2.0 first. If you run an older Superset, check its own SQLAlchemy pin
+against that range.
 :::
 
 ## Add GreptimeDB as database

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -325,9 +325,13 @@ objectStorage:
     endpoint: ""
 ```
 
-#### 使用 AWS EKS Pod Identity 访问 S3
+<AnchorAlias id="使用-aws-eks-pod-identity-访问-s3" />
 
-除了提供静态访问密钥外，你还可以使用 [AWS EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)（IAM Roles for Service Accounts）来授予 GreptimeDB 访问 S3 的权限。这种方式更加安全，因为无需管理长期有效的凭证。
+#### 使用 IAM Roles for Service Accounts（IRSA）访问 S3
+
+除了提供静态访问密钥外，你还可以使用 [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)（IRSA）来授予 GreptimeDB 访问 S3 的权限。这种方式更加安全，因为无需管理长期有效的凭证。
+
+IRSA 和 [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) 是两种不同的机制。下面的配置是 IRSA：通过给 Service Account 加上 role ARN 注解来授权。Pod Identity 则需要建立 pod identity association，不使用这个注解。
 
 首先，为 datanode 的 Service Account 配置 IAM 角色注解。只有 datanode 会读写 S3：
 
@@ -357,7 +361,7 @@ objectStorage:
 ```
 
 :::note
-使用 EKS Pod Identity 时，请完全省略 `objectStorage.credentials` 部分。datanode Pod 将通过与 Service Account 关联的 IAM 角色自动获取临时凭证。
+使用 IRSA 时，请完全省略 `objectStorage.credentials` 部分。datanode Pod 将通过与 Service Account 关联的 IAM 角色自动获取临时凭证。
 :::
 
 #### Google Cloud Storage

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -331,7 +331,7 @@ objectStorage:
 
 除了提供静态访问密钥外，你还可以使用 [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)（IRSA）来授予 GreptimeDB 访问 S3 的权限。这种方式更加安全，因为无需管理长期有效的凭证。
 
-IRSA 和 [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) 是两种不同的机制。下面的配置是 IRSA：通过给 Service Account 加上 role ARN 注解来授权。Pod Identity 则需要建立 pod identity association，不使用这个注解。
+IRSA 与 [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) 是两种不同的机制。下面这份配置属于 IRSA，通过在 Service Account 上标注 role ARN 完成授权；Pod Identity 则需要建立 pod identity association，并不使用该注解。
 
 首先，为 datanode 的 Service Account 配置 IAM 角色注解。只有 datanode 会读写 S3：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/deploy-minio.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/deploy-minio.md
@@ -27,10 +27,6 @@ image:
   repository: greptime/minio
   tag: 2025.4.22-debian-12-r1
 
-auth:
-  rootUser: ${MINIO_ROOT_USER}
-  rootPassword: ${MINIO_ROOT_PASSWORD}
-
 resources:
   requests:
     cpu: 500m
@@ -53,7 +49,9 @@ persistence:
   size: 100Gi
 ```
 
-`auth.rootUser` 和 `auth.rootPassword` 是 MinIO 的 root 凭证，GreptimeDB 也用它们访问 bucket。请从你自己的密钥管理方式提供，不要把它们提交到 `minio-values.yaml` 里——例如安装时用 `--set` 传入，或通过 `auth.existingSecret` 指向已有的 Secret。
+这个文件里刻意没有放 root 凭证。Helm 把 values 文件当作普通 YAML 读取，不会展开其中的 shell 变量，写成 `${MINIO_ROOT_USER}` 会被原样安装进去。请按下面的方式在命令行传入；如果不希望凭证出现在 shell 历史里，可以创建 Secret 并设置 `auth.existingSecret`，配合 `auth.rootUserSecretKey` 和 `auth.rootPasswordSecretKey`。
+
+root 凭证用于管理 MinIO 和登录控制台。GreptimeDB 不使用它——GreptimeDB 用的是你在[生成 Access Key](#生成-access-key) 中单独创建的 Access Key，可以为它单独配置权限策略。
 
 ## 安装 MinIO 集群
 
@@ -64,7 +62,9 @@ helm upgrade \
   --install minio oci://greptime-registry.cn-hangzhou.cr.aliyuncs.com/charts/minio \
   --create-namespace \
   --version 16.0.10 \
-  -n minio --values minio-values.yaml
+  -n minio --values minio-values.yaml \
+  --set-string auth.rootUser="$MINIO_ROOT_USER" \
+  --set-string auth.rootPassword="$MINIO_ROOT_PASSWORD"
 ```
 
 <details>
@@ -153,7 +153,7 @@ kubectl port-forward -n minio svc/minio 9001:9001
 
 2. 打开浏览器访问 http://localhost:9001/login
 
-3. 使用配置文件中设置的账号密码登录，即 `auth.rootUser` 和 `auth.rootPassword` 的值。
+3. 使用安装时传入的 root 凭证登录。
 
 ![MinIO login](/minio-login-page.png)
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/deploy-minio.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/deploy-minio.md
@@ -28,8 +28,8 @@ image:
   tag: 2025.4.22-debian-12-r1
 
 auth:
-  rootUser: greptimedbadmin
-  rootPassword: "greptimedbadmin"  
+  rootUser: ${MINIO_ROOT_USER}
+  rootPassword: ${MINIO_ROOT_PASSWORD}
 
 resources:
   requests:
@@ -52,6 +52,8 @@ persistence:
   storageClass: null
   size: 100Gi
 ```
+
+`auth.rootUser` 和 `auth.rootPassword` 是 MinIO 的 root 凭证，GreptimeDB 也用它们访问 bucket。请从你自己的密钥管理方式提供，不要把它们提交到 `minio-values.yaml` 里——例如安装时用 `--set` 传入，或通过 `auth.existingSecret` 指向已有的 Secret。
 
 ## 安装 MinIO 集群
 
@@ -87,7 +89,7 @@ Did you know there are enterprise versions of the Bitnami catalog? For enhanced 
 
 ** Please be patient while the chart is being deployed **
 
-MinIO&reg; can be accessed via port  on the following DNS name from within your cluster:
+MinIO&reg; can be accessed via port 9000 on the following DNS name from within your cluster:
 
 minio.minio.svc.cluster.local
 
@@ -151,9 +153,7 @@ kubectl port-forward -n minio svc/minio 9001:9001
 
 2. 打开浏览器访问 http://localhost:9001/login
 
-3. 使用配置文件中设置的账号密码登录：
-- username: `greptimedbadmin`
-- password: `greptimedbadmin`
+3. 使用配置文件中设置的账号密码登录，即 `auth.rootUser` 和 `auth.rootPassword` 的值。
 
 ![MinIO login](/minio-login-page.png)
 
@@ -209,7 +209,7 @@ objectStorage:
 # 监控
 
 - 安装 Prometheus Operator (例如: [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack))。
-- 安装 podmonitor CRD。
+- 安装 ServiceMonitor CRD。
 
 要监控 MinIO 集群，你需要提前部署好监控系统（如 Prometheus 和 Grafana）。然后在 `minio-values.yaml` 中增加以下内容，并重新执行更新 MinIO 配置：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/deploy-minio.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/deploy-on-kubernetes/deploy-minio.md
@@ -49,9 +49,27 @@ persistence:
   size: 100Gi
 ```
 
-这个文件里刻意没有放 root 凭证。Helm 把 values 文件当作普通 YAML 读取，不会展开其中的 shell 变量，写成 `${MINIO_ROOT_USER}` 会被原样安装进去。请按下面的方式在命令行传入；如果不希望凭证出现在 shell 历史里，可以创建 Secret 并设置 `auth.existingSecret`，配合 `auth.rootUserSecretKey` 和 `auth.rootPasswordSecretKey`。
+这里没有写入 root 凭证。Helm 读取 values 文件时只当作普通 YAML，不会展开 shell 变量，`${MINIO_ROOT_USER}` 会被当作字面量写进配置。
 
-root 凭证用于管理 MinIO 和登录控制台。GreptimeDB 不使用它——GreptimeDB 用的是你在[生成 Access Key](#生成-access-key) 中单独创建的 Access Key，可以为它单独配置权限策略。
+凭证改用 Secret 保存，再让 chart 引用。密码不要走 `--set-string`：Helm 会对该值按逗号分段，密码中含逗号就会解析失败，在 shell 层加引号也无济于事。
+
+```bash
+kubectl create namespace minio
+kubectl -n minio create secret generic minio-root-credentials \
+  --from-literal=root-user="$MINIO_ROOT_USER" \
+  --from-literal=root-password="$MINIO_ROOT_PASSWORD"
+```
+
+然后在 `minio-values.yaml` 中引用：
+
+```yaml
+auth:
+  existingSecret: minio-root-credentials
+  rootUserSecretKey: root-user
+  rootPasswordSecretKey: root-password
+```
+
+root 凭证用于管理 MinIO 和登录控制台，GreptimeDB 并不使用。GreptimeDB 连接时用的是[生成 Access Key](#生成-access-key) 一节中单独创建的 Access Key，可以为其单独设置权限策略。
 
 ## 安装 MinIO 集群
 
@@ -62,9 +80,7 @@ helm upgrade \
   --install minio oci://greptime-registry.cn-hangzhou.cr.aliyuncs.com/charts/minio \
   --create-namespace \
   --version 16.0.10 \
-  -n minio --values minio-values.yaml \
-  --set-string auth.rootUser="$MINIO_ROOT_USER" \
-  --set-string auth.rootPassword="$MINIO_ROOT_PASSWORD"
+  -n minio --values minio-values.yaml
 ```
 
 <details>
@@ -153,7 +169,7 @@ kubectl port-forward -n minio svc/minio 9001:9001
 
 2. 打开浏览器访问 http://localhost:9001/login
 
-3. 使用安装时传入的 root 凭证登录。
+3. 使用 `minio-root-credentials` Secret 中保存的 root 凭证登录。
 
 ![MinIO login](/minio-login-page.png)
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/monitoring/cluster-monitoring-deployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/monitoring/cluster-monitoring-deployment.md
@@ -125,7 +125,7 @@ monitoring:
 kubectl get greptimedbstandalones.greptime.io ${cluster-name}-monitor -n ${namespace}
 ```
 
-它创建出来的工作负载——Service、StatefulSet 和 Pod——名称是 `${cluster-name}-monitor-standalone`，与资源本身的名称不同。你可以使用以下地址访问监控数据：
+它创建的 Service 和 StatefulSet 名称是 `${cluster-name}-monitor-standalone`，Pod 则带上 StatefulSet 的序号后缀，例如 `${cluster-name}-monitor-standalone-0`。你可以使用以下地址访问监控数据：
 
 - **Prometheus 指标**：`http://${cluster-name}-monitor-standalone.${namespace}.svc.cluster.local:4000/v1/prometheus`
 - **SQL 日志**：`${cluster-name}-monitor-standalone.${namespace}.svc.cluster.local:4002`。默认情况下，集群日志存储在 `public._gt_logs` 表中。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/monitoring/cluster-monitoring-deployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/monitoring/cluster-monitoring-deployment.md
@@ -125,7 +125,7 @@ monitoring:
 kubectl get greptimedbstandalones.greptime.io ${cluster-name}-monitor -n ${namespace}
 ```
 
-它创建的 Service 和 StatefulSet 名称是 `${cluster-name}-monitor-standalone`，Pod 则带上 StatefulSet 的序号后缀，例如 `${cluster-name}-monitor-standalone-0`。你可以使用以下地址访问监控数据：
+它创建的 Service 和 StatefulSet 名为 `${cluster-name}-monitor-standalone`，Pod 在此基础上带 StatefulSet 序号，例如 `${cluster-name}-monitor-standalone-0`。你可以使用以下地址访问监控数据：
 
 - **Prometheus 指标**：`http://${cluster-name}-monitor-standalone.${namespace}.svc.cluster.local:4000/v1/prometheus`
 - **SQL 日志**：`${cluster-name}-monitor-standalone.${namespace}.svc.cluster.local:4002`。默认情况下，集群日志存储在 `public._gt_logs` 表中。
@@ -292,7 +292,7 @@ kubectl -n ${namespace} port-forward svc/${cluster-name}-grafana 18080:80
 ## 清理 PVC
 
 :::danger
-该操作会删除监控用单机实例存储的指标和日志，不会影响 GreptimeDB 集群本身的数据，但监控历史删除后无法恢复。
+该操作删除的是监控单机实例中存储的指标与日志，不影响 GreptimeDB 集群自身的数据；但监控历史一经删除便无法恢复。
 :::
 
 请参考[清理 GreptimeDB 集群](/user-guide/deployments-administration/deploy-on-kubernetes/deploy-greptimedb-cluster.md#cleanup)文档

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/monitoring/cluster-monitoring-deployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/monitoring/cluster-monitoring-deployment.md
@@ -119,13 +119,13 @@ monitoring:
   enabled: true
 ```
 
-这将部署一个名为 `${cluster-name}-monitoring` 的 GreptimeDB Standalone 实例来收集指标和日志。你可以使用以下命令验证部署：
+这将部署一个名为 `${cluster-name}-monitor` 的 `GreptimeDBStandalone` 资源来收集指标和日志。你可以使用以下命令验证部署：
 
 ```bash
-kubectl get greptimedbstandalones.greptime.io ${cluster-name}-monitoring -n ${namespace}
+kubectl get greptimedbstandalones.greptime.io ${cluster-name}-monitor -n ${namespace}
 ```
 
-GreptimeDB Standalone 实例使用 `${cluster-name}-monitoring-standalone` 作为 Kubernetes Service 名称来暴露服务。你可以使用以下地址访问监控数据：
+它创建出来的工作负载——Service、StatefulSet 和 Pod——名称是 `${cluster-name}-monitor-standalone`，与资源本身的名称不同。你可以使用以下地址访问监控数据：
 
 - **Prometheus 指标**：`http://${cluster-name}-monitor-standalone.${namespace}.svc.cluster.local:4000/v1/prometheus`
 - **SQL 日志**：`${cluster-name}-monitor-standalone.${namespace}.svc.cluster.local:4002`。默认情况下，集群日志存储在 `public._gt_logs` 表中。
@@ -292,7 +292,7 @@ kubectl -n ${namespace} port-forward svc/${cluster-name}-grafana 18080:80
 ## 清理 PVC
 
 :::danger
-清理操作将移除 GreptimeDB 集群的元数据和数据，请确保在操作前已备份数据。
+该操作会删除监控用单机实例存储的指标和日志，不会影响 GreptimeDB 集群本身的数据，但监控历史删除后无法恢复。
 :::
 
 请参考[清理 GreptimeDB 集群](/user-guide/deployments-administration/deploy-on-kubernetes/deploy-greptimedb-cluster.md#cleanup)文档
@@ -301,5 +301,5 @@ kubectl -n ${namespace} port-forward svc/${cluster-name}-grafana 18080:80
 要清理 GreptimeDB 用于监控的单机数据库的 PVC，请使用以下命令：
 
 ```bash
-kubectl -n default delete pvc -l app.greptime.io/component=${cluster-name}-monitor-standalone
+kubectl -n ${namespace} delete pvc -l app.greptime.io/component=${cluster-name}-monitor-standalone
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/integrations/grafana.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/integrations/grafana.md
@@ -125,7 +125,7 @@ http://<host>:4000
 | Operation Name Column | 初始值 `span_name`
 | Start Time Column | 初始值 `timestamp`
 | Duration Time Column | 初始值 `duration_nano`
-| Duration Unit | 初始值 `nano_seconds`
+| Duration Unit | 初始值 `nanoseconds`
 | Tags Column | 可多选，对应以 `span_attributes` 开头的列
 | Service Tags Column| 可多选，对应以 `resource_attributes` 开头的列
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/integrations/mindsdb.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/integrations/mindsdb.md
@@ -8,8 +8,15 @@ description: 介绍如何将 GreptimeDB 作为 MindsDB 的数据源，用于机�
 [MindsDB](https://mindsdb.com/) 是一个开源的机器学习平台，使开发人员能够轻松地将
 先进的机器学习能力与现有数据库集成。
 
-使用 MindsDB 扩展，你的 GreptimeDB 实例可以开箱即用。
-你可以使用 MySQL 协议将 GreptimeDB 配置为 MindsDB 中的数据源：
+MindsDB 通过其 GreptimeDB handler 使用 MySQL 协议访问 GreptimeDB。
+
+该 handler 属于 [community handler](https://github.com/mindsdb/community-handlers/tree/main/community_handlers/greptimedb_handler)，而 community handler 默认是关闭的。创建数据源之前需要先开启，然后重启 MindsDB：
+
+```bash
+export MINDSDB_COMMUNITY_HANDLERS=true
+```
+
+开启之后，将 GreptimeDB 配置为数据源：
 
 ```sql
 CREATE DATABASE greptime_datasource

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/integrations/mindsdb.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/integrations/mindsdb.md
@@ -8,15 +8,15 @@ description: 介绍如何将 GreptimeDB 作为 MindsDB 的数据源，用于机�
 [MindsDB](https://mindsdb.com/) 是一个开源的机器学习平台，使开发人员能够轻松地将
 先进的机器学习能力与现有数据库集成。
 
-MindsDB 通过其 GreptimeDB handler 使用 MySQL 协议访问 GreptimeDB。
+MindsDB 通过 GreptimeDB handler 以 MySQL 协议连接 GreptimeDB。
 
-该 handler 属于 [community handler](https://github.com/mindsdb/community-handlers/tree/main/community_handlers/greptimedb_handler)，而 community handler 默认是关闭的。创建数据源之前需要先开启，然后重启 MindsDB：
+该 handler 属于 [community handler](https://github.com/mindsdb/community-handlers/tree/main/community_handlers/greptimedb_handler)，默认不启用。创建数据源前需先开启，并重启 MindsDB：
 
 ```bash
 export MINDSDB_COMMUNITY_HANDLERS=true
 ```
 
-开启之后，将 GreptimeDB 配置为数据源：
+开启后即可将 GreptimeDB 配置为数据源：
 
 ```sql
 CREATE DATABASE greptime_datasource

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/integrations/perses.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/integrations/perses.md
@@ -127,7 +127,13 @@ node_cpu_seconds_total{mode="idle"}
 
 ## 迁移 Grafana 仪表盘
 
-GreptimeDB 兼容 Prometheus 生态。可用 [Perses 迁移工具](https://perses.dev/perses/docs/migration/) 导入现有 Grafana 仪表盘。迁移后，将 PromQL 面板映射到指向 GreptimeDB 的 **Prometheus** 数据源。Node Exporter 等大盘的变量、Gauge 和折线图通常无需修改查询语句。
+GreptimeDB 兼容 Prometheus 生态。可用 [Perses 迁移工具](https://perses.dev/perses/docs/migration/) 导入现有 Grafana 仪表盘。迁移后，将 PromQL 面板映射到指向 GreptimeDB 的 **Prometheus** 数据源。
+
+迁移是 best-effort 的，迁移完需要逐个检查结果，不要默认它已经完整：
+
+- 只迁移仪表盘。告警、用户等其他 Grafana 资源不在迁移范围内。
+- 上游支持 Grafana 9.0.0 到 11.x。超出该范围不保证能迁移成功。
+- Perses 并未实现全部 Grafana 插件。无法映射的面板和变量会被替换成静态占位符，需要手工重建。
 
 ## 下一步
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/integrations/perses.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/integrations/perses.md
@@ -129,11 +129,11 @@ node_cpu_seconds_total{mode="idle"}
 
 GreptimeDB 兼容 Prometheus 生态。可用 [Perses 迁移工具](https://perses.dev/perses/docs/migration/) 导入现有 Grafana 仪表盘。迁移后，将 PromQL 面板映射到指向 GreptimeDB 的 **Prometheus** 数据源。
 
-迁移是 best-effort 的，迁移完需要逐个检查结果，不要默认它已经完整：
+迁移只做尽力而为的转换，完成后需逐项核对，不能默认结果是完整的：
 
-- 只迁移仪表盘。告警、用户等其他 Grafana 资源不在迁移范围内。
-- 上游支持 Grafana 9.0.0 到 11.x。超出该范围不保证能迁移成功。
-- Perses 并未实现全部 Grafana 插件。无法映射的面板和变量会被替换成静态占位符，需要手工重建。
+- 仅迁移仪表盘，告警、用户等其他 Grafana 资源不在范围内。
+- 上游支持的 Grafana 版本为 9.0.0 至 11.x，超出这个范围不保证迁移成功。
+- Perses 并未实现全部 Grafana 插件，无法映射的面板和变量会被替换为静态占位符，需要手工重建。
 
 ## 下一步
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/integrations/superset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/integrations/superset.md
@@ -13,8 +13,8 @@ description: 介绍如何将 GreptimeDB 作为 Apache Superset 的数据源，�
 ### 用 Docker Compose 运行 Superset
 
 [Docker compose](https://superset.apache.org/docs/installation/docker-compose)
-是本地快速试用 Superset 最简单的方式。上游明确表示不支持也不建议把 `docker compose`
-用于生产环境，因此这条路径仅用于评估。在这种运行方式下，需要在 Superset 代码目录下的
+是本地试用 Superset 最快的方式。上游明确表示不支持也不建议将 `docker compose`
+用于生产环境，因此请仅将其用于评估。在这种运行方式下，需要在 Superset 代码目录下的
 `docker/` 中添加一个 `requirements-local.txt`。
 
 并将 GreptimeDB 依赖加入到 `requirements-local.txt`:
@@ -41,9 +41,8 @@ pip install greptimedb-sqlalchemy
 
 :::note SQLAlchemy 版本
 `greptimedb-sqlalchemy` 要求 `sqlalchemy>=1.4,<2`。当前发行版 Superset 6.1.0 锁定
-SQLAlchemy 1.4.54，可以正常配合使用。Superset 主分支已升级到 SQLAlchemy 2.0，后续
-版本需要 dialect 先支持 2.0。如果你使用更老的 Superset，请自行核对它锁定的
-SQLAlchemy 版本是否落在上述范围内。
+SQLAlchemy 1.4.54，两者可以配合使用。Superset 主分支已升级到 SQLAlchemy 2.0，后续
+版本需要 dialect 先支持 2.0。若使用更早的 Superset，请自行核对其锁定的 SQLAlchemy 版本是否落在上述范围内。
 :::
 
 ## 添加 GreptimeDB 数据库

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/integrations/superset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/integrations/superset.md
@@ -13,7 +13,8 @@ description: 介绍如何将 GreptimeDB 作为 Apache Superset 的数据源，�
 ### 用 Docker Compose 运行 Superset
 
 [Docker compose](https://superset.apache.org/docs/installation/docker-compose)
-是 Superset 的推荐使用方式。在这种运行方式下，需要在 Superset 代码目录下的
+是本地快速试用 Superset 最简单的方式。上游明确表示不支持也不建议把 `docker compose`
+用于生产环境，因此这条路径仅用于评估。在这种运行方式下，需要在 Superset 代码目录下的
 `docker/` 中添加一个 `requirements-local.txt`。
 
 并将 GreptimeDB 依赖加入到 `requirements-local.txt`:
@@ -37,6 +38,12 @@ Superset](https://superset.apache.org/docs/installation/pypi)，需要将 Grepti
 ```bash
 pip install greptimedb-sqlalchemy
 ```
+
+:::note SQLAlchemy 版本
+`greptimedb-sqlalchemy` 目前要求 SQLAlchemy 1.x。Superset 6.1.0 及更早版本锁定
+SQLAlchemy 1.4，因此当前两者兼容。Superset 主分支已升级到 SQLAlchemy 2.0，后续
+Superset 版本需要 dialect 先支持 2.0。
+:::
 
 ## 添加 GreptimeDB 数据库
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/integrations/superset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/integrations/superset.md
@@ -40,9 +40,10 @@ pip install greptimedb-sqlalchemy
 ```
 
 :::note SQLAlchemy 版本
-`greptimedb-sqlalchemy` 目前要求 SQLAlchemy 1.x。Superset 6.1.0 及更早版本锁定
-SQLAlchemy 1.4，因此当前两者兼容。Superset 主分支已升级到 SQLAlchemy 2.0，后续
-Superset 版本需要 dialect 先支持 2.0。
+`greptimedb-sqlalchemy` 要求 `sqlalchemy>=1.4,<2`。当前发行版 Superset 6.1.0 锁定
+SQLAlchemy 1.4.54，可以正常配合使用。Superset 主分支已升级到 SQLAlchemy 2.0，后续
+版本需要 dialect 先支持 2.0。如果你使用更老的 Superset，请自行核对它锁定的
+SQLAlchemy 版本是否落在上述范围内。
 :::
 
 ## 添加 GreptimeDB 数据库

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -325,9 +325,13 @@ objectStorage:
     endpoint: ""
 ```
 
-#### 使用 AWS EKS Pod Identity 访问 S3
+<AnchorAlias id="使用-aws-eks-pod-identity-访问-s3" />
 
-除了提供静态访问密钥外，你还可以使用 [AWS EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)（IAM Roles for Service Accounts）来授予 GreptimeDB 访问 S3 的权限。这种方式更加安全，因为无需管理长期有效的凭证。
+#### 使用 IAM Roles for Service Accounts（IRSA）访问 S3
+
+除了提供静态访问密钥外，你还可以使用 [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)（IRSA）来授予 GreptimeDB 访问 S3 的权限。这种方式更加安全，因为无需管理长期有效的凭证。
+
+IRSA 与 [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) 是两种不同的机制。下面这份配置属于 IRSA，通过在 Service Account 上标注 role ARN 完成授权；Pod Identity 则需要建立 pod identity association，并不使用该注解。
 
 首先，为 datanode 的 Service Account 配置 IAM 角色注解。只有 datanode 会读写 S3：
 
@@ -357,7 +361,7 @@ objectStorage:
 ```
 
 :::note
-使用 EKS Pod Identity 时，请完全省略 `objectStorage.credentials` 部分。datanode Pod 将通过与 Service Account 关联的 IAM 角色自动获取临时凭证。
+使用 IRSA 时，请完全省略 `objectStorage.credentials` 部分。datanode Pod 将通过与 Service Account 关联的 IAM 角色自动获取临时凭证。
 :::
 
 #### Google Cloud Storage

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/deployments-administration/deploy-on-kubernetes/deploy-minio.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/deployments-administration/deploy-on-kubernetes/deploy-minio.md
@@ -27,10 +27,6 @@ image:
   repository: greptime/minio
   tag: 2025.4.22-debian-12-r1
 
-auth:
-  rootUser: greptimedbadmin
-  rootPassword: "greptimedbadmin"  
-
 resources:
   requests:
     cpu: 500m
@@ -52,6 +48,28 @@ persistence:
   storageClass: null
   size: 100Gi
 ```
+
+这里没有写入 root 凭证。Helm 读取 values 文件时只当作普通 YAML，不会展开 shell 变量，`${MINIO_ROOT_USER}` 会被当作字面量写进配置。
+
+凭证改用 Secret 保存，再让 chart 引用。密码不要走 `--set-string`：Helm 会对该值按逗号分段，密码中含逗号就会解析失败，在 shell 层加引号也无济于事。
+
+```bash
+kubectl create namespace minio
+kubectl -n minio create secret generic minio-root-credentials \
+  --from-literal=root-user="$MINIO_ROOT_USER" \
+  --from-literal=root-password="$MINIO_ROOT_PASSWORD"
+```
+
+然后在 `minio-values.yaml` 中引用：
+
+```yaml
+auth:
+  existingSecret: minio-root-credentials
+  rootUserSecretKey: root-user
+  rootPasswordSecretKey: root-password
+```
+
+root 凭证用于管理 MinIO 和登录控制台，GreptimeDB 并不使用。GreptimeDB 连接时用的是[生成 Access Key](#生成-access-key) 一节中单独创建的 Access Key，可以为其单独设置权限策略。
 
 ## 安装 MinIO 集群
 
@@ -87,7 +105,7 @@ Did you know there are enterprise versions of the Bitnami catalog? For enhanced 
 
 ** Please be patient while the chart is being deployed **
 
-MinIO&reg; can be accessed via port  on the following DNS name from within your cluster:
+MinIO&reg; can be accessed via port 9000 on the following DNS name from within your cluster:
 
 minio.minio.svc.cluster.local
 
@@ -151,9 +169,7 @@ kubectl port-forward -n minio svc/minio 9001:9001
 
 2. 打开浏览器访问 http://localhost:9001/login
 
-3. 使用配置文件中设置的账号密码登录：
-- username: `greptimedbadmin`
-- password: `greptimedbadmin`
+3. 使用 `minio-root-credentials` Secret 中保存的 root 凭证登录。
 
 ![MinIO login](/minio-login-page.png)
 
@@ -209,7 +225,7 @@ objectStorage:
 # 监控
 
 - 安装 Prometheus Operator (例如: [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack))。
-- 安装 podmonitor CRD。
+- 安装 ServiceMonitor CRD。
 
 要监控 MinIO 集群，你需要提前部署好监控系统（如 Prometheus 和 Grafana）。然后在 `minio-values.yaml` 中增加以下内容，并重新执行更新 MinIO 配置：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/deployments-administration/monitoring/cluster-monitoring-deployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/deployments-administration/monitoring/cluster-monitoring-deployment.md
@@ -119,13 +119,13 @@ monitoring:
   enabled: true
 ```
 
-这将部署一个名为 `${cluster-name}-monitoring` 的 GreptimeDB Standalone 实例来收集指标和日志。你可以使用以下命令验证部署：
+这将部署一个名为 `${cluster-name}-monitor` 的 `GreptimeDBStandalone` 资源来收集指标和日志。你可以使用以下命令验证部署：
 
 ```bash
-kubectl get greptimedbstandalones.greptime.io ${cluster-name}-monitoring -n ${namespace}
+kubectl get greptimedbstandalones.greptime.io ${cluster-name}-monitor -n ${namespace}
 ```
 
-GreptimeDB Standalone 实例使用 `${cluster-name}-monitoring-standalone` 作为 Kubernetes Service 名称来暴露服务。你可以使用以下地址访问监控数据：
+它创建的 Service 和 StatefulSet 名为 `${cluster-name}-monitor-standalone`，Pod 在此基础上带 StatefulSet 序号，例如 `${cluster-name}-monitor-standalone-0`。你可以使用以下地址访问监控数据：
 
 - **Prometheus 指标**：`http://${cluster-name}-monitor-standalone.${namespace}.svc.cluster.local:4000/v1/prometheus`
 - **SQL 日志**：`${cluster-name}-monitor-standalone.${namespace}.svc.cluster.local:4002`。默认情况下，集群日志存储在 `public._gt_logs` 表中。
@@ -292,7 +292,7 @@ kubectl -n ${namespace} port-forward svc/${cluster-name}-grafana 18080:80
 ## 清理 PVC
 
 :::danger
-清理操作将移除 GreptimeDB 集群的元数据和数据，请确保在操作前已备份数据。
+该操作删除的是监控单机实例中存储的指标与日志，不影响 GreptimeDB 集群自身的数据；但监控历史一经删除便无法恢复。
 :::
 
 请参考[清理 GreptimeDB 集群](/user-guide/deployments-administration/deploy-on-kubernetes/deploy-greptimedb-cluster.md#cleanup)文档
@@ -301,5 +301,5 @@ kubectl -n ${namespace} port-forward svc/${cluster-name}-grafana 18080:80
 要清理 GreptimeDB 用于监控的单机数据库的 PVC，请使用以下命令：
 
 ```bash
-kubectl -n default delete pvc -l app.greptime.io/component=${cluster-name}-monitor-standalone
+kubectl -n ${namespace} delete pvc -l app.greptime.io/component=${cluster-name}-monitor-standalone
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/integrations/grafana.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/integrations/grafana.md
@@ -125,7 +125,7 @@ http://<host>:4000
 | Operation Name Column | 初始值 `span_name`
 | Start Time Column | 初始值 `timestamp`
 | Duration Time Column | 初始值 `duration_nano`
-| Duration Unit | 初始值 `nano_seconds`
+| Duration Unit | 初始值 `nanoseconds`
 | Tags Column | 可多选，对应以 `span_attributes` 开头的列
 | Service Tags Column| 可多选，对应以 `resource_attributes` 开头的列
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/integrations/mindsdb.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/integrations/mindsdb.md
@@ -8,8 +8,15 @@ description: 介绍如何将 GreptimeDB 作为 MindsDB 的数据源，用于机�
 [MindsDB](https://mindsdb.com/) 是一个开源的机器学习平台，使开发人员能够轻松地将
 先进的机器学习能力与现有数据库集成。
 
-使用 MindsDB 扩展，你的 GreptimeDB 实例可以开箱即用。
-你可以使用 MySQL 协议将 GreptimeDB 配置为 MindsDB 中的数据源：
+MindsDB 通过 GreptimeDB handler 以 MySQL 协议连接 GreptimeDB。
+
+该 handler 属于 [community handler](https://github.com/mindsdb/community-handlers/tree/main/community_handlers/greptimedb_handler)，默认不启用。创建数据源前需先开启，并重启 MindsDB：
+
+```bash
+export MINDSDB_COMMUNITY_HANDLERS=true
+```
+
+开启后即可将 GreptimeDB 配置为数据源：
 
 ```sql
 CREATE DATABASE greptime_datasource

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/integrations/superset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/integrations/superset.md
@@ -13,7 +13,8 @@ description: 介绍如何将 GreptimeDB 作为 Apache Superset 的数据源，�
 ### 用 Docker Compose 运行 Superset
 
 [Docker compose](https://superset.apache.org/docs/installation/docker-compose)
-是 Superset 的推荐使用方式。在这种运行方式下，需要在 Superset 代码目录下的
+是本地试用 Superset 最快的方式。上游明确表示不支持也不建议将 `docker compose`
+用于生产环境，因此请仅将其用于评估。在这种运行方式下，需要在 Superset 代码目录下的
 `docker/` 中添加一个 `requirements-local.txt`。
 
 并将 GreptimeDB 依赖加入到 `requirements-local.txt`:
@@ -37,6 +38,12 @@ Superset](https://superset.apache.org/docs/installation/pypi)，需要将 Grepti
 ```bash
 pip install greptimedb-sqlalchemy
 ```
+
+:::note SQLAlchemy 版本
+`greptimedb-sqlalchemy` 要求 `sqlalchemy>=1.4,<2`。当前发行版 Superset 6.1.0 锁定
+SQLAlchemy 1.4.54，两者可以配合使用。Superset 主分支已升级到 SQLAlchemy 2.0，后续
+版本需要 dialect 先支持 2.0。若使用更早的 Superset，请自行核对其锁定的 SQLAlchemy 版本是否落在上述范围内。
+:::
 
 ## 添加 GreptimeDB 数据库
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -325,9 +325,13 @@ objectStorage:
     endpoint: ""
 ```
 
-#### 使用 AWS EKS Pod Identity 访问 S3
+<AnchorAlias id="使用-aws-eks-pod-identity-访问-s3" />
 
-除了提供静态访问密钥外，你还可以使用 [AWS EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)（IAM Roles for Service Accounts）来授予 GreptimeDB 访问 S3 的权限。这种方式更加安全，因为无需管理长期有效的凭证。
+#### 使用 IAM Roles for Service Accounts（IRSA）访问 S3
+
+除了提供静态访问密钥外，你还可以使用 [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)（IRSA）来授予 GreptimeDB 访问 S3 的权限。这种方式更加安全，因为无需管理长期有效的凭证。
+
+IRSA 与 [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) 是两种不同的机制。下面这份配置属于 IRSA，通过在 Service Account 上标注 role ARN 完成授权；Pod Identity 则需要建立 pod identity association，并不使用该注解。
 
 首先，为 datanode 的 Service Account 配置 IAM 角色注解。只有 datanode 会读写 S3：
 
@@ -357,7 +361,7 @@ objectStorage:
 ```
 
 :::note
-使用 EKS Pod Identity 时，请完全省略 `objectStorage.credentials` 部分。datanode Pod 将通过与 Service Account 关联的 IAM 角色自动获取临时凭证。
+使用 IRSA 时，请完全省略 `objectStorage.credentials` 部分。datanode Pod 将通过与 Service Account 关联的 IAM 角色自动获取临时凭证。
 :::
 
 #### Google Cloud Storage

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/deploy-on-kubernetes/deploy-minio.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/deploy-on-kubernetes/deploy-minio.md
@@ -27,10 +27,6 @@ image:
   repository: greptime/minio
   tag: 2025.4.22-debian-12-r1
 
-auth:
-  rootUser: greptimedbadmin
-  rootPassword: "greptimedbadmin"  
-
 resources:
   requests:
     cpu: 500m
@@ -52,6 +48,28 @@ persistence:
   storageClass: null
   size: 100Gi
 ```
+
+这里没有写入 root 凭证。Helm 读取 values 文件时只当作普通 YAML，不会展开 shell 变量，`${MINIO_ROOT_USER}` 会被当作字面量写进配置。
+
+凭证改用 Secret 保存，再让 chart 引用。密码不要走 `--set-string`：Helm 会对该值按逗号分段，密码中含逗号就会解析失败，在 shell 层加引号也无济于事。
+
+```bash
+kubectl create namespace minio
+kubectl -n minio create secret generic minio-root-credentials \
+  --from-literal=root-user="$MINIO_ROOT_USER" \
+  --from-literal=root-password="$MINIO_ROOT_PASSWORD"
+```
+
+然后在 `minio-values.yaml` 中引用：
+
+```yaml
+auth:
+  existingSecret: minio-root-credentials
+  rootUserSecretKey: root-user
+  rootPasswordSecretKey: root-password
+```
+
+root 凭证用于管理 MinIO 和登录控制台，GreptimeDB 并不使用。GreptimeDB 连接时用的是[生成 Access Key](#生成-access-key) 一节中单独创建的 Access Key，可以为其单独设置权限策略。
 
 ## 安装 MinIO 集群
 
@@ -87,7 +105,7 @@ Did you know there are enterprise versions of the Bitnami catalog? For enhanced 
 
 ** Please be patient while the chart is being deployed **
 
-MinIO&reg; can be accessed via port  on the following DNS name from within your cluster:
+MinIO&reg; can be accessed via port 9000 on the following DNS name from within your cluster:
 
 minio.minio.svc.cluster.local
 
@@ -151,9 +169,7 @@ kubectl port-forward -n minio svc/minio 9001:9001
 
 2. 打开浏览器访问 http://localhost:9001/login
 
-3. 使用配置文件中设置的账号密码登录：
-- username: `greptimedbadmin`
-- password: `greptimedbadmin`
+3. 使用 `minio-root-credentials` Secret 中保存的 root 凭证登录。
 
 ![MinIO login](/minio-login-page.png)
 
@@ -209,7 +225,7 @@ objectStorage:
 # 监控
 
 - 安装 Prometheus Operator (例如: [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack))。
-- 安装 podmonitor CRD。
+- 安装 ServiceMonitor CRD。
 
 要监控 MinIO 集群，你需要提前部署好监控系统（如 Prometheus 和 Grafana）。然后在 `minio-values.yaml` 中增加以下内容，并重新执行更新 MinIO 配置：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/monitoring/cluster-monitoring-deployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/monitoring/cluster-monitoring-deployment.md
@@ -119,13 +119,13 @@ monitoring:
   enabled: true
 ```
 
-这将部署一个名为 `${cluster-name}-monitoring` 的 GreptimeDB Standalone 实例来收集指标和日志。你可以使用以下命令验证部署：
+这将部署一个名为 `${cluster-name}-monitor` 的 `GreptimeDBStandalone` 资源来收集指标和日志。你可以使用以下命令验证部署：
 
 ```bash
-kubectl get greptimedbstandalones.greptime.io ${cluster-name}-monitoring -n ${namespace}
+kubectl get greptimedbstandalones.greptime.io ${cluster-name}-monitor -n ${namespace}
 ```
 
-GreptimeDB Standalone 实例使用 `${cluster-name}-monitoring-standalone` 作为 Kubernetes Service 名称来暴露服务。你可以使用以下地址访问监控数据：
+它创建的 Service 和 StatefulSet 名为 `${cluster-name}-monitor-standalone`，Pod 在此基础上带 StatefulSet 序号，例如 `${cluster-name}-monitor-standalone-0`。你可以使用以下地址访问监控数据：
 
 - **Prometheus 指标**：`http://${cluster-name}-monitor-standalone.${namespace}.svc.cluster.local:4000/v1/prometheus`
 - **SQL 日志**：`${cluster-name}-monitor-standalone.${namespace}.svc.cluster.local:4002`。默认情况下，集群日志存储在 `public._gt_logs` 表中。
@@ -292,7 +292,7 @@ kubectl -n ${namespace} port-forward svc/${cluster-name}-grafana 18080:80
 ## 清理 PVC
 
 :::danger
-清理操作将移除 GreptimeDB 集群的元数据和数据，请确保在操作前已备份数据。
+该操作删除的是监控单机实例中存储的指标与日志，不影响 GreptimeDB 集群自身的数据；但监控历史一经删除便无法恢复。
 :::
 
 请参考[清理 GreptimeDB 集群](/user-guide/deployments-administration/deploy-on-kubernetes/deploy-greptimedb-cluster.md#cleanup)文档
@@ -301,5 +301,5 @@ kubectl -n ${namespace} port-forward svc/${cluster-name}-grafana 18080:80
 要清理 GreptimeDB 用于监控的单机数据库的 PVC，请使用以下命令：
 
 ```bash
-kubectl -n default delete pvc -l app.greptime.io/component=${cluster-name}-monitor-standalone
+kubectl -n ${namespace} delete pvc -l app.greptime.io/component=${cluster-name}-monitor-standalone
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/integrations/grafana.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/integrations/grafana.md
@@ -125,7 +125,7 @@ http://<host>:4000
 | Operation Name Column | 初始值 `span_name`
 | Start Time Column | 初始值 `timestamp`
 | Duration Time Column | 初始值 `duration_nano`
-| Duration Unit | 初始值 `nano_seconds`
+| Duration Unit | 初始值 `nanoseconds`
 | Tags Column | 可多选，对应以 `span_attributes` 开头的列
 | Service Tags Column| 可多选，对应以 `resource_attributes` 开头的列
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/integrations/mindsdb.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/integrations/mindsdb.md
@@ -8,8 +8,15 @@ description: 介绍如何将 GreptimeDB 作为 MindsDB 的数据源，用于机�
 [MindsDB](https://mindsdb.com/) 是一个开源的机器学习平台，使开发人员能够轻松地将
 先进的机器学习能力与现有数据库集成。
 
-使用 MindsDB 扩展，你的 GreptimeDB 实例可以开箱即用。
-你可以使用 MySQL 协议将 GreptimeDB 配置为 MindsDB 中的数据源：
+MindsDB 通过 GreptimeDB handler 以 MySQL 协议连接 GreptimeDB。
+
+该 handler 属于 [community handler](https://github.com/mindsdb/community-handlers/tree/main/community_handlers/greptimedb_handler)，默认不启用。创建数据源前需先开启，并重启 MindsDB：
+
+```bash
+export MINDSDB_COMMUNITY_HANDLERS=true
+```
+
+开启后即可将 GreptimeDB 配置为数据源：
 
 ```sql
 CREATE DATABASE greptime_datasource

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/integrations/perses.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/integrations/perses.md
@@ -127,7 +127,13 @@ node_cpu_seconds_total{mode="idle"}
 
 ## 迁移 Grafana 仪表盘
 
-GreptimeDB 兼容 Prometheus 生态。可用 [Perses 迁移工具](https://perses.dev/perses/docs/migration/) 导入现有 Grafana 仪表盘。迁移后，将 PromQL 面板映射到指向 GreptimeDB 的 **Prometheus** 数据源。Node Exporter 等大盘的变量、Gauge 和折线图通常无需修改查询语句。
+GreptimeDB 兼容 Prometheus 生态。可用 [Perses 迁移工具](https://perses.dev/perses/docs/migration/) 导入现有 Grafana 仪表盘。迁移后，将 PromQL 面板映射到指向 GreptimeDB 的 **Prometheus** 数据源。
+
+迁移只做尽力而为的转换，完成后需逐项核对，不能默认结果是完整的：
+
+- 仅迁移仪表盘，告警、用户等其他 Grafana 资源不在范围内。
+- 上游支持的 Grafana 版本为 9.0.0 至 11.x，超出这个范围不保证迁移成功。
+- Perses 并未实现全部 Grafana 插件，无法映射的面板和变量会被替换为静态占位符，需要手工重建。
 
 ## 下一步
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/integrations/superset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/integrations/superset.md
@@ -13,7 +13,8 @@ description: 介绍如何将 GreptimeDB 作为 Apache Superset 的数据源，�
 ### 用 Docker Compose 运行 Superset
 
 [Docker compose](https://superset.apache.org/docs/installation/docker-compose)
-是 Superset 的推荐使用方式。在这种运行方式下，需要在 Superset 代码目录下的
+是本地试用 Superset 最快的方式。上游明确表示不支持也不建议将 `docker compose`
+用于生产环境，因此请仅将其用于评估。在这种运行方式下，需要在 Superset 代码目录下的
 `docker/` 中添加一个 `requirements-local.txt`。
 
 并将 GreptimeDB 依赖加入到 `requirements-local.txt`:
@@ -37,6 +38,12 @@ Superset](https://superset.apache.org/docs/installation/pypi)，需要将 Grepti
 ```bash
 pip install greptimedb-sqlalchemy
 ```
+
+:::note SQLAlchemy 版本
+`greptimedb-sqlalchemy` 要求 `sqlalchemy>=1.4,<2`。当前发行版 Superset 6.1.0 锁定
+SQLAlchemy 1.4.54，两者可以配合使用。Superset 主分支已升级到 SQLAlchemy 2.0，后续
+版本需要 dialect 先支持 2.0。若使用更早的 Superset，请自行核对其锁定的 SQLAlchemy 版本是否落在上述范围内。
+:::
 
 ## 添加 GreptimeDB 数据库
 

--- a/versioned_docs/version-1.1/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/versioned_docs/version-1.1/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -325,9 +325,13 @@ objectStorage:
     endpoint: ""
 ```
 
-#### Using AWS EKS Pod Identity for S3
+<AnchorAlias id="using-aws-eks-pod-identity-for-s3" />
 
-Instead of providing static access keys, you can use [AWS EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) (IAM Roles for Service Accounts) to grant S3 access to GreptimeDB. This approach is more secure as it eliminates the need to manage long-lived credentials.
+#### Using IAM Roles for Service Accounts (IRSA) for S3
+
+Instead of providing static access keys, you can use [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) (IRSA) to grant S3 access to GreptimeDB. This approach is more secure as it eliminates the need to manage long-lived credentials.
+
+IRSA and [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) are two different mechanisms. The configuration below is IRSA: it annotates the service account with the role ARN. Pod Identity instead requires a pod identity association and no such annotation.
 
 First, configure the datanode service account with the IAM role annotation. Only the datanode reads from and writes to S3:
 
@@ -358,7 +362,7 @@ objectStorage:
 ```
 
 :::note
-When using EKS Pod Identity, omit the `objectStorage.credentials` section entirely. The datanode pods will automatically obtain temporary credentials through the IAM role associated with the service account.
+When using IRSA, omit the `objectStorage.credentials` section entirely. The datanode pods will automatically obtain temporary credentials through the IAM role associated with the service account.
 :::
 
 #### Google Cloud Storage

--- a/versioned_docs/version-1.1/user-guide/deployments-administration/deploy-on-kubernetes/deploy-minio.md
+++ b/versioned_docs/version-1.1/user-guide/deployments-administration/deploy-on-kubernetes/deploy-minio.md
@@ -27,10 +27,6 @@ image:
   repository: greptime/minio
   tag: 2025.4.22-debian-12-r1
 
-auth:
-  rootUser: greptimedbadmin
-  rootPassword: "greptimedbadmin"  
-
 resources:
   requests:
     cpu: 500m
@@ -52,6 +48,28 @@ persistence:
   storageClass: null
   size: 100Gi
 ```
+
+The root credentials are deliberately absent from this file. Helm reads a values file as plain YAML and does not expand shell variables in it, so a `${MINIO_ROOT_USER}` placeholder would be installed verbatim.
+
+Create a Secret and point the chart at it instead. Avoid `--set-string` for the password: Helm splits that value on commas itself, so a password containing one fails to parse no matter how the shell quotes it.
+
+```bash
+kubectl create namespace minio
+kubectl -n minio create secret generic minio-root-credentials \
+  --from-literal=root-user="$MINIO_ROOT_USER" \
+  --from-literal=root-password="$MINIO_ROOT_PASSWORD"
+```
+
+Then reference it from `minio-values.yaml`:
+
+```yaml
+auth:
+  existingSecret: minio-root-credentials
+  rootUserSecretKey: root-user
+  rootPasswordSecretKey: root-password
+```
+
+These root credentials are for administering MinIO and signing in to its console. GreptimeDB does not use them — it connects with a separate Access Key that you create in [Generating Access Key](#generating-access-key), which you can scope with its own permission policy.
 
 ## Installing MinIO Cluster
 
@@ -87,7 +105,7 @@ Did you know there are enterprise versions of the Bitnami catalog? For enhanced 
 
 ** Please be patient while the chart is being deployed **
 
-MinIO&reg; can be accessed via port  on the following DNS name from within your cluster:
+MinIO&reg; can be accessed via port 9000 on the following DNS name from within your cluster:
 
 minio.minio.svc.cluster.local
 
@@ -151,9 +169,7 @@ kubectl port-forward -n minio svc/minio 9001:9001
 
 2. Open your browser: http://localhost:9001/login
 
-3. Log in using the credentials set in the configuration file:
-- username: `greptimedbadmin`
-- password: `greptimedbadmin`
+3. Log in with the root credentials held in the `minio-root-credentials` Secret.
 
 ![MinIO login](/minio-login-page.png)
 
@@ -208,8 +224,8 @@ objectStorage:
 
 # Monitoring
 
-- Install Prometheus Operator (e.g: [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack))。
-- Install podmonitor CRD。
+- Install Prometheus Operator (e.g: [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)).
+- Install the ServiceMonitor CRD.
 
 To monitor the MinIO cluster, you need to have a monitoring system (such as Prometheus and Grafana) deployed in advance. Then add the following content to minio-values.yaml and re-run the command to update the MinIO configuration:
 

--- a/versioned_docs/version-1.1/user-guide/deployments-administration/monitoring/cluster-monitoring-deployment.md
+++ b/versioned_docs/version-1.1/user-guide/deployments-administration/monitoring/cluster-monitoring-deployment.md
@@ -114,13 +114,13 @@ monitoring:
   enabled: true
 ```
 
-This deploys a GreptimeDB Standalone instance named `${cluster-name}-monitoring` to collect metrics and logs. You can verify the deployment with:
+This deploys a `GreptimeDBStandalone` resource named `${cluster-name}-monitor` to collect metrics and logs. You can verify the deployment with:
 
 ```bash
-kubectl get greptimedbstandalones.greptime.io ${cluster-name}-monitoring -n ${namespace}
+kubectl get greptimedbstandalones.greptime.io ${cluster-name}-monitor -n ${namespace}
 ```
 
-The GreptimeDB Standalone instance exposes services using `${cluster-name}-monitoring-standalone` as the Kubernetes Service name. You can use the following addresses to access monitoring data:
+The Service and StatefulSet it creates are named `${cluster-name}-monitor-standalone`, and the Pods add the usual StatefulSet ordinal, for example `${cluster-name}-monitor-standalone-0`. You can use the following addresses to access monitoring data:
 
 - **Prometheus metrics**: `http://${cluster-name}-monitor-standalone.${namespace}.svc.cluster.local:4000/v1/prometheus`
 - **SQL logs**: `${cluster-name}-monitor-standalone.${namespace}.svc.cluster.local:4002`. By default, cluster logs are stored in the `public._gt_logs` table.
@@ -287,12 +287,12 @@ Navigate to the `Dashboards` section to explore the pre-configured dashboards fo
 ## Cleanup the PVCs
 
 :::danger
-The cleanup operation will remove the metadata and data of the GreptimeDB cluster. Please make sure you have backed up the data before proceeding.
+This removes the collected metrics and logs stored by the monitoring standalone instance. It does not touch the data of the GreptimeDB cluster itself, but the monitoring history is not recoverable afterwards.
 :::
 To uninstall the GreptimeDB cluster, please refer to the [Cleanup GreptimeDB Cluster](/user-guide/deployments-administration/deploy-on-kubernetes/deploy-greptimedb-cluster.md#cleanup) documentation.
 
 To clean up the Persistent Volume Claims (PVCs) used by the GreptimeDB standalone monitoring instance, delete the PVCs using the following command:
 
 ```bash
-kubectl -n default delete pvc -l app.greptime.io/component=${cluster-name}-monitor-standalone
+kubectl -n ${namespace} delete pvc -l app.greptime.io/component=${cluster-name}-monitor-standalone
 ```

--- a/versioned_docs/version-1.1/user-guide/integrations/grafana.md
+++ b/versioned_docs/version-1.1/user-guide/integrations/grafana.md
@@ -131,7 +131,7 @@ Select the `Traces` query type when you want to query distributed tracing data.
 | **Operation Name Column** | Default value: `span_name`                                                                            |
 | **Start Time Column** | Default value: `timestamp`                                                                              |
 | **Duration Time Column** | Default value: `duration_nano`                                                                          |
-| **Duration Unit** | Default value: `nano_seconds`                                                                           |
+| **Duration Unit** | Default value: `nanoseconds`                                                                           |
 | **Tags Column** | Multiple selections allowed. Corresponds to columns starting with `span_attributes` (e.g., `span_attributes.http.method`). |
 | **Service Tags Column** | Multiple selections allowed. Corresponds to columns starting with `resource_attributes` (e.g., `resource_attributes.host.name`). |
 

--- a/versioned_docs/version-1.1/user-guide/integrations/mindsdb.md
+++ b/versioned_docs/version-1.1/user-guide/integrations/mindsdb.md
@@ -9,8 +9,15 @@ description: Guide on configuring GreptimeDB as a data source in MindsDB for mac
 enables developers to easily incorporate advanced machine learning capabilities
 with existing databases.
 
-Your GreptimeDB instance work out of box as using GreptimeDB extension with
-MindsDB. You can configure GreptimeDB as a data source in MindsDB using MySQL protocol:
+MindsDB reaches GreptimeDB through the MySQL protocol using its GreptimeDB handler.
+
+The handler ships as a [community handler](https://github.com/mindsdb/community-handlers/tree/main/community_handlers/greptimedb_handler), and community handlers are disabled by default. Enable them before creating the data source, then restart MindsDB:
+
+```bash
+export MINDSDB_COMMUNITY_HANDLERS=true
+```
+
+Once enabled, configure GreptimeDB as a data source:
 
 ```sql
 CREATE DATABASE greptime_datasource

--- a/versioned_docs/version-1.1/user-guide/integrations/superset.md
+++ b/versioned_docs/version-1.1/user-guide/integrations/superset.md
@@ -14,7 +14,9 @@ follow this guide.
 ### Running Superset with Docker Compose
 
 [Docker compose](https://superset.apache.org/docs/installation/docker-compose)
-is the recommended way to run Superset. To add GreptimeDB extension, create a
+is the quickest way to try Superset locally. Upstream states it does not support
+or recommend the `docker compose` constructs for production use, so treat this
+path as evaluation only. To add GreptimeDB extension, create a
 `requirements-local.txt` file in `docker/` of Superset codebase.
 
 Add GreptimeDB dependency in `requirements-local.txt`:
@@ -38,6 +40,14 @@ to the same environment.
 ```bash
 pip install greptimedb-sqlalchemy
 ```
+
+:::note SQLAlchemy version
+`greptimedb-sqlalchemy` requires `sqlalchemy>=1.4,<2`. Superset 6.1.0, the
+current release, pins SQLAlchemy 1.4.54 and works with it. Superset's main
+branch has moved to SQLAlchemy 2.0, so a later release will need a dialect that
+supports 2.0 first. If you run an older Superset, check its own SQLAlchemy pin
+against that range.
+:::
 
 ## Add GreptimeDB as database
 

--- a/versioned_docs/version-1.2/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
+++ b/versioned_docs/version-1.2/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md
@@ -325,9 +325,13 @@ objectStorage:
     endpoint: ""
 ```
 
-#### Using AWS EKS Pod Identity for S3
+<AnchorAlias id="using-aws-eks-pod-identity-for-s3" />
 
-Instead of providing static access keys, you can use [AWS EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) (IAM Roles for Service Accounts) to grant S3 access to GreptimeDB. This approach is more secure as it eliminates the need to manage long-lived credentials.
+#### Using IAM Roles for Service Accounts (IRSA) for S3
+
+Instead of providing static access keys, you can use [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) (IRSA) to grant S3 access to GreptimeDB. This approach is more secure as it eliminates the need to manage long-lived credentials.
+
+IRSA and [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) are two different mechanisms. The configuration below is IRSA: it annotates the service account with the role ARN. Pod Identity instead requires a pod identity association and no such annotation.
 
 First, configure the datanode service account with the IAM role annotation. Only the datanode reads from and writes to S3:
 
@@ -358,7 +362,7 @@ objectStorage:
 ```
 
 :::note
-When using EKS Pod Identity, omit the `objectStorage.credentials` section entirely. The datanode pods will automatically obtain temporary credentials through the IAM role associated with the service account.
+When using IRSA, omit the `objectStorage.credentials` section entirely. The datanode pods will automatically obtain temporary credentials through the IAM role associated with the service account.
 :::
 
 #### Google Cloud Storage

--- a/versioned_docs/version-1.2/user-guide/deployments-administration/deploy-on-kubernetes/deploy-minio.md
+++ b/versioned_docs/version-1.2/user-guide/deployments-administration/deploy-on-kubernetes/deploy-minio.md
@@ -27,10 +27,6 @@ image:
   repository: greptime/minio
   tag: 2025.4.22-debian-12-r1
 
-auth:
-  rootUser: greptimedbadmin
-  rootPassword: "greptimedbadmin"  
-
 resources:
   requests:
     cpu: 500m
@@ -52,6 +48,28 @@ persistence:
   storageClass: null
   size: 100Gi
 ```
+
+The root credentials are deliberately absent from this file. Helm reads a values file as plain YAML and does not expand shell variables in it, so a `${MINIO_ROOT_USER}` placeholder would be installed verbatim.
+
+Create a Secret and point the chart at it instead. Avoid `--set-string` for the password: Helm splits that value on commas itself, so a password containing one fails to parse no matter how the shell quotes it.
+
+```bash
+kubectl create namespace minio
+kubectl -n minio create secret generic minio-root-credentials \
+  --from-literal=root-user="$MINIO_ROOT_USER" \
+  --from-literal=root-password="$MINIO_ROOT_PASSWORD"
+```
+
+Then reference it from `minio-values.yaml`:
+
+```yaml
+auth:
+  existingSecret: minio-root-credentials
+  rootUserSecretKey: root-user
+  rootPasswordSecretKey: root-password
+```
+
+These root credentials are for administering MinIO and signing in to its console. GreptimeDB does not use them — it connects with a separate Access Key that you create in [Generating Access Key](#generating-access-key), which you can scope with its own permission policy.
 
 ## Installing MinIO Cluster
 
@@ -87,7 +105,7 @@ Did you know there are enterprise versions of the Bitnami catalog? For enhanced 
 
 ** Please be patient while the chart is being deployed **
 
-MinIO&reg; can be accessed via port  on the following DNS name from within your cluster:
+MinIO&reg; can be accessed via port 9000 on the following DNS name from within your cluster:
 
 minio.minio.svc.cluster.local
 
@@ -151,9 +169,7 @@ kubectl port-forward -n minio svc/minio 9001:9001
 
 2. Open your browser: http://localhost:9001/login
 
-3. Log in using the credentials set in the configuration file:
-- username: `greptimedbadmin`
-- password: `greptimedbadmin`
+3. Log in with the root credentials held in the `minio-root-credentials` Secret.
 
 ![MinIO login](/minio-login-page.png)
 
@@ -208,8 +224,8 @@ objectStorage:
 
 # Monitoring
 
-- Install Prometheus Operator (e.g: [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack))。
-- Install podmonitor CRD。
+- Install Prometheus Operator (e.g: [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)).
+- Install the ServiceMonitor CRD.
 
 To monitor the MinIO cluster, you need to have a monitoring system (such as Prometheus and Grafana) deployed in advance. Then add the following content to minio-values.yaml and re-run the command to update the MinIO configuration:
 

--- a/versioned_docs/version-1.2/user-guide/deployments-administration/monitoring/cluster-monitoring-deployment.md
+++ b/versioned_docs/version-1.2/user-guide/deployments-administration/monitoring/cluster-monitoring-deployment.md
@@ -114,13 +114,13 @@ monitoring:
   enabled: true
 ```
 
-This deploys a GreptimeDB Standalone instance named `${cluster-name}-monitoring` to collect metrics and logs. You can verify the deployment with:
+This deploys a `GreptimeDBStandalone` resource named `${cluster-name}-monitor` to collect metrics and logs. You can verify the deployment with:
 
 ```bash
-kubectl get greptimedbstandalones.greptime.io ${cluster-name}-monitoring -n ${namespace}
+kubectl get greptimedbstandalones.greptime.io ${cluster-name}-monitor -n ${namespace}
 ```
 
-The GreptimeDB Standalone instance exposes services using `${cluster-name}-monitoring-standalone` as the Kubernetes Service name. You can use the following addresses to access monitoring data:
+The Service and StatefulSet it creates are named `${cluster-name}-monitor-standalone`, and the Pods add the usual StatefulSet ordinal, for example `${cluster-name}-monitor-standalone-0`. You can use the following addresses to access monitoring data:
 
 - **Prometheus metrics**: `http://${cluster-name}-monitor-standalone.${namespace}.svc.cluster.local:4000/v1/prometheus`
 - **SQL logs**: `${cluster-name}-monitor-standalone.${namespace}.svc.cluster.local:4002`. By default, cluster logs are stored in the `public._gt_logs` table.
@@ -287,12 +287,12 @@ Navigate to the `Dashboards` section to explore the pre-configured dashboards fo
 ## Cleanup the PVCs
 
 :::danger
-The cleanup operation will remove the metadata and data of the GreptimeDB cluster. Please make sure you have backed up the data before proceeding.
+This removes the collected metrics and logs stored by the monitoring standalone instance. It does not touch the data of the GreptimeDB cluster itself, but the monitoring history is not recoverable afterwards.
 :::
 To uninstall the GreptimeDB cluster, please refer to the [Cleanup GreptimeDB Cluster](/user-guide/deployments-administration/deploy-on-kubernetes/deploy-greptimedb-cluster.md#cleanup) documentation.
 
 To clean up the Persistent Volume Claims (PVCs) used by the GreptimeDB standalone monitoring instance, delete the PVCs using the following command:
 
 ```bash
-kubectl -n default delete pvc -l app.greptime.io/component=${cluster-name}-monitor-standalone
+kubectl -n ${namespace} delete pvc -l app.greptime.io/component=${cluster-name}-monitor-standalone
 ```

--- a/versioned_docs/version-1.2/user-guide/integrations/grafana.md
+++ b/versioned_docs/version-1.2/user-guide/integrations/grafana.md
@@ -131,7 +131,7 @@ Select the `Traces` query type when you want to query distributed tracing data.
 | **Operation Name Column** | Default value: `span_name`                                                                            |
 | **Start Time Column** | Default value: `timestamp`                                                                              |
 | **Duration Time Column** | Default value: `duration_nano`                                                                          |
-| **Duration Unit** | Default value: `nano_seconds`                                                                           |
+| **Duration Unit** | Default value: `nanoseconds`                                                                           |
 | **Tags Column** | Multiple selections allowed. Corresponds to columns starting with `span_attributes` (e.g., `span_attributes.http.method`). |
 | **Service Tags Column** | Multiple selections allowed. Corresponds to columns starting with `resource_attributes` (e.g., `resource_attributes.host.name`). |
 

--- a/versioned_docs/version-1.2/user-guide/integrations/mindsdb.md
+++ b/versioned_docs/version-1.2/user-guide/integrations/mindsdb.md
@@ -9,8 +9,15 @@ description: Guide on configuring GreptimeDB as a data source in MindsDB for mac
 enables developers to easily incorporate advanced machine learning capabilities
 with existing databases.
 
-Your GreptimeDB instance work out of box as using GreptimeDB extension with
-MindsDB. You can configure GreptimeDB as a data source in MindsDB using MySQL protocol:
+MindsDB reaches GreptimeDB through the MySQL protocol using its GreptimeDB handler.
+
+The handler ships as a [community handler](https://github.com/mindsdb/community-handlers/tree/main/community_handlers/greptimedb_handler), and community handlers are disabled by default. Enable them before creating the data source, then restart MindsDB:
+
+```bash
+export MINDSDB_COMMUNITY_HANDLERS=true
+```
+
+Once enabled, configure GreptimeDB as a data source:
 
 ```sql
 CREATE DATABASE greptime_datasource

--- a/versioned_docs/version-1.2/user-guide/integrations/perses.md
+++ b/versioned_docs/version-1.2/user-guide/integrations/perses.md
@@ -127,7 +127,13 @@ See [PromQL](/user-guide/query-data/promql.md) for query syntax.
 
 ## Migrate Grafana dashboards
 
-GreptimeDB is compatible with the Prometheus ecosystem. You can import existing Grafana dashboards into Perses with the [Perses migration tool](https://perses.dev/perses/docs/migration/). After migration, map PromQL panels to the **Prometheus** datasource pointing at GreptimeDB. Variables, gauges, and time series panels from dashboards such as Node Exporter should work without changes to the queries.
+GreptimeDB is compatible with the Prometheus ecosystem. You can import existing Grafana dashboards into Perses with the [Perses migration tool](https://perses.dev/perses/docs/migration/). After migration, map PromQL panels to the **Prometheus** datasource pointing at GreptimeDB.
+
+The migration is best-effort, so review the result rather than assuming it is complete:
+
+- Only dashboards are migrated. Alerts, users and other Grafana resources are not.
+- Upstream supports Grafana 9.0.0 through 11.x. Outside that range the migration is not guaranteed to work.
+- Perses does not implement every Grafana plugin. Panels and variables it cannot map are replaced with static placeholders, which you then have to rebuild by hand.
 
 ## Next steps
 

--- a/versioned_docs/version-1.2/user-guide/integrations/superset.md
+++ b/versioned_docs/version-1.2/user-guide/integrations/superset.md
@@ -14,7 +14,9 @@ follow this guide.
 ### Running Superset with Docker Compose
 
 [Docker compose](https://superset.apache.org/docs/installation/docker-compose)
-is the recommended way to run Superset. To add GreptimeDB extension, create a
+is the quickest way to try Superset locally. Upstream states it does not support
+or recommend the `docker compose` constructs for production use, so treat this
+path as evaluation only. To add GreptimeDB extension, create a
 `requirements-local.txt` file in `docker/` of Superset codebase.
 
 Add GreptimeDB dependency in `requirements-local.txt`:
@@ -38,6 +40,14 @@ to the same environment.
 ```bash
 pip install greptimedb-sqlalchemy
 ```
+
+:::note SQLAlchemy version
+`greptimedb-sqlalchemy` requires `sqlalchemy>=1.4,<2`. Superset 6.1.0, the
+current release, pins SQLAlchemy 1.4.54 and works with it. Superset's main
+branch has moved to SQLAlchemy 2.0, so a later release will need a dialect that
+supports 2.0 first. If you run an older Superset, check its own SQLAlchemy pin
+against that range.
+:::
 
 ## Add GreptimeDB as database
 


### PR DESCRIPTION
## What changed

### Deployment

| Page | Correction | Evidence |
| --- | --- | --- |
| `monitoring/cluster-monitoring-deployment.md` | The page used `${cluster-name}-monitoring` for the CR and `${cluster-name}-monitoring-standalone` for the Service, while other lines on the same page already used `-monitor-standalone`. The operator creates a `GreptimeDBStandalone` named **`${cluster}-monitor`**, and its Service/StatefulSet/Pods are named **`${cluster}-monitor-standalone`**. These are two different names and the page now says so. | operator `controllers/common/common.go:306-308` (`MonitoringServiceName` returns `name + "-monitor"`), used as the CR object key at `greptimedbcluster/deployers/monitoring.go:90-93`; the workload DNS at `:123` wraps it in `ResourceName(..., StandaloneRoleKind)` |
| same | The PVC cleanup `danger` box said the operation removes the GreptimeDB cluster's metadata and data. It deletes the monitoring standalone's PVCs. The command also hardcoded `-n default` while using `${cluster-name}`. | Same page |
| `common-helm-chart-configurations.md` | The S3 section was titled "AWS EKS Pod Identity" and glossed it as "IAM Roles for Service Accounts", but the example annotates a service account with `eks.amazonaws.com/role-arn`, which is IRSA. Pod Identity uses a pod identity association and no such annotation. Retitled to IRSA and noted the distinction; the published slug is preserved with `AnchorAlias`. | AWS docs for both mechanisms |
| `deploy-minio.md` | Install output was missing the port ("accessed via port  on"); the prerequisite said PodMonitor CRD while the example configures `serviceMonitor`; the sample root password was presented as fixed login credentials. | Same page |

### Integrations

| Page | Correction | Evidence |
| --- | --- | --- |
| `mindsdb.md` | "work out of box" no longer holds. The GreptimeDB handler moved to `mindsdb/community-handlers`, and community handlers are disabled by default — `MINDSDB_COMMUNITY_HANDLERS=true` plus a restart is required. The `ENGINE = 'greptimedb'` syntax itself is unchanged, so the example stays. | `mindsdb/mindshub@490c5f0` removed `greptimedb_handler/*`; the handler and its `ENGINE` syntax live in `mindsdb/community-handlers`; the env var is documented in that repo's README |
| `perses.md` | Dropped the claim that panels and variables "should work without changes". Upstream states the migration is best-effort, supports Grafana 9.0–11.x, does not migrate alerts or users, and replaces unsupported panels/variables with static placeholders. | perses.dev migration docs |
| `superset.md` | Marked Docker Compose as evaluation-only (upstream: "we do not support nor recommend using our `docker compose` constructs to support production-type use-cases") and documented the SQLAlchemy constraint. | `greptimedb-sqlalchemy` 0.1.7 requires `sqlalchemy<2,>=1.4`; Superset 6.1.0 ships 1.4.54 (**compatible today**), master has moved to 2.0.51 |
| `grafana.md` | `Duration Unit` default was `nano_seconds`, which is not a valid value. | Plugin `src/types/queryBuilder.ts` `TimeUnit` enum and `DurationUnitSelect.tsx` accept only `seconds`/`milliseconds`/`microseconds`/`nanoseconds` |

## Coverage

All 19 pages under `user-guide/integrations/` were checked against their upstreams this round, not sampled. Results for the ones **not** changed:

- **flink, spark** — connector identifier `greptimedb` and every documented option (`endpoints`, `database`, `table`, `time-index`, `tags`, `batch.max-rows`, `query.jdbc-url`, `query.fetch-size`) match the connector sources. `io.greptime:{flink,spark}-connector-greptimedb:0.1.0` and its `shaded` classifier are both present on Maven Central.
- **dbeaver, streamlit, metabase** — ports 4002 (MySQL) and 4003 (PostgreSQL) match `config/standalone.example.toml:127,162`; the Metabase driver asset is still named `greptimedb.metabase-driver.jar` in the latest release.
- **coroot** — uses the `?db=<db-name>` query parameter, which matches the canonical form in the Prometheus ingest docs. No header change needed.
- **alloy, emqx, fluent-bit, kafka, prometheus, telegraf, vector, overview** — pure redirect pages with no configuration of their own; their link targets are covered by the link checker.
- **mcp** — corrected separately in #2764.

`integrations/overview.md` still opens with "seamlessly integrated" / "comprehensive guidance". That is a wording issue, not a factual one, and belongs to the deferred wording pass rather than this PR.

## Scope

- Documentation versions: Nightly, 1.2, 1.1 (Perses: Nightly and 1.2 only — the page does not exist in 1.1)
- Languages: English, Chinese

## Verification

```
git diff --check
DOC_LANG=en pnpm check:links
DOC_LANG=zh pnpm check:links
```

Both link checks pass, including the `AnchorAlias` added for the renamed IRSA heading.

## Still open

The Grafana plugin install section documents `info8fcc-greptimedb-datasource.zip`, while the plugin README instructs downloading `info8fcc-greptimedb-datasource-unsigned.zip` and setting `allow_loading_unsigned_plugins`. Both assets exist in the latest release and I could not determine from release metadata whether the signed one loads without the allowlist. Left unchanged pending confirmation from the plugin maintainer.

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] I updated navigation when the document structure changed. No structural change.