### PR TITLE
docs: fix broken hyperlink parsing caused by trailing punctuation

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/http-endpoints.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/http-endpoints.md
@@ -129,7 +129,7 @@ is_strict_mode = false
 - **描述**: 提供对服务器仪表盘界面的访问。
 - **用法**: 访问这些端点以与基于 Web 的仪表盘进行交互。
 
-此仪表盘与 GreptimeDB 服务器一起打包，并提供一个用户友好的界面与服务器进行交互。构建 GreptimeDB 时需要启用相应的编译标志。仪表盘的原始源代码在 https://github.com/GreptimeTeam/dashboard。
+此仪表盘与 GreptimeDB 服务器一起打包，并提供一个用户友好的界面与服务器进行交互。构建 GreptimeDB 时需要启用相应的编译标志。仪表盘的原始源代码在 [GreptimeTeam/dashboard](https://github.com/GreptimeTeam/dashboard)。
 
 ### 日志级别
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.14/reference/http-endpoints.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.14/reference/http-endpoints.md
@@ -46,7 +46,7 @@ description: 介绍 GreptimeDB 中各种 HTTP 路径及其用法的完整列表�
 - **描述**: 提供对服务器仪表盘界面的访问。
 - **用法**: 访问这些端点以与基于 Web 的仪表盘进行交互。
 
-此仪表盘与 GreptimeDB 服务器一起打包，并提供一个用户友好的界面与服务器进行交互。构建 GreptimeDB 时需要启用相应的编译标志。仪表盘的原始源代码在 https://github.com/GreptimeTeam/dashboard。
+此仪表盘与 GreptimeDB 服务器一起打包，并提供一个用户友好的界面与服务器进行交互。构建 GreptimeDB 时需要启用相应的编译标志。仪表盘的原始源代码在 [GreptimeTeam/dashboard](https://github.com/GreptimeTeam/dashboard)。
 
 ### 日志级别
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.15/reference/http-endpoints.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.15/reference/http-endpoints.md
@@ -46,7 +46,7 @@ description: 介绍 GreptimeDB 中各种 HTTP 路径及其用法的完整列表�
 - **描述**: 提供对服务器仪表盘界面的访问。
 - **用法**: 访问这些端点以与基于 Web 的仪表盘进行交互。
 
-此仪表盘与 GreptimeDB 服务器一起打包，并提供一个用户友好的界面与服务器进行交互。构建 GreptimeDB 时需要启用相应的编译标志。仪表盘的原始源代码在 https://github.com/GreptimeTeam/dashboard。
+此仪表盘与 GreptimeDB 服务器一起打包，并提供一个用户友好的界面与服务器进行交互。构建 GreptimeDB 时需要启用相应的编译标志。仪表盘的原始源代码在 [GreptimeTeam/dashboard](https://github.com/GreptimeTeam/dashboard)。
 
 ### 日志级别
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.16/reference/http-endpoints.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.16/reference/http-endpoints.md
@@ -100,7 +100,7 @@ is_strict_mode = false
 - **描述**: 提供对服务器仪表盘界面的访问。
 - **用法**: 访问这些端点以与基于 Web 的仪表盘进行交互。
 
-此仪表盘与 GreptimeDB 服务器一起打包，并提供一个用户友好的界面与服务器进行交互。构建 GreptimeDB 时需要启用相应的编译标志。仪表盘的原始源代码在 https://github.com/GreptimeTeam/dashboard。
+此仪表盘与 GreptimeDB 服务器一起打包，并提供一个用户友好的界面与服务器进行交互。构建 GreptimeDB 时需要启用相应的编译标志。仪表盘的原始源代码在 [GreptimeTeam/dashboard](https://github.com/GreptimeTeam/dashboard)。
 
 ### 日志级别
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-0.17/reference/http-endpoints.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-0.17/reference/http-endpoints.md
@@ -100,7 +100,7 @@ is_strict_mode = false
 - **描述**: 提供对服务器仪表盘界面的访问。
 - **用法**: 访问这些端点以与基于 Web 的仪表盘进行交互。
 
-此仪表盘与 GreptimeDB 服务器一起打包，并提供一个用户友好的界面与服务器进行交互。构建 GreptimeDB 时需要启用相应的编译标志。仪表盘的原始源代码在 https://github.com/GreptimeTeam/dashboard。
+此仪表盘与 GreptimeDB 服务器一起打包，并提供一个用户友好的界面与服务器进行交互。构建 GreptimeDB 时需要启用相应的编译标志。仪表盘的原始源代码在 [GreptimeTeam/dashboard](https://github.com/GreptimeTeam/dashboard)。
 
 ### 日志级别
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.0/reference/http-endpoints.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.0/reference/http-endpoints.md
@@ -104,7 +104,7 @@ is_strict_mode = false
 - **描述**: 提供对服务器仪表盘界面的访问。
 - **用法**: 访问这些端点以与基于 Web 的仪表盘进行交互。
 
-此仪表盘与 GreptimeDB 服务器一起打包，并提供一个用户友好的界面与服务器进行交互。构建 GreptimeDB 时需要启用相应的编译标志。仪表盘的原始源代码在 https://github.com/GreptimeTeam/dashboard。
+此仪表盘与 GreptimeDB 服务器一起打包，并提供一个用户友好的界面与服务器进行交互。构建 GreptimeDB 时需要启用相应的编译标志。仪表盘的原始源代码在 [GreptimeTeam/dashboard](https://github.com/GreptimeTeam/dashboard)。
 
 ### 日志级别
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/reference/http-endpoints.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/reference/http-endpoints.md
@@ -104,7 +104,7 @@ is_strict_mode = false
 - **描述**: 提供对服务器仪表盘界面的访问。
 - **用法**: 访问这些端点以与基于 Web 的仪表盘进行交互。
 
-此仪表盘与 GreptimeDB 服务器一起打包，并提供一个用户友好的界面与服务器进行交互。构建 GreptimeDB 时需要启用相应的编译标志。仪表盘的原始源代码在 https://github.com/GreptimeTeam/dashboard。
+此仪表盘与 GreptimeDB 服务器一起打包，并提供一个用户友好的界面与服务器进行交互。构建 GreptimeDB 时需要启用相应的编译标志。仪表盘的原始源代码在 [GreptimeTeam/dashboard](https://github.com/GreptimeTeam/dashboard)。
 
 ### 日志级别
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/http-endpoints.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/http-endpoints.md
@@ -129,7 +129,7 @@ is_strict_mode = false
 - **描述**: 提供对服务器仪表盘界面的访问。
 - **用法**: 访问这些端点以与基于 Web 的仪表盘进行交互。
 
-此仪表盘与 GreptimeDB 服务器一起打包，并提供一个用户友好的界面与服务器进行交互。构建 GreptimeDB 时需要启用相应的编译标志。仪表盘的原始源代码在 https://github.com/GreptimeTeam/dashboard。
+此仪表盘与 GreptimeDB 服务器一起打包，并提供一个用户友好的界面与服务器进行交互。构建 GreptimeDB 时需要启用相应的编译标志。仪表盘的原始源代码在 [GreptimeTeam/dashboard](https://github.com/GreptimeTeam/dashboard)。
 
 ### 日志级别
 


### PR DESCRIPTION
## What changed

A raw URL in the markdown file was not wrapped in angle brackets (<>). As a result, the Markdown parser incorrectly included the trailing period (。) into the hyperlink, which broke the link. Initially, I tried using angle brackets (<>), but it caused compilation errors, so i changed the raw URL to the standard inline link format (e.g., [URL](URL)). Only fix it in the Chinese version because the English version displays normally.

## Scope

- Documentation versions: every version
- Languages: Chinese

## Verification

checked by build in local.

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] I updated navigation when the document structure changed.
