### PR TITLE
feat: add audit-log configuration

### DIFF
--- a/docs/enterprise/deployments-administration/deploy-on-kubernetes/installation.md
+++ b/docs/enterprise/deployments-administration/deploy-on-kubernetes/installation.md
@@ -356,6 +356,42 @@ auth:
       password: "1fa44bbc-5ded-42bd-a3f1-c3621affce63"
       permission: "admin"       
 
+# Audit logging configuration
+# Audit logs record operations executed on the database, helping monitor user activity,
+# detect suspicious operations, and ensure compliance.
+# See /enterprise/deployments-administration/monitoring/audit-logging.md
+auditLog:
+  # Enable the audit log plugin. Default: false.
+  enabled: true
+
+  # Allowed sources for auditing. This option acts as a filter.
+  # Multiple sources are separated by commas (",").
+  # Available sources: "unknown", "http", "grpc", "mysql", "postgres".
+  # A special value "all" (default) means all sources.
+  sources: "all"
+
+  # Allowed statement classes for auditing. This option acts as a filter.
+  # Multiple classes are separated by commas (",").
+  # Available classes: "read", "write", "admin", "ddl", "misc".
+  # A special value "all" means all classes. Default: "ddl,admin".
+  classes: "ddl,admin"
+
+  # Allowed statement commands for auditing. This option acts as a filter.
+  # Multiple commands are separated by commas (",").
+  # Available commands: "promql", "select", "copy", "insert", "delete", "create",
+  # "alter", "truncate", "drop", "admin", "misc".
+  # A special value "all" (default) means all commands.
+  commands: "all"
+
+  # Allowed object types for auditing. This option acts as a filter.
+  # Multiple object types are separated by commas (",").
+  # Available object types: "database", "table", "view", "flow", "index", "misc", "trigger".
+  # A special value "all" (default) means all object types.
+  objectTypes: "all"
+
+  # Maximum number of audit log files to retain. Default: 30.
+  maxLogFiles: 30
+
 # Remote WAL related configuration, enable as needed
 # remoteWal:
 #   enabled: true

--- a/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/deployments-administration/deploy-on-kubernetes/installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/deployments-administration/deploy-on-kubernetes/installation.md
@@ -356,6 +356,41 @@ auth:
       password: "1fa44bbc-5ded-42bd-a3f1-c3621affce63"
       permission: "admin"       
 
+# 审计日志配置
+# 审计日志记录在数据库上执行的操作，帮助监控用户活动、检测可疑操作并确保合规。
+# 参见 /enterprise/deployments-administration/monitoring/audit-logging.md
+auditLog:
+  # 启用审计日志插件。默认：false。
+  enabled: true
+
+  # 允许审计的来源。该选项作为过滤器使用。
+  # 多个来源用逗号（","）分隔。
+  # 可用来源："unknown"、"http"、"grpc"、"mysql"、"postgres"。
+  # 特殊值 "all"（默认）表示所有来源。
+  sources: "all"
+
+  # 允许审计的语句类别。该选项作为过滤器使用。
+  # 多个类别用逗号（","）分隔。
+  # 可用类别："read"、"write"、"admin"、"ddl"、"misc"。
+  # 特殊值 "all" 表示所有类别。默认："ddl,admin"。
+  classes: "ddl,admin"
+
+  # 允许审计的语句命令。该选项作为过滤器使用。
+  # 多个命令用逗号（","）分隔。
+  # 可用命令："promql"、"select"、"copy"、"insert"、"delete"、"create"、
+  # "alter"、"truncate"、"drop"、"admin"、"misc"。
+  # 特殊值 "all"（默认）表示所有命令。
+  commands: "all"
+
+  # 允许审计的对象类型。该选项作为过滤器使用。
+  # 多个对象类型用逗号（","）分隔。
+  # 可用对象类型："database"、"table"、"view"、"flow"、"index"、"misc"、"trigger"。
+  # 特殊值 "all"（默认）表示所有对象类型。
+  objectTypes: "all"
+
+  # 最多保留的审计日志文件数量。默认：30。
+  maxLogFiles: 30
+
 # Remote WAL相关配置，按需打开
 # remoteWal:
 #   enabled: true

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.0/enterprise/deployments-administration/deploy-on-kubernetes/installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.0/enterprise/deployments-administration/deploy-on-kubernetes/installation.md
@@ -356,6 +356,41 @@ auth:
       password: "1fa44bbc-5ded-42bd-a3f1-c3621affce63"
       permission: "admin"       
 
