### PR TITLE
chore: bump v1.2 docs to v1.2.0-beta.2

### DIFF
--- a/variables/variables-1.2.ts
+++ b/variables/variables-1.2.ts
@@ -1,5 +1,5 @@
 export const variables = {
-  greptimedbVersion: 'v1.2.0-beta.1',
+  greptimedbVersion: 'v1.2.0-beta.2',
   prometheusVersion: 'v2.52.0',
   nodeExporterVersion: 'v1.8.0',
   goSdkVersion: 'v0.7.2',


### PR DESCRIPTION
## What changed

Update `greptimedbVersion` in `variables/variables-1.2.ts` from `v1.2.0-beta.1` to `v1.2.0-beta.2`.

## Scope

- Documentation versions: 1.2
- Languages: English, Chinese (shared variables file)

## Verification

`grep` confirms no hard-coded `1.2.0-beta.1` remains in the 1.2 docs trees; all pages use `VAR::greptimedbVersion`. Still a pre-release, so the site root version is unaffected.

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] I updated navigation when the document structure changed.