+# 审计日志配置
+# 审计日志记录在数据库上执行的操作，帮助监控用户活动、检测可疑操作并确保合规。
+# 参见 /enterprise/deployments-administration/monitoring/audit-logging.md
+auditLog:
+  # 启用审计日志插件。默认：false。
+  enabled: true
+
+  # 允许审计的来源。该选项作为过滤器使用。
+  # 多个来源用逗号（","）分隔。
+  # 可用来源："unknown"、"http"、"grpc"、"mysql"、"postgres"。
+  # 特殊值 "all"（默认）表示所有来源。
+  sources: "all"
+
+  # 允许审计的语句类别。该选项作为过滤器使用。
+  # 多个类别用逗号（","）分隔。
+  # 可用类别："read"、"write"、"admin"、"ddl"、"misc"。
+  # 特殊值 "all" 表示所有类别。默认："ddl,admin"。
+  classes: "ddl,admin"
+
+  # 允许审计的语句命令。该选项作为过滤器使用。
+  # 多个命令用逗号（","）分隔。
+  # 可用命令："promql"、"select"、"copy"、"insert"、"delete"、"create"、
+  # "alter"、"truncate"、"drop"、"admin"、"misc"。
+  # 特殊值 "all"（默认）表示所有命令。
+  commands: "all"
+
+  # 允许审计的对象类型。该选项作为过滤器使用。
+  # 多个对象类型用逗号（","）分隔。
+  # 可用对象类型："database"、"table"、"view"、"flow"、"index"、"misc"、"trigger"。
+  # 特殊值 "all"（默认）表示所有对象类型。
+  objectTypes: "all"
+
+  # 最多保留的审计日志文件数量。默认：30。
+  maxLogFiles: 30
+
 # Remote WAL相关配置，按需打开
 # remoteWal:
 #   enabled: true

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/enterprise/deployments-administration/deploy-on-kubernetes/installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/enterprise/deployments-administration/deploy-on-kubernetes/installation.md
@@ -356,6 +356,41 @@ auth:
       password: "1fa44bbc-5ded-42bd-a3f1-c3621affce63"
       permission: "admin"       
 
+# 审计日志配置
+# 审计日志记录在数据库上执行的操作，帮助监控用户活动、检测可疑操作并确保合规。
+# 参见 /enterprise/deployments-administration/monitoring/audit-logging.md
+auditLog:
+  # 启用审计日志插件。默认：false。
+  enabled: true
+
+  # 允许审计的来源。该选项作为过滤器使用。
+  # 多个来源用逗号（","）分隔。
+  # 可用来源："unknown"、"http"、"grpc"、"mysql"、"postgres"。
+  # 特殊值 "all"（默认）表示所有来源。
+  sources: "all"
+
+  # 允许审计的语句类别。该选项作为过滤器使用。
+  # 多个类别用逗号（","）分隔。
+  # 可用类别："read"、"write"、"admin"、"ddl"、"misc"。
+  # 特殊值 "all" 表示所有类别。默认："ddl,admin"。
+  classes: "ddl,admin"
+
+  # 允许审计的语句命令。该选项作为过滤器使用。
+  # 多个命令用逗号（","）分隔。
+  # 可用命令："promql"、"select"、"copy"、"insert"、"delete"、"create"、
+  # "alter"、"truncate"、"drop"、"admin"、"misc"。
+  # 特殊值 "all"（默认）表示所有命令。
+  commands: "all"
+
+  # 允许审计的对象类型。该选项作为过滤器使用。
+  # 多个对象类型用逗号（","）分隔。
+  # 可用对象类型："database"、"table"、"view"、"flow"、"index"、"misc"、"trigger"。
+  # 特殊值 "all"（默认）表示所有对象类型。
+  objectTypes: "all"
+
+  # 最多保留的审计日志文件数量。默认：30。
+  maxLogFiles: 30
+
 # Remote WAL相关配置，按需打开
 # remoteWal:
 #   enabled: true

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/enterprise/deployments-administration/deploy-on-kubernetes/installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/enterprise/deployments-administration/deploy-on-kubernetes/installation.md
@@ -356,6 +356,41 @@ auth:
       password: "1fa44bbc-5ded-42bd-a3f1-c3621affce63"
       permission: "admin"       
 
+# 审计日志配置
+# 审计日志记录在数据库上执行的操作，帮助监控用户活动、检测可疑操作并确保合规。
+# 参见 /enterprise/deployments-administration/monitoring/audit-logging.md
+auditLog:
+  # 启用审计日志插件。默认：false。
+  enabled: true
+
+  # 允许审计的来源。该选项作为过滤器使用。
+  # 多个来源用逗号（","）分隔。
+  # 可用来源："unknown"、"http"、"grpc"、"mysql"、"postgres"。
+  # 特殊值 "all"（默认）表示所有来源。
+  sources: "all"
+
+  # 允许审计的语句类别。该选项作为过滤器使用。
+  # 多个类别用逗号（","）分隔。
+  # 可用类别："read"、"write"、"admin"、"ddl"、"misc"。
+  # 特殊值 "all" 表示所有类别。默认："ddl,admin"。
+  classes: "ddl,admin"
+
+  # 允许审计的语句命令。该选项作为过滤器使用。
+  # 多个命令用逗号（","）分隔。
+  # 可用命令："promql"、"select"、"copy"、"insert"、"delete"、"create"、
+  # "alter"、"truncate"、"drop"、"admin"、"misc"。
+  # 特殊值 "all"（默认）表示所有命令。
+  commands: "all"
+
+  # 允许审计的对象类型。该选项作为过滤器使用。
+  # 多个对象类型用逗号（","）分隔。
+  # 可用对象类型："database"、"table"、"view"、"flow"、"index"、"misc"、"trigger"。
+  # 特殊值 "all"（默认）表示所有对象类型。
+  objectTypes: "all"
+
+  # 最多保留的审计日志文件数量。默认：30。
+  maxLogFiles: 30
+
 # Remote WAL相关配置，按需打开
 # remoteWal:
 #   enabled: true

--- a/variables/variables-1.0.ts
+++ b/variables/variables-1.0.ts
@@ -7,6 +7,6 @@ export const variables = {
   debugPodVersion: '20250606-04e3c7d',
   etcdChartVersion: "12.0.8",
   etcdImageVersion: "3.6.1-debian-12-r3",
-  greptimedbOperatorVersion: 'v0.6.0',
+  greptimedbOperatorVersion: 'v0.6.1',
   vectorImageVersion: "0.49.0-debian"
 };

--- a/variables/variables-1.1.ts
+++ b/variables/variables-1.1.ts
@@ -9,6 +9,6 @@ export const variables = {
   debugPodVersion: '20250606-04e3c7d',
   etcdChartVersion: "12.0.8",
   etcdImageVersion: "3.6.1-debian-12-r3",
-  greptimedbOperatorVersion: 'v0.6.0',
+  greptimedbOperatorVersion: 'v0.6.1',
   vectorImageVersion: "0.49.0-debian"
 };

--- a/variables/variables-1.2.ts
+++ b/variables/variables-1.2.ts
@@ -9,6 +9,6 @@ export const variables = {
   debugPodVersion: '20250606-04e3c7d',
   etcdChartVersion: "12.0.8",
   etcdImageVersion: "3.6.1-debian-12-r3",
-  greptimedbOperatorVersion: 'v0.6.0',
+  greptimedbOperatorVersion: 'v0.6.1',
   vectorImageVersion: "0.49.0-debian"
 };

--- a/variables/variables-nightly.ts
+++ b/variables/variables-nightly.ts
@@ -9,6 +9,6 @@ export const variables = {
   debugPodVersion: '20250606-04e3c7d',
   etcdChartVersion: "12.0.8",
   etcdImageVersion: "3.6.1-debian-12-r3",
-  greptimedbOperatorVersion: 'v0.6.0',
+  greptimedbOperatorVersion: 'v0.6.1',
   vectorImageVersion: "0.49.0-debian"
 };

--- a/versioned_docs/version-1.0/enterprise/deployments-administration/deploy-on-kubernetes/installation.md
+++ b/versioned_docs/version-1.0/enterprise/deployments-administration/deploy-on-kubernetes/installation.md
@@ -356,6 +356,42 @@ auth:
       password: "1fa44bbc-5ded-42bd-a3f1-c3621affce63"
       permission: "admin"       
 
+# Audit logging configuration
+# Audit logs record operations executed on the database, helping monitor user activity,
+# detect suspicious operations, and ensure compliance.
+# See /enterprise/deployments-administration/monitoring/audit-logging.md
+auditLog:
+  # Enable the audit log plugin. Default: false.
+  enabled: true
+
+  # Allowed sources for auditing. This option acts as a filter.
+  # Multiple sources are separated by commas (",").
+  # Available sources: "unknown", "http", "grpc", "mysql", "postgres".
+  # A special value "all" (default) means all sources.
+  sources: "all"
+
+  # Allowed statement classes for auditing. This option acts as a filter.
+  # Multiple classes are separated by commas (",").
+  # Available classes: "read", "write", "admin", "ddl", "misc".
+  # A special value "all" means all classes. Default: "ddl,admin".
+  classes: "ddl,admin"
+
+  # Allowed statement commands for auditing. This option acts as a filter.
+  # Multiple commands are separated by commas (",").
+  # Available commands: "promql", "select", "copy", "insert", "delete", "create",
+  # "alter", "truncate", "drop", "admin", "misc".
+  # A special value "all" (default) means all commands.
+  commands: "all"
+
+  # Allowed object types for auditing. This option acts as a filter.
+  # Multiple object types are separated by commas (",").
+  # Available object types: "database", "table", "view", "flow", "index", "misc", "trigger".
+  # A special value "all" (default) means all object types.
+  objectTypes: "all"
+
+  # Maximum number of audit log files to retain. Default: 30.
+  maxLogFiles: 30
+
 # Remote WAL related configuration, enable as needed
 # remoteWal:
 #   enabled: true

--- a/versioned_docs/version-1.1/enterprise/deployments-administration/deploy-on-kubernetes/installation.md
+++ b/versioned_docs/version-1.1/enterprise/deployments-administration/deploy-on-kubernetes/installation.md
@@ -356,6 +356,42 @@ auth:
       password: "1fa44bbc-5ded-42bd-a3f1-c3621affce63"
       permission: "admin"       
 
+# Audit logging configuration
+# Audit logs record operations executed on the database, helping monitor user activity,
+# detect suspicious operations, and ensure compliance.
+# See /enterprise/deployments-administration/monitoring/audit-logging.md
+auditLog:
+  # Enable the audit log plugin. Default: false.
+  enabled: true
+
+  # Allowed sources for auditing. This option acts as a filter.
+  # Multiple sources are separated by commas (",").
+  # Available sources: "unknown", "http", "grpc", "mysql", "postgres".
+  # A special value "all" (default) means all sources.
+  sources: "all"
+
+  # Allowed statement classes for auditing. This option acts as a filter.
+  # Multiple classes are separated by commas (",").
+  # Available classes: "read", "write", "admin", "ddl", "misc".
+  # A special value "all" means all classes. Default: "ddl,admin".
+  classes: "ddl,admin"
+
+  # Allowed statement commands for auditing. This option acts as a filter.
+  # Multiple commands are separated by commas (",").
+  # Available commands: "promql", "select", "copy", "insert", "delete", "create",
+  # "alter", "truncate", "drop", "admin", "misc".
+  # A special value "all" (default) means all commands.
+  commands: "all"
+
+  # Allowed object types for auditing. This option acts as a filter.
+  # Multiple object types are separated by commas (",").
+  # Available object types: "database", "table", "view", "flow", "index", "misc", "trigger".
+  # A special value "all" (default) means all object types.
+  objectTypes: "all"
+
+  # Maximum number of audit log files to retain. Default: 30.
+  maxLogFiles: 30
+
 # Remote WAL related configuration, enable as needed
 # remoteWal:
 #   enabled: true

--- a/versioned_docs/version-1.2/enterprise/deployments-administration/deploy-on-kubernetes/installation.md
+++ b/versioned_docs/version-1.2/enterprise/deployments-administration/deploy-on-kubernetes/installation.md
@@ -356,6 +356,42 @@ auth:
       password: "1fa44bbc-5ded-42bd-a3f1-c3621affce63"
       permission: "admin"       
 
+# Audit logging configuration
+# Audit logs record operations executed on the database, helping monitor user activity,
+# detect suspicious operations, and ensure compliance.
+# See /enterprise/deployments-administration/monitoring/audit-logging.md
+auditLog:
+  # Enable the audit log plugin. Default: false.
+  enabled: true
+
+  # Allowed sources for auditing. This option acts as a filter.
+  # Multiple sources are separated by commas (",").
+  # Available sources: "unknown", "http", "grpc", "mysql", "postgres".
+  # A special value "all" (default) means all sources.
+  sources: "all"
+
+  # Allowed statement classes for auditing. This option acts as a filter.
+  # Multiple classes are separated by commas (",").
+  # Available classes: "read", "write", "admin", "ddl", "misc".
+  # A special value "all" means all classes. Default: "ddl,admin".
+  classes: "ddl,admin"
+
+  # Allowed statement commands for auditing. This option acts as a filter.
+  # Multiple commands are separated by commas (",").
+  # Available commands: "promql", "select", "copy", "insert", "delete", "create",
+  # "alter", "truncate", "drop", "admin", "misc".
+  # A special value "all" (default) means all commands.
+  commands: "all"
+
+  # Allowed object types for auditing. This option acts as a filter.
+  # Multiple object types are separated by commas (",").
+  # Available object types: "database", "table", "view", "flow", "index", "misc", "trigger".
+  # A special value "all" (default) means all object types.
+  objectTypes: "all"
+
+  # Maximum number of audit log files to retain. Default: 30.
+  maxLogFiles: 30
+
 # Remote WAL related configuration, enable as needed
 # remoteWal:
 #   enabled: true


### PR DESCRIPTION
## What changed
1. bump greptimedb-operator version to v0.6.1.
2. Enabled audit-logs in enterprise greptimedb installation.

## Scope

- Documentation versions: <!-- e.g. Nightly, 1.1 -->
- Languages: <!-- e.g. English, Chinese -->

## Verification

<!-- List commands run and any manual checks. -->

## Checklist

- [ ] I verified the content against the applicable GreptimeDB version.
- [ ] I updated the relevant documentation versions and languages, or explained why not.
- [ ] I checked changed links and anchors.
- [ ] I updated navigation when the document structure changed.
