### PR TITLE
docs: refresh logs, traces, and OTLP guidance

### DIFF
--- a/docs/user-guide/ingest-data/for-observability/alloy.md
+++ b/docs/user-guide/ingest-data/for-observability/alloy.md
@@ -15,11 +15,14 @@ Configure GreptimeDB as remote write target:
 ```hcl
 prometheus.remote_write "greptimedb" {
     endpoint {
-        url = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/prometheus/write?db=${GREPTIME_DB:=public}"
+        url = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+          coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+          coalesce(sys.env("GREPTIME_PORT"), "4000") +
+          "/v1/prometheus/write?db=" + coalesce(sys.env("GREPTIME_DB"), "public")
 
         basic_auth {
-            username = "${GREPTIME_USERNAME}"
-            password = "${GREPTIME_PASSWORD}"
+            username = sys.env("GREPTIME_USERNAME")
+            password = sys.env("GREPTIME_PASSWORD")
         }
     }
 }
@@ -40,17 +43,19 @@ GreptimeDB can also be configured as OpenTelemetry collector.
 ```hcl
 otelcol.exporter.otlphttp "greptimedb" {
   client {
-    endpoint = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/otlp/"
+    endpoint = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/otlp/"
     headers  = {
-      "X-Greptime-DB-Name" = "${GREPTIME_DB:=public}",
+      "X-Greptime-DB-Name" = coalesce(sys.env("GREPTIME_DB"), "public"),
     }
     auth     = otelcol.auth.basic.credentials.handler
   }
 }
 
 otelcol.auth.basic "credentials" {
-  username = "${GREPTIME_USERNAME}"
-  password = "${GREPTIME_PASSWORD}"
+  username = sys.env("GREPTIME_USERNAME")
+  password = sys.env("GREPTIME_PASSWORD")
 }
 ```
 
@@ -90,16 +95,18 @@ otelcol.processor.batch "greptimedb_logs" {
 }
 
 otelcol.auth.basic "credentials" {
-  username = "${GREPTIME_USERNAME}"
-  password = "${GREPTIME_PASSWORD}"
+  username = sys.env("GREPTIME_USERNAME")
+  password = sys.env("GREPTIME_PASSWORD")
 }
 
 otelcol.exporter.otlphttp "greptimedb_logs" {
   client {
-    endpoint = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/otlp/"
+    endpoint = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/otlp/"
     headers = {
-      "X-Greptime-DB-Name"          = "${GREPTIME_DB:=public}",
-      "X-Greptime-Log-Table-Name"   = "${GREPTIME_LOG_TABLE_NAME:=demo_logs}",
+      "X-Greptime-DB-Name"          = coalesce(sys.env("GREPTIME_DB"), "public"),
+      "X-Greptime-Log-Table-Name"   = coalesce(sys.env("GREPTIME_LOG_TABLE_NAME"), "demo_logs"),
       "X-Greptime-Log-Extract-Keys" = "filename,log.file.name,loki.attribute.labels",
     }
     auth = otelcol.auth.basic.credentials.handler
@@ -151,15 +158,17 @@ loki.process "greptime" {
 
 loki.write "greptimedb" {
   endpoint {
-    url = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/loki/api/v1/push"
+    url = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/loki/api/v1/push"
     headers = {
-      "X-Greptime-DB-Name"        = "${GREPTIME_DB:=public}",
-      "X-Greptime-Log-Table-Name" = "${GREPTIME_LOG_TABLE_NAME:=loki_demo_logs}",
+      "X-Greptime-DB-Name"        = coalesce(sys.env("GREPTIME_DB"), "public"),
+      "X-Greptime-Log-Table-Name" = coalesce(sys.env("GREPTIME_LOG_TABLE_NAME"), "loki_demo_logs"),
     }
 
     basic_auth {
-      username = "${GREPTIME_USERNAME}"
-      password = "${GREPTIME_PASSWORD}"
+      username = sys.env("GREPTIME_USERNAME")
+      password = sys.env("GREPTIME_PASSWORD")
     }
   }
 }

--- a/docs/user-guide/ingest-data/for-observability/fluent-bit.md
+++ b/docs/user-guide/ingest-data/for-observability/fluent-bit.md
@@ -51,46 +51,27 @@ The `greptime_identity` pipeline creates the table directly from the JSON fields
 
 GreptimeDB can also be configured as OpenTelemetry collector. Using Fluent Bit's [OpenTelemetry Output Plugin](https://docs.fluentbit.io/manual/pipeline/outputs/opentelemetry), you can send metrics, logs, and traces to GreptimeDB.
 
-```
-[OUTPUT]
-    Name                 opentelemetry
-    Match                *
-    Host                 127.0.0.1
-    Port                 4000
-    Metrics_uri          /v1/otlp/v1/metrics
-    Logs_uri             /v1/otlp/v1/logs
-    Traces_uri           /v1/otlp/v1/traces
-    Log_response_payload True
-    Tls                  Off
-    Tls.verify           Off
-    logs_body_key message
-    http_User <username>
-    http_Passwd <password>
-```
-
-- `Metrics_uri`, `Logs_uri`, and `Traces_uri`: The endpoint to send metrics, logs, and traces to.
-- `http_user` and `http_passwd`: The [authentication credentials](/user-guide/deployments-administration/authentication/static.md) for GreptimeDB.
-
-We recommend not writing metrics, logs, and traces to a single output simultaneously, as each has specific header options for specifying parameters. We suggest creating a separate OpenTelemetry output for metrics, logs, and traces. for example:
+Use a separate output for each signal because GreptimeDB uses signal-specific headers. Assign a distinct tag to each signal in the Fluent Bit inputs, then match that tag in the corresponding output:
 
 ```
 # Only for metrics
 [OUTPUT]
     Name                 opentelemetry
     Alias                opentelemetry_metrics
-    Match                *
+    Match                <metrics_tag>
     Host                 127.0.0.1
     Port                 4000
     Metrics_uri          /v1/otlp/v1/metrics
     Log_response_payload True
     Tls                  Off
     Tls.verify           Off
+    Header X-Greptime-DB-Name "<dbname>"
 
 # Only for logs
 [OUTPUT]
     Name                 opentelemetry
     Alias                opentelemetry_logs
-    Match                *
+    Match                <logs_tag>
     Host                 127.0.0.1
     Port                 4000
     Logs_uri             /v1/otlp/v1/logs
@@ -98,10 +79,27 @@ We recommend not writing metrics, logs, and traces to a single output simultaneo
     Tls                  Off
     Tls.verify           Off
     Header X-Greptime-Log-Table-Name "<log_table_name>"
-    Header X-Greptime-Log-Pipeline-Name "<pipeline_name>"
+    Header X-Greptime-Pipeline-Name "<pipeline_name>"
+    Header X-Greptime-DB-Name "<dbname>"
+
+# Only for traces
+[OUTPUT]
+    Name                 opentelemetry
+    Alias                opentelemetry_traces
+    Match                <traces_tag>
+    Host                 127.0.0.1
+    Port                 4000
+    Traces_uri           /v1/otlp/v1/traces
+    Log_response_payload True
+    Tls                  Off
+    Tls.verify           Off
+    Header X-Greptime-Pipeline-Name "greptime_trace_v1"
     Header X-Greptime-DB-Name "<dbname>"
 ```
 
+- `Metrics_uri`, `Logs_uri`, and `Traces_uri`: The endpoints for metrics, logs, and traces.
+- `Match`: The signal-specific tag configured on the corresponding Fluent Bit input.
+- `http_user` and `http_passwd`: The [authentication credentials](/user-guide/deployments-administration/authentication/static.md) for GreptimeDB. Add them to each output when authentication is enabled.
 
 In this example, the OpenTelemetry OTLP/HTTP API is used. For signal-specific headers and options, see the OpenTelemetry API sections for [metrics](/user-guide/ingest-data/for-observability/opentelemetry.md#otlphttp-api), [logs](/user-guide/ingest-data/for-observability/opentelemetry.md#otlphttp-api-1), and [traces](/user-guide/ingest-data/for-observability/opentelemetry.md#otlphttp-api-2).
 

--- a/docs/user-guide/ingest-data/for-observability/loki.md
+++ b/docs/user-guide/ingest-data/for-observability/loki.md
@@ -17,7 +17,10 @@ To send logs to GreptimeDB through the raw HTTP API, use the following informati
   * `Authorization`: `Basic` authentication, which is a Base64 encoded string of `<username>:<password>`. For more information, please refer to [Authentication](https://docs.greptime.com/user-guide/deployments-administration/authentication/static/) and [HTTP API](https://docs.greptime.com/user-guide/protocols/http#authentication).
   * `X-Greptime-Log-Table-Name`: `<table_name>` (optional) - The table name to store the logs. If not provided, the default table name is `loki_logs`.
 
-The request uses binary protobuf to encode the payload. The defined schema is the same as the [logproto.proto](https://github.com/grafana/loki/blob/main/pkg/logproto/logproto.proto).
+GreptimeDB accepts either of the Loki Push API payload encodings:
+
+* **Protobuf**: Send a Snappy-compressed `PushRequest` matching [logproto.proto](https://github.com/grafana/loki/blob/main/pkg/logproto/logproto.proto) with `Content-Type: application/x-protobuf`.
+* **JSON**: Send a Loki JSON push body with `Content-Type: application/json`.
 
 ### Example Code
 
@@ -35,10 +38,12 @@ loki.source.file "greptime" {
 
 loki.write "greptime_loki" {
     endpoint {
-        url = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/loki/api/v1/push"
+        url = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+          coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+          coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/loki/api/v1/push"
         headers  = {
-          "x-greptime-db-name" = "${GREPTIME_DB:=public}",
-          "x-greptime-log-table-name" = "${GREPTIME_LOG_TABLE_NAME:=loki_demo_logs}",
+          "x-greptime-db-name" = coalesce(sys.env("GREPTIME_DB"), "public"),
+          "x-greptime-log-table-name" = coalesce(sys.env("GREPTIME_LOG_TABLE_NAME"), "loki_demo_logs"),
         }
     }
     external_labels = {
@@ -56,11 +61,11 @@ You can run the following command to check the data in the table:
 
 ```sql
 SELECT * FROM loki_demo_logs;
-+----------------------------+------------------------+--------------+-------+----------+
-| greptime_timestamp         | line                   | filename     | from  | job      |
-+----------------------------+------------------------+--------------+-------+----------+
-| 2024-11-25 11:02:31.256251 | Greptime is very cool! | /tmp/foo.txt | alloy | greptime |
-+----------------------------+------------------------+--------------+-------+----------+
++----------------------------+------------------------+---------------------+--------------+-------+----------+
+| greptime_timestamp         | line                   | structured_metadata | filename     | from  | job      |
++----------------------------+------------------------+---------------------+--------------+-------+----------+
+| 2024-11-25 11:02:31.256251 | Greptime is very cool! | {}                  | /tmp/foo.txt | alloy | greptime |
++----------------------------+------------------------+---------------------+--------------+-------+----------+
 1 row in set (0.01 sec)
 ```
 
@@ -118,6 +123,7 @@ SHOW CREATE TABLE loki_demo_logs\G
 Create Table: CREATE TABLE IF NOT EXISTS `loki_demo_logs` (
   `greptime_timestamp` TIMESTAMP(9) NOT NULL,
   `line` STRING NULL,
+  `structured_metadata` JSON NULL,
   `filename` STRING NULL,
   `from` STRING NULL,
   `job` STRING NULL,
@@ -127,7 +133,10 @@ Create Table: CREATE TABLE IF NOT EXISTS `loki_demo_logs` (
 
 ENGINE=mito
 WITH(
-  append_mode = 'true'
+  'comment' = 'Created on insertion',
+  append_mode = 'true',
+  'greptime.semantic.signal_type' = 'log',
+  'greptime.semantic.source' = 'loki'
 )
 1 row in set (0.00 sec)
 ```

--- a/docs/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/docs/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -118,8 +118,13 @@ For more information on the example code, please refer to the official documenta
 GreptimeDB supports a Prometheus-compatible mode for OTLP metrics ingestion.
 If the metrics data is persisted using the Prometheus-compatible format, you should be able to query them using PromQL, just like any Prometheus metrics.
 
-If you have not ingested any OTLP metrics before, it will automatically use the Prometheus-compatible format.
-Otherwise, it will remain the old data format with the existing table, but use the new data format for any newly created tables.
+GreptimeDB selects the ingestion format once for each OTLP export request:
+
+- If none of the referenced metric tables exists, GreptimeDB uses the Prometheus-compatible format.
+- If all referenced existing tables use the same format, GreptimeDB uses that format for every metric in the request, including any tables created by the request.
+- If the request references existing tables in both formats, GreptimeDB rejects the request.
+
+Send legacy and Prometheus-compatible metrics in separate OTLP export requests.
 
 GreptimeDB pre-processes the incoming data before persisting them, including:
 1. Converting the metric names(table names) and the label names to the Prometheus style(e.g: replace `.` with `_`). By default, GreptimeDB also adds Prometheus-style suffixes based on the metric unit and type. See [here](https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/#metric-metadata-1) for details.
@@ -132,7 +137,7 @@ GreptimeDB pre-processes the incoming data before persisting them, including:
    | `memory.usage` | Gauge / `By` | `memory_usage_bytes` |
    | `queue.length` | Gauge / `{item}` | `queue_length` |
    | `http.server.request.duration` | Histogram / `s` | `http_server_request_duration_seconds` |
-   | `rpc.server.duration` | Histogram / `ms` | `rpc_server_duration_seconds` |
+   | `rpc.server.duration` | Histogram / `ms` | `rpc_server_duration_milliseconds` |
    | `http.client.request.size` | Sum (Monotonic) / `By` | `http_client_request_size_bytes_total` |
    | `system.network.io` | Sum (Monotonic) / `By` | `system_network_io_bytes_total` |
    | `http.status_code` (Attribute) | - | `http_status_code` |
@@ -227,7 +232,7 @@ When `X-Greptime-Pipeline-Name` is provided, GreptimeDB converts each OTLP log r
 
 The OTLP logs data model is mapped to the GreptimeDB data model according to the following rules:
 
-Default table schema:
+Default schema for a newly created table:
 
 ```sql
 +-----------------------+---------------------+------+------+---------+---------------+
@@ -240,7 +245,7 @@ Default table schema:
 | severity_number       | Int32               |      | YES  |         | FIELD         |
 | body                  | String              |      | YES  |         | FIELD         |
 | log_attributes        | Json                |      | YES  |         | FIELD         |
-| trace_flags           | UInt32              |      | YES  |         | FIELD         |
+| trace_flags           | Int32               |      | YES  |         | FIELD         |
 | scope_name            | String              | PRI  | YES  |         | TAG           |
 | scope_version         | String              |      | YES  |         | FIELD         |
 | scope_attributes      | Json                |      | YES  |         | FIELD         |
@@ -292,7 +297,7 @@ You can directly send OpenTelemetry traces data to GreptimeDB, or use OpenTeleme
 
 ### Data Model
 
-GreptimeDB maps the OTLP traces data model to a table schema. By default, trace data is stored in the `opentelemetry_traces` table.
+GreptimeDB maps the OTLP traces data model to a table schema. By default, trace data is stored in the `opentelemetry_traces` table. The following example shows the schema of a newly created trace table:
 
 ```sql
 +------------------------------------+---------------------+------+------+---------+---------------+
@@ -300,7 +305,7 @@ GreptimeDB maps the OTLP traces data model to a table schema. By default, trace 
 +------------------------------------+---------------------+------+------+---------+---------------+
 | timestamp                          | TimestampNanosecond | PRI  | NO   |         | TIMESTAMP     |
 | timestamp_end                      | TimestampNanosecond |      | YES  |         | FIELD         |
-| duration_nano                      | UInt64              |      | YES  |         | FIELD         |
+| duration_nano                      | Int64               |      | YES  |         | FIELD         |
 | parent_span_id                     | String              |      | YES  |         | FIELD         |
 | trace_id                           | String              |      | YES  |         | FIELD         |
 | span_id                            | String              |      | YES  |         | FIELD         |

--- a/docs/user-guide/ingest-data/for-observability/otel-collector.md
+++ b/docs/user-guide/ingest-data/for-observability/otel-collector.md
@@ -24,7 +24,7 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 exporters:
-  otlphttp/traces:
+  otlp_http/traces:
     endpoint: 'http://127.0.0.1:4000/v1/otlp'
     # auth:
     #   authenticator: basicauth/client
@@ -33,7 +33,7 @@ exporters:
       x-greptime-pipeline-name: 'greptime_trace_v1'
     tls:
       insecure: true
-  otlphttp/logs:
+  otlp_http/logs:
     endpoint: 'http://127.0.0.1:4000/v1/otlp'
     # auth:
     #   authenticator: basicauth/client
@@ -41,11 +41,11 @@ exporters:
       # x-greptime-db-name: '<your_db_name>'
       # x-greptime-log-table-name: '<table_name>'
       # x-greptime-pipeline-name: '<pipeline_name>'
-      # x-greptime-pipeline-params: '<key=value,...>'
+      # x-greptime-pipeline-params: '<key1=value1&key2=value2>'
     tls:
       insecure: true
 
-  otlphttp/metrics:
+  otlp_http/metrics:
     endpoint: 'http://127.0.0.1:4000/v1/otlp'
     # auth:
     #   authenticator: basicauth/client
@@ -59,16 +59,16 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [otlphttp/traces]
+      exporters: [otlp_http/traces]
     logs:
       receivers: [otlp]
-      exporters: [otlphttp/logs]
+      exporters: [otlp_http/logs]
     metrics:
       receivers: [otlp]
-      exporters: [otlphttp/metrics]
+      exporters: [otlp_http/metrics]
 ```
 
-In the above configuration, we define a receiver `otlp` that can receive data from OpenTelemetry. We also define three exporters: `otlphttp/traces`, `otlphttp/logs`, and `otlphttp/metrics`, which send data to the OTLP endpoint of GreptimeDB.
+In the above configuration, we define a receiver `otlp` that can receive data from OpenTelemetry. We also define three exporters: `otlp_http/traces`, `otlp_http/logs`, and `otlp_http/metrics`, which send data to the OTLP endpoint of GreptimeDB.
 
 Based on the OTLP/HTTP protocol, we have added some headers to specify certain parameters, such as `x-greptime-pipeline-name` and `x-greptime-log-table-name`:
 * The `x-greptime-pipeline-name` header is used to specify the pipeline name to use, and,

--- a/docs/user-guide/ingest-data/for-observability/vector.md
+++ b/docs/user-guide/ingest-data/for-observability/vector.md
@@ -134,7 +134,7 @@ inputs = [ "my_source_id" ]
 compression = "gzip"
 dbname = "public"
 endpoint = "http://<host>:4000"
-extra_headers = { "skip_error" = "true" }
+extra_headers = { "x-greptime-pipeline-params" = "max_nested_levels=10" }
 pipeline_name = "greptime_identity"
 table = "<table>"
 username = "<username>"
@@ -142,7 +142,7 @@ password = "<password>"
 
 [sinks.my_sink_id.extra_params]
 source = "vector"
-x-greptime-pipeline-params = "max_nested_levels=10"
+skip_error = "true"
 ```
 
 This example demonstrates how to use `greptimedb_logs` sink to write generated demo logs data to GreptimeDB. For more information, please refer to [Vector greptimedb_logs sink](https://vector.dev/docs/reference/configuration/sinks/greptimedb_logs/) documentation.

--- a/docs/user-guide/logs/fulltext-search.md
+++ b/docs/user-guide/logs/fulltext-search.md
@@ -11,7 +11,7 @@ GreptimeDB allows for flexible querying of data using SQL statements. This secti
 
 ## Pattern Matching Using the `matches_term` Function
 
-In SQL statements, you can use the `matches_term` function to perform exact term/phrase matching, which is especially useful for log analysis. The `matches_term` function supports pattern matching on `String` type columns. You can also use the `@@` operator as a shorthand for `matches_term`. Here's an example of how it can be used:
+In SQL statements, you can use the `matches_term` function to perform script-aware term/phrase matching, which is especially useful for log analysis. The `matches_term` function supports pattern matching on `String` type columns. You can also use the `@@` operator as a shorthand for `matches_term`. Here's an example of how it can be used:
 
 ```sql
 -- Using matches_term function
@@ -21,19 +21,20 @@ SELECT * FROM logs WHERE matches_term(message, 'error') OR matches_term(message,
 SELECT * FROM logs WHERE message @@ 'error' OR message @@ 'fail';
 ```
 
-The `matches_term` function is designed for exact term/phrase matching and uses the following syntax:
+The `matches_term` function finds an exact character sequence and applies boundary rules based on the characters in the search term:
 
 - `text`: The text column to search, which should contain textual data of type `String`.
-- `term`: The search term or phrase to match exactly, following these rules:
+- `term`: The search term or phrase, following these rules:
   - Case-sensitive matching
-  - Matches must have non-alphanumeric boundaries (start/end of text or any non-alphanumeric character)
+  - For terms without Han characters, word-boundary rules apply. ASCII alphanumeric edges cannot be adjacent to ASCII alphanumeric characters; other Unicode alphanumeric edges cannot be adjacent to alphanumeric or Han characters.
+  - Terms containing Han characters match as contiguous substrings without requiring word boundaries.
   - Supports whole-word matching and phrase matching
 
 ## Query Statements
 
 ### Simple Term Matching
 
-The `matches_term` function performs exact word matching, which means it will only match complete words that are properly bounded by non-alphanumeric characters or the start/end of the text. This is particularly useful for finding specific error messages, status codes, version numbers, or paths in logs.
+For terms without Han characters, `matches_term` performs exact word matching. The match must have the boundaries described above or occur at the start or end of the text. This is particularly useful for finding specific error messages, status codes, version numbers, or paths in logs.
 
 Error messages:
 ```sql
@@ -65,6 +66,18 @@ Examples of matches and non-matches for '/start':
 - ❌ "start" - no match because it's missing the leading slash
 - ❌ "start/stop" - no match because "/start" is not a complete term
 
+### Han Term Matching
+
+Terms containing Han characters use contiguous substring matching and do not require word boundaries.
+
+```sql
+SELECT * FROM logs WHERE matches_term(message, '手机');
+```
+
+Examples of matches and non-matches:
+- ✅ "登录手机号18888888888的动态key" - matches because it contains the exact substring "手机"
+- ❌ "手持设备" - no match because it does not contain the exact substring "手机"
+
 ### Multiple Term Searches
 
 You can combine multiple `matches_term` conditions using the `OR` operator to search for logs containing any of several terms. This is useful when you want to find logs that might contain different variations of an error or different types of issues.
@@ -84,7 +97,7 @@ Examples of matches and non-matches:
 - ✅ "An error occurred!" - matches "error"
 - ✅ "critical failure detected" - matches "critical"
 - ❌ "errors" - no match because "error" is part of a larger word
-- ❌ "critical_errors" - no match because terms are part of larger words
+- ✅ "critical_errors" - matches "critical" because an underscore is a non-alphanumeric boundary
 
 ### Exclusion Searches
 

--- a/docs/user-guide/query-data/jaeger.md
+++ b/docs/user-guide/query-data/jaeger.md
@@ -17,6 +17,7 @@ GreptimeDB currently supports the following [Jaeger](https://www.jaegertracing.i
 - `/api/operations?service={service}`: Get all operations for a service.
 - `/api/services/{service}/operations`: Get all operations for a service.
 - `/api/traces`: Get traces by query parameters.
+- `/api/traces/{trace_id}`: Get a trace by its ID.
 
 You can use [Grafana's Jaeger plugin](https://grafana.com/docs/grafana/latest/datasources/jaeger/)(Recommended) or [Jaeger UI](https://github.com/jaegertracing/jaeger-ui) to query traces data in GreptimeDB. When using Jaeger UI, you can set the `proxyConfig` in `packages/jaeger-ui/vite.config.mts` to the GreptimeDB address, for example:
 

--- a/docs/user-guide/traces/data-model.md
+++ b/docs/user-guide/traces/data-model.md
@@ -108,15 +108,15 @@ span_attributes.user_agent.original        | python-requests/2.32.3
 span_attributes.http.route                 | todos/
 ```
 
-To check the table definition, you can use `show create table opentelemetry_traces`
-statement. An output like this is expected:
+To check the table definition, you can use the `show create table opentelemetry_traces`
+statement. For a newly created table, an output like this is expected:
 
 ```
 Table        | opentelemetry_traces
 Create Table | CREATE TABLE IF NOT EXISTS "opentelemetry_traces" (                                           +
              |   "timestamp" TIMESTAMP(9) NOT NULL,                                                    +
              |   "timestamp_end" TIMESTAMP(9) NULL,                                                    +
-             |   "duration_nano" BIGINT UNSIGNED NULL,                                                 +
+             |   "duration_nano" BIGINT NULL,                                                          +
              |   "trace_id" STRING NULL SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM'),    +
              |   "span_id" STRING NULL,                                                                +
              |   "span_kind" STRING NULL,                                                              +

--- a/docs/user-guide/traces/read-write.md
+++ b/docs/user-guide/traces/read-write.md
@@ -49,7 +49,7 @@ docker run --rm \
   -p 4317:4317 \
   -p 4318:4318 \
   -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml \
-  otel/opentelemetry-collector-contrib:0.123.0
+  otel/opentelemetry-collector-contrib:0.159.0
 ```
 
 The content of the `config.yaml` file is as follows:
@@ -64,7 +64,7 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 exporters:
-  otlphttp:
+  otlp_http:
     endpoint: "http://greptimedb:4000/v1/otlp" # Replace greptimedb with your setup
     headers:
       x-greptime-pipeline-name: "greptime_trace_v1"
@@ -76,7 +76,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [otlphttp]
+      exporters: [otlp_http]
 ```
 
 #### Write Trace Data to OpenTelemetry Collector

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/alloy.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/alloy.md
@@ -15,11 +15,14 @@ description: 介绍了如何将 GreptimeDB 配置为 Grafana Alloy 的数据接�
 ```hcl
 prometheus.remote_write "greptimedb" {
   endpoint {
-    url = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/prometheus/write?db=${GREPTIME_DB:=public}"
+    url = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") +
+      "/v1/prometheus/write?db=" + coalesce(sys.env("GREPTIME_DB"), "public")
 
     basic_auth {
-      username = "${GREPTIME_USERNAME}"
-      password = "${GREPTIME_PASSWORD}"
+      username = sys.env("GREPTIME_USERNAME")
+      password = sys.env("GREPTIME_PASSWORD")
     }
   }
 }
@@ -40,17 +43,19 @@ GreptimeDB 也可以配置为 OpenTelemetry Collector 的目标。
 ```hcl
 otelcol.exporter.otlphttp "greptimedb" {
   client {
-    endpoint = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/otlp/"
+    endpoint = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/otlp/"
     headers  = {
-      "X-Greptime-DB-Name" = "${GREPTIME_DB:=public}",
+      "X-Greptime-DB-Name" = coalesce(sys.env("GREPTIME_DB"), "public"),
     }
     auth     = otelcol.auth.basic.credentials.handler
   }
 }
 
 otelcol.auth.basic "credentials" {
-  username = "${GREPTIME_USERNAME}"
-  password = "${GREPTIME_PASSWORD}"
+  username = sys.env("GREPTIME_USERNAME")
+  password = sys.env("GREPTIME_PASSWORD")
 }
 ```
 
@@ -90,16 +95,18 @@ otelcol.processor.batch "greptimedb_logs" {
 }
 
 otelcol.auth.basic "credentials" {
-  username = "${GREPTIME_USERNAME}"
-  password = "${GREPTIME_PASSWORD}"
+  username = sys.env("GREPTIME_USERNAME")
+  password = sys.env("GREPTIME_PASSWORD")
 }
 
 otelcol.exporter.otlphttp "greptimedb_logs" {
   client {
-    endpoint = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/otlp/"
+    endpoint = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/otlp/"
     headers = {
-      "X-Greptime-DB-Name"          = "${GREPTIME_DB:=public}",
-      "X-Greptime-Log-Table-Name"   = "${GREPTIME_LOG_TABLE_NAME:=demo_logs}",
+      "X-Greptime-DB-Name"          = coalesce(sys.env("GREPTIME_DB"), "public"),
+      "X-Greptime-Log-Table-Name"   = coalesce(sys.env("GREPTIME_LOG_TABLE_NAME"), "demo_logs"),
       "X-Greptime-Log-Extract-Keys" = "filename,log.file.name,loki.attribute.labels",
     }
     auth = otelcol.auth.basic.credentials.handler
@@ -151,15 +158,17 @@ loki.process "greptime" {
 
 loki.write "greptimedb" {
   endpoint {
-    url = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/loki/api/v1/push"
+    url = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/loki/api/v1/push"
     headers = {
-      "X-Greptime-DB-Name"        = "${GREPTIME_DB:=public}",
-      "X-Greptime-Log-Table-Name" = "${GREPTIME_LOG_TABLE_NAME:=loki_demo_logs}",
+      "X-Greptime-DB-Name"        = coalesce(sys.env("GREPTIME_DB"), "public"),
+      "X-Greptime-Log-Table-Name" = coalesce(sys.env("GREPTIME_LOG_TABLE_NAME"), "loki_demo_logs"),
     }
 
     basic_auth {
-      username = "${GREPTIME_USERNAME}"
-      password = "${GREPTIME_PASSWORD}"
+      username = sys.env("GREPTIME_USERNAME")
+      password = sys.env("GREPTIME_PASSWORD")
     }
   }
 }

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/fluent-bit.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/fluent-bit.md
@@ -50,42 +50,27 @@ description: 将 GreptimeDB 与 Fluent bit 集成以实现 Prometheus Remote Wri
 
 GreptimeDB 也可以配置为 OpenTelemetry 收集器。使用 Fluent Bit 的 [OpenTelemetry 输出插件](https://docs.fluentbit.io/manual/pipeline/outputs/opentelemetry)，你可以将指标、日志和跟踪发送到 GreptimeDB。
 
-```
-[OUTPUT]
-    Name                 opentelemetry
-    Match                *
-    Host                 127.0.0.1
-    Port                 4000
-    Metrics_uri          /v1/otlp/v1/metrics
-    Logs_uri             /v1/otlp/v1/logs
-    Traces_uri           /v1/otlp/v1/traces
-    Log_response_payload True
-    Tls                  Off
-    Tls.verify           Off
-```
-
-- `Metrics_uri`, `Logs_uri`, 和 `Traces_uri`: 发送指标、日志和跟踪的端点。
-
-我们建议不要在一个 output 同时写入 metrics log 和 trace，因为我们的写入接口它们各自有一些特殊的 header 选项用于指定一些参数，我们建议一个为 metrics log 和 trace 单独创建一个 opentelemetry output 例如：
+由于 GreptimeDB 会为不同 signal 使用不同的 header，请为每种 signal 配置独立的 output。在 Fluent Bit input 中为每种 signal 设置不同的 tag，然后在对应的 output 中匹配该 tag：
 
 ```
-# Only for metrics
+# 仅用于 metrics
 [OUTPUT]
     Name                 opentelemetry
     Alias                opentelemetry_metrics
-    Match                *
+    Match                <metrics_tag>
     Host                 127.0.0.1
     Port                 4000
     Metrics_uri          /v1/otlp/v1/metrics
     Log_response_payload True
     Tls                  Off
     Tls.verify           Off
+    Header X-Greptime-DB-Name "<dbname>"
 
-# Only for logs
+# 仅用于 logs
 [OUTPUT]
     Name                 opentelemetry
     Alias                opentelemetry_logs
-    Match                *
+    Match                <logs_tag>
     Host                 127.0.0.1
     Port                 4000
     Logs_uri             /v1/otlp/v1/logs
@@ -93,9 +78,27 @@ GreptimeDB 也可以配置为 OpenTelemetry 收集器。使用 Fluent Bit 的 [O
     Tls                  Off
     Tls.verify           Off
     Header X-Greptime-Log-Table-Name "<log_table_name>"
-    Header X-Greptime-Log-Pipeline-Name "<pipeline_name>"
+    Header X-Greptime-Pipeline-Name "<pipeline_name>"
+    Header X-Greptime-DB-Name "<dbname>"
+
+# 仅用于 traces
+[OUTPUT]
+    Name                 opentelemetry
+    Alias                opentelemetry_traces
+    Match                <traces_tag>
+    Host                 127.0.0.1
+    Port                 4000
+    Traces_uri           /v1/otlp/v1/traces
+    Log_response_payload True
+    Tls                  Off
+    Tls.verify           Off
+    Header X-Greptime-Pipeline-Name "greptime_trace_v1"
     Header X-Greptime-DB-Name "<dbname>"
 ```
+
+- `Metrics_uri`、`Logs_uri` 和 `Traces_uri`：分别用于发送 metrics、logs 和 traces 的端点。
+- `Match`：在对应 Fluent Bit input 中配置的 signal tag。
+- `http_user` 和 `http_passwd`：GreptimeDB 的[认证凭据](/user-guide/deployments-administration/authentication/static.md)。启用鉴权时，请将它们添加到每个 output 中。
 
 本示例使用的是 OpenTelemetry OTLP/HTTP API。不同 signal 支持的 header 和选项不同，具体请分别参考 OpenTelemetry API 的 [metrics](/user-guide/ingest-data/for-observability/opentelemetry.md#otlphttp-api)、[logs](/user-guide/ingest-data/for-observability/opentelemetry.md#otlphttp-api-1) 和 [traces](/user-guide/ingest-data/for-observability/opentelemetry.md#otlphttp-api-2) 部分。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/loki.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/loki.md
@@ -17,7 +17,10 @@ description: 介绍如何使用 Loki 将日志数据发送到 GreptimeDB，包�
   * `Authorization`: `Basic` 认证，这是一个 Base64 编码的 `<username>:<password>` 字符串。更多信息，请参考 [认证](https://docs.greptime.com/user-guide/deployments-administration/authentication/static/) 和 [HTTP API](https://docs.greptime.com/user-guide/protocols/http#authentication)。
   * `X-Greptime-Log-Table-Name`: `<table_name>`（可选）- 存储日志的表名。如果未提供，默认表名为 `loki_logs`。
 
-请求使用二进制 protobuf 编码负载。定义的格式与 [logproto.proto](https://github.com/grafana/loki/blob/main/pkg/logproto/logproto.proto) 相同。
+GreptimeDB 支持 Loki Push API 的以下两种负载编码：
+
+* **Protobuf**：发送符合 [logproto.proto](https://github.com/grafana/loki/blob/main/pkg/logproto/logproto.proto) 定义、经过 Snappy 压缩的 `PushRequest`，并设置 `Content-Type: application/x-protobuf`。
+* **JSON**：发送 Loki JSON Push 请求体，并设置 `Content-Type: application/json`。
 
 ### 示例代码
 
@@ -35,10 +38,12 @@ loki.source.file "greptime" {
 
 loki.write "greptime_loki" {
     endpoint {
-        url = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/loki/api/v1/push"
+        url = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+          coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+          coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/loki/api/v1/push"
         headers  = {
-          "x-greptime-db-name" = "${GREPTIME_DB:=public}",
-          "x-greptime-log-table-name" = "${GREPTIME_LOG_TABLE_NAME:=loki_demo_logs}",
+          "x-greptime-db-name" = coalesce(sys.env("GREPTIME_DB"), "public"),
+          "x-greptime-log-table-name" = coalesce(sys.env("GREPTIME_LOG_TABLE_NAME"), "loki_demo_logs"),
         }
     }
     external_labels = {
@@ -56,11 +61,11 @@ loki.write "greptime_loki" {
 
 ```sql
 SELECT * FROM loki_demo_logs;
-+----------------------------+------------------------+--------------+-------+----------+
-| greptime_timestamp         | line                   | filename     | from  | job      |
-+----------------------------+------------------------+--------------+-------+----------+
-| 2024-11-25 11:02:31.256251 | Greptime is very cool! | /tmp/foo.txt | alloy | greptime |
-+----------------------------+------------------------+--------------+-------+----------+
++----------------------------+------------------------+---------------------+--------------+-------+----------+
+| greptime_timestamp         | line                   | structured_metadata | filename     | from  | job      |
++----------------------------+------------------------+---------------------+--------------+-------+----------+
+| 2024-11-25 11:02:31.256251 | Greptime is very cool! | {}                  | /tmp/foo.txt | alloy | greptime |
++----------------------------+------------------------+---------------------+--------------+-------+----------+
 1 row in set (0.01 sec)
 ```
 
@@ -118,6 +123,7 @@ SHOW CREATE TABLE loki_demo_logs\G
 Create Table: CREATE TABLE IF NOT EXISTS `loki_demo_logs` (
   `greptime_timestamp` TIMESTAMP(9) NOT NULL,
   `line` STRING NULL,
+  `structured_metadata` JSON NULL,
   `filename` STRING NULL,
   `from` STRING NULL,
   `job` STRING NULL,
@@ -127,7 +133,10 @@ Create Table: CREATE TABLE IF NOT EXISTS `loki_demo_logs` (
 
 ENGINE=mito
 WITH(
-  append_mode = 'true'
+  'comment' = 'Created on insertion',
+  append_mode = 'true',
+  'greptime.semantic.signal_type' = 'log',
+  'greptime.semantic.source' = 'loki'
 )
 1 row in set (0.00 sec)
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -120,8 +120,13 @@ exporter = OTLPMetricExporter(
 GreptimeDB 支持以 Prometheus 兼容模式写入 OTLP 指标。
 如果指标以这种兼容模式写入，你可以像查询 Prometheus 原生指标一样使用 PromQL 直接查询这些指标。
 
-如果你之前没有使用过 OTLP 指标写入，那么 GreptimeDB 会默认使用新的兼容模式。
-否则，GreptimeDB 会对已经存在的表保留原有的数据模型，只有对新创建的指标表使用兼容模式写入。
+GreptimeDB 会为每个 OTLP 导出请求统一选择写入格式：
+
+- 如果请求涉及的指标表都不存在，GreptimeDB 使用 Prometheus 兼容格式。
+- 如果请求涉及的已有表都使用同一种格式，GreptimeDB 对请求中的所有指标使用该格式，包括由该请求新建的表。
+- 如果请求同时涉及两种格式的已有表，GreptimeDB 会拒绝该请求。
+
+如需同时写入旧格式和 Prometheus 兼容格式的指标，请将它们拆分到不同的 OTLP 导出请求中。
 
 GreptimeDB 会首先对数据进行预处理，包括：
 1. 将指标名（表名）和标签名转换成 Prometheus 风格的命名（例如：将 `.` 替换为 `_`）。默认情况下，GreptimeDB 还会根据指标单位和类型添加 Prometheus 风格的后缀。具体信息请参考[这里](https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/#metric-metadata-1)
@@ -134,7 +139,7 @@ GreptimeDB 会首先对数据进行预处理，包括：
    | `memory.usage` | Gauge / `By` | `memory_usage_bytes` |
    | `queue.length` | Gauge / `{item}` | `queue_length` |
    | `http.server.request.duration` | Histogram / `s` | `http_server_request_duration_seconds` |
-   | `rpc.server.duration` | Histogram / `ms` | `rpc_server_duration_seconds` |
+   | `rpc.server.duration` | Histogram / `ms` | `rpc_server_duration_milliseconds` |
    | `http.client.request.size` | Sum (Monotonic) / `By` | `http_client_request_size_bytes_total` |
    | `system.network.io` | Sum (Monotonic) / `By` | `system_network_io_bytes_total` |
    | `http.status_code` (属性) | - | `http_status_code` |
@@ -229,7 +234,7 @@ GreptimeDB 是能够通过 [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/
 
 OTLP 日志数据模型根据以下规则映射到 GreptimeDB 数据模型：
 
-默认表结构：
+新建表的默认表结构：
 
 ```sql
 +-----------------------+---------------------+------+------+---------+---------------+
@@ -242,7 +247,7 @@ OTLP 日志数据模型根据以下规则映射到 GreptimeDB 数据模型：
 | severity_number       | Int32               |      | YES  |         | FIELD         |
 | body                  | String              |      | YES  |         | FIELD         |
 | log_attributes        | Json                |      | YES  |         | FIELD         |
-| trace_flags           | UInt32              |      | YES  |         | FIELD         |
+| trace_flags           | Int32               |      | YES  |         | FIELD         |
 | scope_name            | String              | PRI  | YES  |         | TAG           |
 | scope_version         | String              |      | YES  |         | FIELD         |
 | scope_attributes      | Json                |      | YES  |         | FIELD         |
@@ -291,7 +296,7 @@ GreptimeDB 会通过 **HTTP 协议** 接受 **protobuf 编码的 traces 数据**
 
 ### 数据模型
 
-GreptimeDB 将 OTLP traces 数据模型映射到表结构。默认情况下，Trace 数据存储在 `opentelemetry_traces` 表中。
+GreptimeDB 将 OTLP traces 数据模型映射到表结构。默认情况下，Trace 数据存储在 `opentelemetry_traces` 表中。以下示例展示了新建 trace 表的表结构：
 
 ```sql
 +------------------------------------+---------------------+------+------+---------+---------------+
@@ -299,7 +304,7 @@ GreptimeDB 将 OTLP traces 数据模型映射到表结构。默认情况下，Tr
 +------------------------------------+---------------------+------+------+---------+---------------+
 | timestamp                          | TimestampNanosecond | PRI  | NO   |         | TIMESTAMP     |
 | timestamp_end                      | TimestampNanosecond |      | YES  |         | FIELD         |
-| duration_nano                      | UInt64              |      | YES  |         | FIELD         |
+| duration_nano                      | Int64               |      | YES  |         | FIELD         |
 | parent_span_id                     | String              |      | YES  |         | FIELD         |
 | trace_id                           | String              |      | YES  |         | FIELD         |
 | span_id                            | String              |      | YES  |         | FIELD         |

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/otel-collector.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/otel-collector.md
@@ -24,7 +24,7 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 exporters:
-  otlphttp/traces:
+  otlp_http/traces:
     endpoint: 'http://127.0.0.1:4000/v1/otlp'
     # auth:
     #   authenticator: basicauth/client
@@ -33,7 +33,7 @@ exporters:
       x-greptime-pipeline-name: 'greptime_trace_v1'
     tls:
       insecure: true
-  otlphttp/logs:
+  otlp_http/logs:
     endpoint: 'http://127.0.0.1:4000/v1/otlp'
     # auth:
     #   authenticator: basicauth/client
@@ -41,11 +41,11 @@ exporters:
       # x-greptime-db-name: '<your_db_name>'
       # x-greptime-log-table-name: '<table_name>'
       # x-greptime-pipeline-name: '<pipeline_name>'
-      # x-greptime-pipeline-params: '<key=value,...>'
+      # x-greptime-pipeline-params: '<key1=value1&key2=value2>'
     tls:
       insecure: true
 
-  otlphttp/metrics:
+  otlp_http/metrics:
     endpoint: 'http://127.0.0.1:4000/v1/otlp'
     # auth:
     #   authenticator: basicauth/client
@@ -59,16 +59,16 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [otlphttp/traces]
+      exporters: [otlp_http/traces]
     logs:
       receivers: [otlp]
-      exporters: [otlphttp/logs]
+      exporters: [otlp_http/logs]
     metrics:
       receivers: [otlp]
-      exporters: [otlphttp/metrics]
+      exporters: [otlp_http/metrics]
 ```
 
-在上面的配置中，我们定义了一个接收器 `otlp`，它可以接收来自 OpenTelemetry 的数据。我们还定义了三个导出器 `otlphttp/traces`、`otlphttp/logs` 和 `otlphttp/metrics`，它们将数据发送到 GreptimeDB 的 OTLP 路径。
+在上面的配置中，我们定义了一个接收器 `otlp`，它可以接收来自 OpenTelemetry 的数据。我们还定义了三个导出器 `otlp_http/traces`、`otlp_http/logs` 和 `otlp_http/metrics`，它们将数据发送到 GreptimeDB 的 OTLP 路径。
 
 基于 OTLP/HTTP 协议，我们增加了一些 header 用来指定参数，比如 `x-greptime-pipeline-name` 和 `x-greptime-log-table-name`:
 * `x-greptime-pipeline-name` 用来指定要使用的 pipeline 名称

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/vector.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/ingest-data/for-observability/vector.md
@@ -143,7 +143,7 @@ inputs = [ "my_source_id" ]
 compression = "gzip"
 dbname = "public"
 endpoint = "http://<host>:4000"
-extra_headers = { "skip_error" = "true" }
+extra_headers = { "x-greptime-pipeline-params" = "max_nested_levels=10" }
 pipeline_name = "greptime_identity"
 table = "<table>"
 username = "<username>"
@@ -151,7 +151,7 @@ password = "<password>"
 
 [sinks.my_sink_id.extra_params]
 source = "vector"
-x-greptime-pipeline-params = "max_nested_levels=10"
+skip_error = "true"
 ```
 
 此示例展示了如何使用 `greptimedb_logs` sink 将生成的 demo 日志数据写入 GreptimeDB。更多信息请参考 [Vector greptimedb_logs sink](https://vector.dev/docs/reference/configuration/sinks/greptimedb_logs/) 文档。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/fulltext-search.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/fulltext-search.md
@@ -11,7 +11,7 @@ GreptimeDB 支持通过 SQL 语句灵活查询数据。本节将介绍特定的�
 
 ## 使用 `matches_term` 函数进行精确匹配
 
-在 SQL 查询中，你可以使用 `matches_term` 函数执行精确的词语/短语匹配，这在日志分析中尤其实用。`matches_term` 函数支持对 `String` 类型列进行精确匹配。你也可以使用 `@@` 操作符作为 `matches_term` 的简写形式。下面是一个典型示例：
+在 SQL 查询中，你可以使用 `matches_term` 函数执行根据字符类型应用边界规则的词语/短语匹配，这在日志分析中尤其实用。`matches_term` 函数支持对 `String` 类型列进行匹配。你也可以使用 `@@` 操作符作为 `matches_term` 的简写形式。下面是一个典型示例：
 
 ```sql
 -- 使用 matches_term 函数
@@ -21,19 +21,20 @@ SELECT * FROM logs WHERE matches_term(message, 'error') OR matches_term(message,
 SELECT * FROM logs WHERE message @@ 'error' OR message @@ 'fail';
 ```
 
-`matches_term` 函数专门用于精确匹配，使用方式如下：
+`matches_term` 函数查找完全相同的字符序列，并根据搜索词中的字符应用边界规则：
 
 - `text`：需要进行匹配的文本列，该列应包含 `String` 类型的文本数据。
 - `term`：要匹配的词语或短语，遵循以下规则：
   - 区分大小写
-  - 匹配项必须由非字母数字字符（包括空格、标点符号等）或文本开头/结尾界定
+  - 对于不包含汉字的搜索词，需要满足词边界规则。如果搜索词的首尾字符是 ASCII 字母或数字，则相邻字符不能是 ASCII 字母或数字；如果首尾字符是其他 Unicode 字母或数字，则相邻字符不能是字母、数字或汉字。
+  - 包含汉字的搜索词按连续子串匹配，不要求词边界。
   - 支持完整词语匹配和短语匹配
 
 ## 查询语句示例
 
 ### 简单词语匹配
 
-`matches_term` 函数执行精确词语匹配，这意味着它只会匹配由非字母数字字符或文本开头/结尾界定的完整词语。这对于在日志中查找特定的错误消息或状态码特别有用。
+对于不包含汉字的搜索词，`matches_term` 执行精确词语匹配。匹配项必须满足上述边界规则，或者位于文本开头或结尾。这对于在日志中查找特定的错误消息或状态码特别有用。
 
 ```sql
 -- 使用 matches_term 函数
@@ -52,6 +53,18 @@ SELECT * FROM logs WHERE message @@ 'error';
 - ❌ "errors" - 不匹配，因为 "error" 是更大词语的一部分
 - ❌ "error123" - 不匹配，因为 "error" 后面跟着数字
 - ❌ "errorLogs" - 不匹配，因为 "error" 是驼峰命名词语的一部分
+
+### 汉字搜索词匹配
+
+包含汉字的搜索词按连续子串匹配，不要求词边界。
+
+```sql
+SELECT * FROM logs WHERE matches_term(message, '手机');
+```
+
+匹配和不匹配的示例：
+- ✅ "登录手机号18888888888的动态key" - 匹配，因为其中包含完全相同的子串 "手机"
+- ❌ "手持设备" - 不匹配，因为其中不包含完全相同的子串 "手机"
 
 ### 多关键词搜索
 
@@ -72,7 +85,7 @@ SELECT * FROM logs WHERE message @@ 'critical' OR message @@ 'error';
 - ✅ "An error occurred!" - 匹配 "error"
 - ✅ "critical failure detected" - 匹配 "critical"
 - ❌ "errors" - 不匹配，因为 "error" 是更大词语的一部分
-- ❌ "critical_errors" - 不匹配，因为词语是更大词语的一部分
+- ✅ "critical_errors" - 匹配 "critical"，因为下划线属于非字母数字边界
 
 ### 排除条件搜索
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/query-data/jaeger.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/query-data/jaeger.md
@@ -17,6 +17,7 @@ GreptimeDB 目前支持以下 [Jaeger](https://www.jaegertracing.io/) 查询接�
 - `/api/operations?service={service}`: 获取指定 Service 的所有 Operations。
 - `/api/services/{service}/operations`: 获取指定 Service 的所有 Operations。
 - `/api/traces`: 根据查询参数获取 traces 数据。
+- `/api/traces/{trace_id}`: 根据 trace ID 获取 trace 数据。
 
 你可以使用 Grafana 的 [Jaeger 插件](https://grafana.com/docs/grafana/latest/datasources/jaeger/)（推荐） 或者 [Jaeger UI](https://github.com/jaegertracing/jaeger-ui) 来查询 GreptimeDB 中的 traces 数据。当你在使用 Jaeger UI 的时候，可将 `packages/jaeger-ui/vite.config.mts` 的 `proxyConfig` 配置为 GreptimeDB 的地址，比如：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/traces/data-model.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/traces/data-model.md
@@ -87,14 +87,14 @@ span_attributes.user_agent.original        | python-requests/2.32.3
 span_attributes.http.route                 | todos/
 ```
 
-可以通过执行 `show create table opentelemetry_traces` 来查看表建表语句：
+对于新建的表，可以通过执行 `show create table opentelemetry_traces` 来查看建表语句：
 
 ```
 Table        | opentelemetry_traces
 Create Table | CREATE TABLE IF NOT EXISTS "opentelemetry_traces" (                                           +
              |   "timestamp" TIMESTAMP(9) NOT NULL,                                                    +
              |   "timestamp_end" TIMESTAMP(9) NULL,                                                    +
-             |   "duration_nano" BIGINT UNSIGNED NULL,                                                 +
+             |   "duration_nano" BIGINT NULL,                                                          +
              |   "trace_id" STRING NULL SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM'),    +
              |   "span_id" STRING NULL,                                                                +
              |   "span_kind" STRING NULL,                                                              +

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/traces/read-write.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/traces/read-write.md
@@ -45,7 +45,7 @@ docker run --rm \
   -p 4317:4317 \
   -p 4318:4318 \
   -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml \
-  otel/opentelemetry-collector-contrib:0.123.0
+  otel/opentelemetry-collector-contrib:0.159.0
 ```
 
 其中 `config.yaml` 文件内容如下：
@@ -60,7 +60,7 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 exporters:
-  otlphttp:
+  otlp_http:
     endpoint: "http://greptimedb:4000/v1/otlp" # GreptimeDB 的 OTLP 路径
     headers:
       x-greptime-pipeline-name: "greptime_trace_v1"
@@ -72,7 +72,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [otlphttp]
+      exporters: [otlp_http]
 ```
 
 #### 将 Trace 数据写入到 OpenTelemetry Collector

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/ingest-data/for-observability/alloy.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/ingest-data/for-observability/alloy.md
@@ -15,11 +15,14 @@ description: 介绍了如何将 GreptimeDB 配置为 Grafana Alloy 的数据接�
 ```hcl
 prometheus.remote_write "greptimedb" {
   endpoint {
-    url = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/prometheus/write?db=${GREPTIME_DB:=public}"
+    url = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") +
+      "/v1/prometheus/write?db=" + coalesce(sys.env("GREPTIME_DB"), "public")
 
     basic_auth {
-      username = "${GREPTIME_USERNAME}"
-      password = "${GREPTIME_PASSWORD}"
+      username = sys.env("GREPTIME_USERNAME")
+      password = sys.env("GREPTIME_PASSWORD")
     }
   }
 }
@@ -40,17 +43,19 @@ GreptimeDB 也可以配置为 OpenTelemetry Collector 的目标。
 ```hcl
 otelcol.exporter.otlphttp "greptimedb" {
   client {
-    endpoint = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/otlp/"
+    endpoint = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/otlp/"
     headers  = {
-      "X-Greptime-DB-Name" = "${GREPTIME_DB:=public}",
+      "X-Greptime-DB-Name" = coalesce(sys.env("GREPTIME_DB"), "public"),
     }
     auth     = otelcol.auth.basic.credentials.handler
   }
 }
 
 otelcol.auth.basic "credentials" {
-  username = "${GREPTIME_USERNAME}"
-  password = "${GREPTIME_PASSWORD}"
+  username = sys.env("GREPTIME_USERNAME")
+  password = sys.env("GREPTIME_PASSWORD")
 }
 ```
 
@@ -90,16 +95,18 @@ otelcol.processor.batch "greptimedb_logs" {
 }
 
 otelcol.auth.basic "credentials" {
-  username = "${GREPTIME_USERNAME}"
-  password = "${GREPTIME_PASSWORD}"
+  username = sys.env("GREPTIME_USERNAME")
+  password = sys.env("GREPTIME_PASSWORD")
 }
 
 otelcol.exporter.otlphttp "greptimedb_logs" {
   client {
-    endpoint = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/otlp/"
+    endpoint = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/otlp/"
     headers = {
-      "X-Greptime-DB-Name"          = "${GREPTIME_DB:=public}",
-      "X-Greptime-Log-Table-Name"   = "${GREPTIME_LOG_TABLE_NAME:=demo_logs}",
+      "X-Greptime-DB-Name"          = coalesce(sys.env("GREPTIME_DB"), "public"),
+      "X-Greptime-Log-Table-Name"   = coalesce(sys.env("GREPTIME_LOG_TABLE_NAME"), "demo_logs"),
       "X-Greptime-Log-Extract-Keys" = "filename,log.file.name,loki.attribute.labels",
     }
     auth = otelcol.auth.basic.credentials.handler
@@ -151,15 +158,17 @@ loki.process "greptime" {
 
 loki.write "greptimedb" {
   endpoint {
-    url = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/loki/api/v1/push"
+    url = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/loki/api/v1/push"
     headers = {
-      "X-Greptime-DB-Name"        = "${GREPTIME_DB:=public}",
-      "X-Greptime-Log-Table-Name" = "${GREPTIME_LOG_TABLE_NAME:=loki_demo_logs}",
+      "X-Greptime-DB-Name"        = coalesce(sys.env("GREPTIME_DB"), "public"),
+      "X-Greptime-Log-Table-Name" = coalesce(sys.env("GREPTIME_LOG_TABLE_NAME"), "loki_demo_logs"),
     }
 
     basic_auth {
-      username = "${GREPTIME_USERNAME}"
-      password = "${GREPTIME_PASSWORD}"
+      username = sys.env("GREPTIME_USERNAME")
+      password = sys.env("GREPTIME_PASSWORD")
     }
   }
 }

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/ingest-data/for-observability/fluent-bit.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/ingest-data/for-observability/fluent-bit.md
@@ -50,42 +50,27 @@ description: 将 GreptimeDB 与 Fluent bit 集成以实现 Prometheus Remote Wri
 
 GreptimeDB 也可以配置为 OpenTelemetry 收集器。使用 Fluent Bit 的 [OpenTelemetry 输出插件](https://docs.fluentbit.io/manual/pipeline/outputs/opentelemetry)，你可以将指标、日志和跟踪发送到 GreptimeDB。
 
-```
-[OUTPUT]
-    Name                 opentelemetry
-    Match                *
-    Host                 127.0.0.1
-    Port                 4000
-    Metrics_uri          /v1/otlp/v1/metrics
-    Logs_uri             /v1/otlp/v1/logs
-    Traces_uri           /v1/otlp/v1/traces
-    Log_response_payload True
-    Tls                  Off
-    Tls.verify           Off
-```
-
-- `Metrics_uri`, `Logs_uri`, 和 `Traces_uri`: 发送指标、日志和跟踪的端点。
-
-我们建议不要在一个 output 同时写入 metrics log 和 trace，因为我们的写入接口它们各自有一些特殊的 header 选项用于指定一些参数，我们建议一个为 metrics log 和 trace 单独创建一个 opentelemetry output 例如：
+由于 GreptimeDB 会为不同 signal 使用不同的 header，请为每种 signal 配置独立的 output。在 Fluent Bit input 中为每种 signal 设置不同的 tag，然后在对应的 output 中匹配该 tag：
 
 ```
-# Only for metrics
+# 仅用于 metrics
 [OUTPUT]
     Name                 opentelemetry
     Alias                opentelemetry_metrics
-    Match                *
+    Match                <metrics_tag>
     Host                 127.0.0.1
     Port                 4000
     Metrics_uri          /v1/otlp/v1/metrics
     Log_response_payload True
     Tls                  Off
     Tls.verify           Off
+    Header X-Greptime-DB-Name "<dbname>"
 
-# Only for logs
+# 仅用于 logs
 [OUTPUT]
     Name                 opentelemetry
     Alias                opentelemetry_logs
-    Match                *
+    Match                <logs_tag>
     Host                 127.0.0.1
     Port                 4000
     Logs_uri             /v1/otlp/v1/logs
@@ -93,9 +78,27 @@ GreptimeDB 也可以配置为 OpenTelemetry 收集器。使用 Fluent Bit 的 [O
     Tls                  Off
     Tls.verify           Off
     Header X-Greptime-Log-Table-Name "<log_table_name>"
-    Header X-Greptime-Log-Pipeline-Name "<pipeline_name>"
+    Header X-Greptime-Pipeline-Name "<pipeline_name>"
+    Header X-Greptime-DB-Name "<dbname>"
+
+# 仅用于 traces
+[OUTPUT]
+    Name                 opentelemetry
+    Alias                opentelemetry_traces
+    Match                <traces_tag>
+    Host                 127.0.0.1
+    Port                 4000
+    Traces_uri           /v1/otlp/v1/traces
+    Log_response_payload True
+    Tls                  Off
+    Tls.verify           Off
+    Header X-Greptime-Pipeline-Name "greptime_trace_v1"
     Header X-Greptime-DB-Name "<dbname>"
 ```
+
+- `Metrics_uri`、`Logs_uri` 和 `Traces_uri`：分别用于发送 metrics、logs 和 traces 的端点。
+- `Match`：在对应 Fluent Bit input 中配置的 signal tag。
+- `http_user` 和 `http_passwd`：GreptimeDB 的[认证凭据](/user-guide/deployments-administration/authentication/static.md)。启用鉴权时，请将它们添加到每个 output 中。
 
 本示例使用的是 OpenTelemetry OTLP/HTTP API。不同 signal 支持的 header 和选项不同，具体请分别参考 OpenTelemetry API 的 [metrics](/user-guide/ingest-data/for-observability/opentelemetry.md#otlphttp-api)、[logs](/user-guide/ingest-data/for-observability/opentelemetry.md#otlphttp-api-1) 和 [traces](/user-guide/ingest-data/for-observability/opentelemetry.md#otlphttp-api-2) 部分。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/ingest-data/for-observability/loki.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/ingest-data/for-observability/loki.md
@@ -17,7 +17,10 @@ description: 介绍如何使用 Loki 将日志数据发送到 GreptimeDB，包�
   * `Authorization`: `Basic` 认证，这是一个 Base64 编码的 `<username>:<password>` 字符串。更多信息，请参考 [认证](https://docs.greptime.com/user-guide/deployments-administration/authentication/static/) 和 [HTTP API](https://docs.greptime.com/user-guide/protocols/http#authentication)。
   * `X-Greptime-Log-Table-Name`: `<table_name>`（可选）- 存储日志的表名。如果未提供，默认表名为 `loki_logs`。
 
-请求使用二进制 protobuf 编码负载。定义的格式与 [logproto.proto](https://github.com/grafana/loki/blob/main/pkg/logproto/logproto.proto) 相同。
+GreptimeDB 支持 Loki Push API 的以下两种负载编码：
+
+* **Protobuf**：发送符合 [logproto.proto](https://github.com/grafana/loki/blob/main/pkg/logproto/logproto.proto) 定义、经过 Snappy 压缩的 `PushRequest`，并设置 `Content-Type: application/x-protobuf`。
+* **JSON**：发送 Loki JSON Push 请求体，并设置 `Content-Type: application/json`。
 
 ### 示例代码
 
@@ -35,10 +38,12 @@ loki.source.file "greptime" {
 
 loki.write "greptime_loki" {
     endpoint {
-        url = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/loki/api/v1/push"
+        url = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+          coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+          coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/loki/api/v1/push"
         headers  = {
-          "x-greptime-db-name" = "${GREPTIME_DB:=public}",
-          "x-greptime-log-table-name" = "${GREPTIME_LOG_TABLE_NAME:=loki_demo_logs}",
+          "x-greptime-db-name" = coalesce(sys.env("GREPTIME_DB"), "public"),
+          "x-greptime-log-table-name" = coalesce(sys.env("GREPTIME_LOG_TABLE_NAME"), "loki_demo_logs"),
         }
     }
     external_labels = {
@@ -56,11 +61,11 @@ loki.write "greptime_loki" {
 
 ```sql
 SELECT * FROM loki_demo_logs;
-+----------------------------+------------------------+--------------+-------+----------+
-| greptime_timestamp         | line                   | filename     | from  | job      |
-+----------------------------+------------------------+--------------+-------+----------+
-| 2024-11-25 11:02:31.256251 | Greptime is very cool! | /tmp/foo.txt | alloy | greptime |
-+----------------------------+------------------------+--------------+-------+----------+
++----------------------------+------------------------+---------------------+--------------+-------+----------+
+| greptime_timestamp         | line                   | structured_metadata | filename     | from  | job      |
++----------------------------+------------------------+---------------------+--------------+-------+----------+
+| 2024-11-25 11:02:31.256251 | Greptime is very cool! | {}                  | /tmp/foo.txt | alloy | greptime |
++----------------------------+------------------------+---------------------+--------------+-------+----------+
 1 row in set (0.01 sec)
 ```
 
@@ -118,6 +123,7 @@ SHOW CREATE TABLE loki_demo_logs\G
 Create Table: CREATE TABLE IF NOT EXISTS `loki_demo_logs` (
   `greptime_timestamp` TIMESTAMP(9) NOT NULL,
   `line` STRING NULL,
+  `structured_metadata` JSON NULL,
   `filename` STRING NULL,
   `from` STRING NULL,
   `job` STRING NULL,
@@ -127,7 +133,10 @@ Create Table: CREATE TABLE IF NOT EXISTS `loki_demo_logs` (
 
 ENGINE=mito
 WITH(
-  append_mode = 'true'
+  'comment' = 'Created on insertion',
+  append_mode = 'true',
+  'greptime.semantic.signal_type' = 'log',
+  'greptime.semantic.source' = 'loki'
 )
 1 row in set (0.00 sec)
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -120,8 +120,13 @@ exporter = OTLPMetricExporter(
 GreptimeDB 支持以 Prometheus 兼容模式写入 OTLP 指标。
 如果指标以这种兼容模式写入，你可以像查询 Prometheus 原生指标一样使用 PromQL 直接查询这些指标。
 
-如果你之前没有使用过 OTLP 指标写入，那么 GreptimeDB 会默认使用新的兼容模式。
-否则，GreptimeDB 会对已经存在的表保留原有的数据模型，只有对新创建的指标表使用兼容模式写入。
+GreptimeDB 会为每个 OTLP 导出请求统一选择写入格式：
+
+- 如果请求涉及的指标表都不存在，GreptimeDB 使用 Prometheus 兼容格式。
+- 如果请求涉及的已有表都使用同一种格式，GreptimeDB 对请求中的所有指标使用该格式，包括由该请求新建的表。
+- 如果请求同时涉及两种格式的已有表，GreptimeDB 会拒绝该请求。
+
+如需同时写入旧格式和 Prometheus 兼容格式的指标，请将它们拆分到不同的 OTLP 导出请求中。
 
 GreptimeDB 会首先对数据进行预处理，包括：
 1. 将指标名（表名）和标签名转换成 Prometheus 风格的命名（例如：将 `.` 替换为 `_`）。默认情况下，GreptimeDB 还会根据指标单位和类型添加 Prometheus 风格的后缀。具体信息请参考[这里](https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/#metric-metadata-1)
@@ -134,7 +139,7 @@ GreptimeDB 会首先对数据进行预处理，包括：
    | `memory.usage` | Gauge / `By` | `memory_usage_bytes` |
    | `queue.length` | Gauge / `{item}` | `queue_length` |
    | `http.server.request.duration` | Histogram / `s` | `http_server_request_duration_seconds` |
-   | `rpc.server.duration` | Histogram / `ms` | `rpc_server_duration_seconds` |
+   | `rpc.server.duration` | Histogram / `ms` | `rpc_server_duration_milliseconds` |
    | `http.client.request.size` | Sum (Monotonic) / `By` | `http_client_request_size_bytes_total` |
    | `system.network.io` | Sum (Monotonic) / `By` | `system_network_io_bytes_total` |
    | `http.status_code` (属性) | - | `http_status_code` |

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/ingest-data/for-observability/otel-collector.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/ingest-data/for-observability/otel-collector.md
@@ -24,7 +24,7 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 exporters:
-  otlphttp/traces:
+  otlp_http/traces:
     endpoint: 'http://127.0.0.1:4000/v1/otlp'
     # auth:
     #   authenticator: basicauth/client
@@ -33,7 +33,7 @@ exporters:
       x-greptime-pipeline-name: 'greptime_trace_v1'
     tls:
       insecure: true
-  otlphttp/logs:
+  otlp_http/logs:
     endpoint: 'http://127.0.0.1:4000/v1/otlp'
     # auth:
     #   authenticator: basicauth/client
@@ -41,11 +41,11 @@ exporters:
       # x-greptime-db-name: '<your_db_name>'
       # x-greptime-log-table-name: '<table_name>'
       # x-greptime-pipeline-name: '<pipeline_name>'
-      # x-greptime-pipeline-params: '<key=value,...>'
+      # x-greptime-pipeline-params: '<key1=value1&key2=value2>'
     tls:
       insecure: true
 
-  otlphttp/metrics:
+  otlp_http/metrics:
     endpoint: 'http://127.0.0.1:4000/v1/otlp'
     # auth:
     #   authenticator: basicauth/client
@@ -59,16 +59,16 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [otlphttp/traces]
+      exporters: [otlp_http/traces]
     logs:
       receivers: [otlp]
-      exporters: [otlphttp/logs]
+      exporters: [otlp_http/logs]
     metrics:
       receivers: [otlp]
-      exporters: [otlphttp/metrics]
+      exporters: [otlp_http/metrics]
 ```
 
-在上面的配置中，我们定义了一个接收器 `otlp`，它可以接收来自 OpenTelemetry 的数据。我们还定义了三个导出器 `otlphttp/traces`、`otlphttp/logs` 和 `otlphttp/metrics`，它们将数据发送到 GreptimeDB 的 OTLP 路径。
+在上面的配置中，我们定义了一个接收器 `otlp`，它可以接收来自 OpenTelemetry 的数据。我们还定义了三个导出器 `otlp_http/traces`、`otlp_http/logs` 和 `otlp_http/metrics`，它们将数据发送到 GreptimeDB 的 OTLP 路径。
 
 基于 OTLP/HTTP 协议，我们增加了一些 header 用来指定参数，比如 `x-greptime-pipeline-name` 和 `x-greptime-log-table-name`:
 * `x-greptime-pipeline-name` 用来指定要使用的 pipeline 名称

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/ingest-data/for-observability/vector.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/ingest-data/for-observability/vector.md
@@ -143,7 +143,7 @@ inputs = [ "my_source_id" ]
 compression = "gzip"
 dbname = "public"
 endpoint = "http://<host>:4000"
-extra_headers = { "skip_error" = "true" }
+extra_headers = { "x-greptime-pipeline-params" = "max_nested_levels=10" }
 pipeline_name = "greptime_identity"
 table = "<table>"
 username = "<username>"
@@ -151,7 +151,7 @@ password = "<password>"
 
 [sinks.my_sink_id.extra_params]
 source = "vector"
-x-greptime-pipeline-params = "max_nested_levels=10"
+skip_error = "true"
 ```
 
 此示例展示了如何使用 `greptimedb_logs` sink 将生成的 demo 日志数据写入 GreptimeDB。更多信息请参考 [Vector greptimedb_logs sink](https://vector.dev/docs/reference/configuration/sinks/greptimedb_logs/) 文档。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/logs/fulltext-search.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/logs/fulltext-search.md
@@ -11,7 +11,7 @@ GreptimeDB 支持通过 SQL 语句灵活查询数据。本节将介绍特定的�
 
 ## 使用 `matches_term` 函数进行精确匹配
 
-在 SQL 查询中，你可以使用 `matches_term` 函数执行精确的词语/短语匹配，这在日志分析中尤其实用。`matches_term` 函数支持对 `String` 类型列进行精确匹配。你也可以使用 `@@` 操作符作为 `matches_term` 的简写形式。下面是一个典型示例：
+在 SQL 查询中，你可以使用 `matches_term` 函数执行根据字符类型应用边界规则的词语/短语匹配，这在日志分析中尤其实用。`matches_term` 函数支持对 `String` 类型列进行匹配。你也可以使用 `@@` 操作符作为 `matches_term` 的简写形式。下面是一个典型示例：
 
 ```sql
 -- 使用 matches_term 函数
@@ -21,19 +21,20 @@ SELECT * FROM logs WHERE matches_term(message, 'error') OR matches_term(message,
 SELECT * FROM logs WHERE message @@ 'error' OR message @@ 'fail';
 ```
 
-`matches_term` 函数专门用于精确匹配，使用方式如下：
+`matches_term` 函数查找完全相同的字符序列，并根据搜索词中的字符应用边界规则：
 
 - `text`：需要进行匹配的文本列，该列应包含 `String` 类型的文本数据。
 - `term`：要匹配的词语或短语，遵循以下规则：
   - 区分大小写
-  - 匹配项必须由非字母数字字符（包括空格、标点符号等）或文本开头/结尾界定
+  - 对于不包含汉字的搜索词，需要满足词边界规则。如果搜索词的首尾字符是 ASCII 字母或数字，则相邻字符不能是 ASCII 字母或数字；如果首尾字符是其他 Unicode 字母或数字，则相邻字符不能是字母、数字或汉字。
+  - 包含汉字的搜索词按连续子串匹配，不要求词边界。
   - 支持完整词语匹配和短语匹配
 
 ## 查询语句示例
 
 ### 简单词语匹配
 
-`matches_term` 函数执行精确词语匹配，这意味着它只会匹配由非字母数字字符或文本开头/结尾界定的完整词语。这对于在日志中查找特定的错误消息或状态码特别有用。
+对于不包含汉字的搜索词，`matches_term` 执行精确词语匹配。匹配项必须满足上述边界规则，或者位于文本开头或结尾。这对于在日志中查找特定的错误消息或状态码特别有用。
 
 ```sql
 -- 使用 matches_term 函数
@@ -52,6 +53,18 @@ SELECT * FROM logs WHERE message @@ 'error';
 - ❌ "errors" - 不匹配，因为 "error" 是更大词语的一部分
 - ❌ "error123" - 不匹配，因为 "error" 后面跟着数字
 - ❌ "errorLogs" - 不匹配，因为 "error" 是驼峰命名词语的一部分
+
+### 汉字搜索词匹配
+
+包含汉字的搜索词按连续子串匹配，不要求词边界。
+
+```sql
+SELECT * FROM logs WHERE matches_term(message, '手机');
+```
+
+匹配和不匹配的示例：
+- ✅ "登录手机号18888888888的动态key" - 匹配，因为其中包含完全相同的子串 "手机"
+- ❌ "手持设备" - 不匹配，因为其中不包含完全相同的子串 "手机"
 
 ### 多关键词搜索
 
@@ -72,7 +85,7 @@ SELECT * FROM logs WHERE message @@ 'critical' OR message @@ 'error';
 - ✅ "An error occurred!" - 匹配 "error"
 - ✅ "critical failure detected" - 匹配 "critical"
 - ❌ "errors" - 不匹配，因为 "error" 是更大词语的一部分
-- ❌ "critical_errors" - 不匹配，因为词语是更大词语的一部分
+- ✅ "critical_errors" - 匹配 "critical"，因为下划线属于非字母数字边界
 
 ### 排除条件搜索
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/query-data/jaeger.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/query-data/jaeger.md
@@ -17,6 +17,7 @@ GreptimeDB 目前支持以下 [Jaeger](https://www.jaegertracing.io/) 查询接�
 - `/api/operations?service={service}`: 获取指定 Service 的所有 Operations。
 - `/api/services/{service}/operations`: 获取指定 Service 的所有 Operations。
 - `/api/traces`: 根据查询参数获取 traces 数据。
+- `/api/traces/{trace_id}`: 根据 trace ID 获取 trace 数据。
 
 你可以使用 Grafana 的 [Jaeger 插件](https://grafana.com/docs/grafana/latest/datasources/jaeger/)（推荐） 或者 [Jaeger UI](https://github.com/jaegertracing/jaeger-ui) 来查询 GreptimeDB 中的 traces 数据。当你在使用 Jaeger UI 的时候，可将 `packages/jaeger-ui/vite.config.mts` 的 `proxyConfig` 配置为 GreptimeDB 的地址，比如：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/traces/read-write.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/traces/read-write.md
@@ -45,7 +45,7 @@ docker run --rm \
   -p 4317:4317 \
   -p 4318:4318 \
   -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml \
-  otel/opentelemetry-collector-contrib:0.123.0
+  otel/opentelemetry-collector-contrib:0.159.0
 ```
 
 其中 `config.yaml` 文件内容如下：
@@ -60,7 +60,7 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 exporters:
-  otlphttp:
+  otlp_http:
     endpoint: "http://greptimedb:4000/v1/otlp" # GreptimeDB 的 OTLP 路径
     headers:
       x-greptime-pipeline-name: "greptime_trace_v1"
@@ -72,7 +72,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [otlphttp]
+      exporters: [otlp_http]
 ```
 
 #### 将 Trace 数据写入到 OpenTelemetry Collector

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/ingest-data/for-observability/alloy.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/ingest-data/for-observability/alloy.md
@@ -15,11 +15,14 @@ description: 介绍了如何将 GreptimeDB 配置为 Grafana Alloy 的数据接�
 ```hcl
 prometheus.remote_write "greptimedb" {
   endpoint {
-    url = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/prometheus/write?db=${GREPTIME_DB:=public}"
+    url = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") +
+      "/v1/prometheus/write?db=" + coalesce(sys.env("GREPTIME_DB"), "public")
 
     basic_auth {
-      username = "${GREPTIME_USERNAME}"
-      password = "${GREPTIME_PASSWORD}"
+      username = sys.env("GREPTIME_USERNAME")
+      password = sys.env("GREPTIME_PASSWORD")
     }
   }
 }
@@ -40,17 +43,19 @@ GreptimeDB 也可以配置为 OpenTelemetry Collector 的目标。
 ```hcl
 otelcol.exporter.otlphttp "greptimedb" {
   client {
-    endpoint = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/otlp/"
+    endpoint = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/otlp/"
     headers  = {
-      "X-Greptime-DB-Name" = "${GREPTIME_DB:=public}",
+      "X-Greptime-DB-Name" = coalesce(sys.env("GREPTIME_DB"), "public"),
     }
     auth     = otelcol.auth.basic.credentials.handler
   }
 }
 
 otelcol.auth.basic "credentials" {
-  username = "${GREPTIME_USERNAME}"
-  password = "${GREPTIME_PASSWORD}"
+  username = sys.env("GREPTIME_USERNAME")
+  password = sys.env("GREPTIME_PASSWORD")
 }
 ```
 
@@ -90,16 +95,18 @@ otelcol.processor.batch "greptimedb_logs" {
 }
 
 otelcol.auth.basic "credentials" {
-  username = "${GREPTIME_USERNAME}"
-  password = "${GREPTIME_PASSWORD}"
+  username = sys.env("GREPTIME_USERNAME")
+  password = sys.env("GREPTIME_PASSWORD")
 }
 
 otelcol.exporter.otlphttp "greptimedb_logs" {
   client {
-    endpoint = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/otlp/"
+    endpoint = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/otlp/"
     headers = {
-      "X-Greptime-DB-Name"          = "${GREPTIME_DB:=public}",
-      "X-Greptime-Log-Table-Name"   = "${GREPTIME_LOG_TABLE_NAME:=demo_logs}",
+      "X-Greptime-DB-Name"          = coalesce(sys.env("GREPTIME_DB"), "public"),
+      "X-Greptime-Log-Table-Name"   = coalesce(sys.env("GREPTIME_LOG_TABLE_NAME"), "demo_logs"),
       "X-Greptime-Log-Extract-Keys" = "filename,log.file.name,loki.attribute.labels",
     }
     auth = otelcol.auth.basic.credentials.handler
@@ -151,15 +158,17 @@ loki.process "greptime" {
 
 loki.write "greptimedb" {
   endpoint {
-    url = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/loki/api/v1/push"
+    url = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/loki/api/v1/push"
     headers = {
-      "X-Greptime-DB-Name"        = "${GREPTIME_DB:=public}",
-      "X-Greptime-Log-Table-Name" = "${GREPTIME_LOG_TABLE_NAME:=loki_demo_logs}",
+      "X-Greptime-DB-Name"        = coalesce(sys.env("GREPTIME_DB"), "public"),
+      "X-Greptime-Log-Table-Name" = coalesce(sys.env("GREPTIME_LOG_TABLE_NAME"), "loki_demo_logs"),
     }
 
     basic_auth {
-      username = "${GREPTIME_USERNAME}"
-      password = "${GREPTIME_PASSWORD}"
+      username = sys.env("GREPTIME_USERNAME")
+      password = sys.env("GREPTIME_PASSWORD")
     }
   }
 }

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/ingest-data/for-observability/fluent-bit.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/ingest-data/for-observability/fluent-bit.md
@@ -50,42 +50,27 @@ description: 将 GreptimeDB 与 Fluent bit 集成以实现 Prometheus Remote Wri
 
 GreptimeDB 也可以配置为 OpenTelemetry 收集器。使用 Fluent Bit 的 [OpenTelemetry 输出插件](https://docs.fluentbit.io/manual/pipeline/outputs/opentelemetry)，你可以将指标、日志和跟踪发送到 GreptimeDB。
 
-```
-[OUTPUT]
-    Name                 opentelemetry
-    Match                *
-    Host                 127.0.0.1
-    Port                 4000
-    Metrics_uri          /v1/otlp/v1/metrics
-    Logs_uri             /v1/otlp/v1/logs
-    Traces_uri           /v1/otlp/v1/traces
-    Log_response_payload True
-    Tls                  Off
-    Tls.verify           Off
-```
-
-- `Metrics_uri`, `Logs_uri`, 和 `Traces_uri`: 发送指标、日志和跟踪的端点。
-
-我们建议不要在一个 output 同时写入 metrics log 和 trace，因为我们的写入接口它们各自有一些特殊的 header 选项用于指定一些参数，我们建议一个为 metrics log 和 trace 单独创建一个 opentelemetry output 例如：
+由于 GreptimeDB 会为不同 signal 使用不同的 header，请为每种 signal 配置独立的 output。在 Fluent Bit input 中为每种 signal 设置不同的 tag，然后在对应的 output 中匹配该 tag：
 
 ```
-# Only for metrics
+# 仅用于 metrics
 [OUTPUT]
     Name                 opentelemetry
     Alias                opentelemetry_metrics
-    Match                *
+    Match                <metrics_tag>
     Host                 127.0.0.1
     Port                 4000
     Metrics_uri          /v1/otlp/v1/metrics
     Log_response_payload True
     Tls                  Off
     Tls.verify           Off
+    Header X-Greptime-DB-Name "<dbname>"
 
-# Only for logs
+# 仅用于 logs
 [OUTPUT]
     Name                 opentelemetry
     Alias                opentelemetry_logs
-    Match                *
+    Match                <logs_tag>
     Host                 127.0.0.1
     Port                 4000
     Logs_uri             /v1/otlp/v1/logs
@@ -93,9 +78,27 @@ GreptimeDB 也可以配置为 OpenTelemetry 收集器。使用 Fluent Bit 的 [O
     Tls                  Off
     Tls.verify           Off
     Header X-Greptime-Log-Table-Name "<log_table_name>"
-    Header X-Greptime-Log-Pipeline-Name "<pipeline_name>"
+    Header X-Greptime-Pipeline-Name "<pipeline_name>"
+    Header X-Greptime-DB-Name "<dbname>"
+
+# 仅用于 traces
+[OUTPUT]
+    Name                 opentelemetry
+    Alias                opentelemetry_traces
+    Match                <traces_tag>
+    Host                 127.0.0.1
+    Port                 4000
+    Traces_uri           /v1/otlp/v1/traces
+    Log_response_payload True
+    Tls                  Off
+    Tls.verify           Off
+    Header X-Greptime-Pipeline-Name "greptime_trace_v1"
     Header X-Greptime-DB-Name "<dbname>"
 ```
+
+- `Metrics_uri`、`Logs_uri` 和 `Traces_uri`：分别用于发送 metrics、logs 和 traces 的端点。
+- `Match`：在对应 Fluent Bit input 中配置的 signal tag。
+- `http_user` 和 `http_passwd`：GreptimeDB 的[认证凭据](/user-guide/deployments-administration/authentication/static.md)。启用鉴权时，请将它们添加到每个 output 中。
 
 本示例使用的是 OpenTelemetry OTLP/HTTP API。不同 signal 支持的 header 和选项不同，具体请分别参考 OpenTelemetry API 的 [metrics](/user-guide/ingest-data/for-observability/opentelemetry.md#otlphttp-api)、[logs](/user-guide/ingest-data/for-observability/opentelemetry.md#otlphttp-api-1) 和 [traces](/user-guide/ingest-data/for-observability/opentelemetry.md#otlphttp-api-2) 部分。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/ingest-data/for-observability/loki.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/ingest-data/for-observability/loki.md
@@ -17,7 +17,10 @@ description: 介绍如何使用 Loki 将日志数据发送到 GreptimeDB，包�
   * `Authorization`: `Basic` 认证，这是一个 Base64 编码的 `<username>:<password>` 字符串。更多信息，请参考 [认证](https://docs.greptime.com/user-guide/deployments-administration/authentication/static/) 和 [HTTP API](https://docs.greptime.com/user-guide/protocols/http#authentication)。
   * `X-Greptime-Log-Table-Name`: `<table_name>`（可选）- 存储日志的表名。如果未提供，默认表名为 `loki_logs`。
 
-请求使用二进制 protobuf 编码负载。定义的格式与 [logproto.proto](https://github.com/grafana/loki/blob/main/pkg/logproto/logproto.proto) 相同。
+GreptimeDB 支持 Loki Push API 的以下两种负载编码：
+
+* **Protobuf**：发送符合 [logproto.proto](https://github.com/grafana/loki/blob/main/pkg/logproto/logproto.proto) 定义、经过 Snappy 压缩的 `PushRequest`，并设置 `Content-Type: application/x-protobuf`。
+* **JSON**：发送 Loki JSON Push 请求体，并设置 `Content-Type: application/json`。
 
 ### 示例代码
 
@@ -35,10 +38,12 @@ loki.source.file "greptime" {
 
 loki.write "greptime_loki" {
     endpoint {
-        url = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/loki/api/v1/push"
+        url = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+          coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+          coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/loki/api/v1/push"
         headers  = {
-          "x-greptime-db-name" = "${GREPTIME_DB:=public}",
-          "x-greptime-log-table-name" = "${GREPTIME_LOG_TABLE_NAME:=loki_demo_logs}",
+          "x-greptime-db-name" = coalesce(sys.env("GREPTIME_DB"), "public"),
+          "x-greptime-log-table-name" = coalesce(sys.env("GREPTIME_LOG_TABLE_NAME"), "loki_demo_logs"),
         }
     }
     external_labels = {
@@ -56,11 +61,11 @@ loki.write "greptime_loki" {
 
 ```sql
 SELECT * FROM loki_demo_logs;
-+----------------------------+------------------------+--------------+-------+----------+
-| greptime_timestamp         | line                   | filename     | from  | job      |
-+----------------------------+------------------------+--------------+-------+----------+
-| 2024-11-25 11:02:31.256251 | Greptime is very cool! | /tmp/foo.txt | alloy | greptime |
-+----------------------------+------------------------+--------------+-------+----------+
++----------------------------+------------------------+---------------------+--------------+-------+----------+
+| greptime_timestamp         | line                   | structured_metadata | filename     | from  | job      |
++----------------------------+------------------------+---------------------+--------------+-------+----------+
+| 2024-11-25 11:02:31.256251 | Greptime is very cool! | {}                  | /tmp/foo.txt | alloy | greptime |
++----------------------------+------------------------+---------------------+--------------+-------+----------+
 1 row in set (0.01 sec)
 ```
 
@@ -118,6 +123,7 @@ SHOW CREATE TABLE loki_demo_logs\G
 Create Table: CREATE TABLE IF NOT EXISTS `loki_demo_logs` (
   `greptime_timestamp` TIMESTAMP(9) NOT NULL,
   `line` STRING NULL,
+  `structured_metadata` JSON NULL,
   `filename` STRING NULL,
   `from` STRING NULL,
   `job` STRING NULL,
@@ -127,7 +133,10 @@ Create Table: CREATE TABLE IF NOT EXISTS `loki_demo_logs` (
 
 ENGINE=mito
 WITH(
-  append_mode = 'true'
+  'comment' = 'Created on insertion',
+  append_mode = 'true',
+  'greptime.semantic.signal_type' = 'log',
+  'greptime.semantic.source' = 'loki'
 )
 1 row in set (0.00 sec)
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -120,8 +120,13 @@ exporter = OTLPMetricExporter(
 GreptimeDB 支持以 Prometheus 兼容模式写入 OTLP 指标。
 如果指标以这种兼容模式写入，你可以像查询 Prometheus 原生指标一样使用 PromQL 直接查询这些指标。
 
-如果你之前没有使用过 OTLP 指标写入，那么 GreptimeDB 会默认使用新的兼容模式。
-否则，GreptimeDB 会对已经存在的表保留原有的数据模型，只有对新创建的指标表使用兼容模式写入。
+GreptimeDB 会为每个 OTLP 导出请求统一选择写入格式：
+
+- 如果请求涉及的指标表都不存在，GreptimeDB 使用 Prometheus 兼容格式。
+- 如果请求涉及的已有表都使用同一种格式，GreptimeDB 对请求中的所有指标使用该格式，包括由该请求新建的表。
+- 如果请求同时涉及两种格式的已有表，GreptimeDB 会拒绝该请求。
+
+如需同时写入旧格式和 Prometheus 兼容格式的指标，请将它们拆分到不同的 OTLP 导出请求中。
 
 GreptimeDB 会首先对数据进行预处理，包括：
 1. 将指标名（表名）和标签名转换成 Prometheus 风格的命名（例如：将 `.` 替换为 `_`）。默认情况下，GreptimeDB 还会根据指标单位和类型添加 Prometheus 风格的后缀。具体信息请参考[这里](https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/#metric-metadata-1)
@@ -134,7 +139,7 @@ GreptimeDB 会首先对数据进行预处理，包括：
    | `memory.usage` | Gauge / `By` | `memory_usage_bytes` |
    | `queue.length` | Gauge / `{item}` | `queue_length` |
    | `http.server.request.duration` | Histogram / `s` | `http_server_request_duration_seconds` |
-   | `rpc.server.duration` | Histogram / `ms` | `rpc_server_duration_seconds` |
+   | `rpc.server.duration` | Histogram / `ms` | `rpc_server_duration_milliseconds` |
    | `http.client.request.size` | Sum (Monotonic) / `By` | `http_client_request_size_bytes_total` |
    | `system.network.io` | Sum (Monotonic) / `By` | `system_network_io_bytes_total` |
    | `http.status_code` (属性) | - | `http_status_code` |

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/ingest-data/for-observability/otel-collector.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/ingest-data/for-observability/otel-collector.md
@@ -24,7 +24,7 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 exporters:
-  otlphttp/traces:
+  otlp_http/traces:
     endpoint: 'http://127.0.0.1:4000/v1/otlp'
     # auth:
     #   authenticator: basicauth/client
@@ -33,7 +33,7 @@ exporters:
       x-greptime-pipeline-name: 'greptime_trace_v1'
     tls:
       insecure: true
-  otlphttp/logs:
+  otlp_http/logs:
     endpoint: 'http://127.0.0.1:4000/v1/otlp'
     # auth:
     #   authenticator: basicauth/client
@@ -41,11 +41,11 @@ exporters:
       # x-greptime-db-name: '<your_db_name>'
       # x-greptime-log-table-name: '<table_name>'
       # x-greptime-pipeline-name: '<pipeline_name>'
-      # x-greptime-pipeline-params: '<key=value,...>'
+      # x-greptime-pipeline-params: '<key1=value1&key2=value2>'
     tls:
       insecure: true
 
-  otlphttp/metrics:
+  otlp_http/metrics:
     endpoint: 'http://127.0.0.1:4000/v1/otlp'
     # auth:
     #   authenticator: basicauth/client
@@ -59,16 +59,16 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [otlphttp/traces]
+      exporters: [otlp_http/traces]
     logs:
       receivers: [otlp]
-      exporters: [otlphttp/logs]
+      exporters: [otlp_http/logs]
     metrics:
       receivers: [otlp]
-      exporters: [otlphttp/metrics]
+      exporters: [otlp_http/metrics]
 ```
 
-在上面的配置中，我们定义了一个接收器 `otlp`，它可以接收来自 OpenTelemetry 的数据。我们还定义了三个导出器 `otlphttp/traces`、`otlphttp/logs` 和 `otlphttp/metrics`，它们将数据发送到 GreptimeDB 的 OTLP 路径。
+在上面的配置中，我们定义了一个接收器 `otlp`，它可以接收来自 OpenTelemetry 的数据。我们还定义了三个导出器 `otlp_http/traces`、`otlp_http/logs` 和 `otlp_http/metrics`，它们将数据发送到 GreptimeDB 的 OTLP 路径。
 
 基于 OTLP/HTTP 协议，我们增加了一些 header 用来指定参数，比如 `x-greptime-pipeline-name` 和 `x-greptime-log-table-name`:
 * `x-greptime-pipeline-name` 用来指定要使用的 pipeline 名称

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/ingest-data/for-observability/vector.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/ingest-data/for-observability/vector.md
@@ -143,7 +143,7 @@ inputs = [ "my_source_id" ]
 compression = "gzip"
 dbname = "public"
 endpoint = "http://<host>:4000"
-extra_headers = { "skip_error" = "true" }
+extra_headers = { "x-greptime-pipeline-params" = "max_nested_levels=10" }
 pipeline_name = "greptime_identity"
 table = "<table>"
 username = "<username>"
@@ -151,7 +151,7 @@ password = "<password>"
 
 [sinks.my_sink_id.extra_params]
 source = "vector"
-x-greptime-pipeline-params = "max_nested_levels=10"
+skip_error = "true"
 ```
 
 此示例展示了如何使用 `greptimedb_logs` sink 将生成的 demo 日志数据写入 GreptimeDB。更多信息请参考 [Vector greptimedb_logs sink](https://vector.dev/docs/reference/configuration/sinks/greptimedb_logs/) 文档。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/logs/fulltext-search.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/logs/fulltext-search.md
@@ -11,7 +11,7 @@ GreptimeDB 支持通过 SQL 语句灵活查询数据。本节将介绍特定的�
 
 ## 使用 `matches_term` 函数进行精确匹配
 
-在 SQL 查询中，你可以使用 `matches_term` 函数执行精确的词语/短语匹配，这在日志分析中尤其实用。`matches_term` 函数支持对 `String` 类型列进行精确匹配。你也可以使用 `@@` 操作符作为 `matches_term` 的简写形式。下面是一个典型示例：
+在 SQL 查询中，你可以使用 `matches_term` 函数执行根据字符类型应用边界规则的词语/短语匹配，这在日志分析中尤其实用。`matches_term` 函数支持对 `String` 类型列进行匹配。你也可以使用 `@@` 操作符作为 `matches_term` 的简写形式。下面是一个典型示例：
 
 ```sql
 -- 使用 matches_term 函数
@@ -21,19 +21,20 @@ SELECT * FROM logs WHERE matches_term(message, 'error') OR matches_term(message,
 SELECT * FROM logs WHERE message @@ 'error' OR message @@ 'fail';
 ```
 
-`matches_term` 函数专门用于精确匹配，使用方式如下：
+`matches_term` 函数查找完全相同的字符序列，并根据搜索词中的字符应用边界规则：
 
 - `text`：需要进行匹配的文本列，该列应包含 `String` 类型的文本数据。
 - `term`：要匹配的词语或短语，遵循以下规则：
   - 区分大小写
-  - 匹配项必须由非字母数字字符（包括空格、标点符号等）或文本开头/结尾界定
+  - 对于不包含汉字的搜索词，需要满足词边界规则。如果搜索词的首尾字符是 ASCII 字母或数字，则相邻字符不能是 ASCII 字母或数字；如果首尾字符是其他 Unicode 字母或数字，则相邻字符不能是字母、数字或汉字。
+  - 包含汉字的搜索词按连续子串匹配，不要求词边界。
   - 支持完整词语匹配和短语匹配
 
 ## 查询语句示例
 
 ### 简单词语匹配
 
-`matches_term` 函数执行精确词语匹配，这意味着它只会匹配由非字母数字字符或文本开头/结尾界定的完整词语。这对于在日志中查找特定的错误消息或状态码特别有用。
+对于不包含汉字的搜索词，`matches_term` 执行精确词语匹配。匹配项必须满足上述边界规则，或者位于文本开头或结尾。这对于在日志中查找特定的错误消息或状态码特别有用。
 
 ```sql
 -- 使用 matches_term 函数
@@ -52,6 +53,18 @@ SELECT * FROM logs WHERE message @@ 'error';
 - ❌ "errors" - 不匹配，因为 "error" 是更大词语的一部分
 - ❌ "error123" - 不匹配，因为 "error" 后面跟着数字
 - ❌ "errorLogs" - 不匹配，因为 "error" 是驼峰命名词语的一部分
+
+### 汉字搜索词匹配
+
+包含汉字的搜索词按连续子串匹配，不要求词边界。
+
+```sql
+SELECT * FROM logs WHERE matches_term(message, '手机');
+```
+
+匹配和不匹配的示例：
+- ✅ "登录手机号18888888888的动态key" - 匹配，因为其中包含完全相同的子串 "手机"
+- ❌ "手持设备" - 不匹配，因为其中不包含完全相同的子串 "手机"
 
 ### 多关键词搜索
 
@@ -72,7 +85,7 @@ SELECT * FROM logs WHERE message @@ 'critical' OR message @@ 'error';
 - ✅ "An error occurred!" - 匹配 "error"
 - ✅ "critical failure detected" - 匹配 "critical"
 - ❌ "errors" - 不匹配，因为 "error" 是更大词语的一部分
-- ❌ "critical_errors" - 不匹配，因为词语是更大词语的一部分
+- ✅ "critical_errors" - 匹配 "critical"，因为下划线属于非字母数字边界
 
 ### 排除条件搜索
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/query-data/jaeger.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/query-data/jaeger.md
@@ -17,6 +17,7 @@ GreptimeDB 目前支持以下 [Jaeger](https://www.jaegertracing.io/) 查询接�
 - `/api/operations?service={service}`: 获取指定 Service 的所有 Operations。
 - `/api/services/{service}/operations`: 获取指定 Service 的所有 Operations。
 - `/api/traces`: 根据查询参数获取 traces 数据。
+- `/api/traces/{trace_id}`: 根据 trace ID 获取 trace 数据。
 
 你可以使用 Grafana 的 [Jaeger 插件](https://grafana.com/docs/grafana/latest/datasources/jaeger/)（推荐） 或者 [Jaeger UI](https://github.com/jaegertracing/jaeger-ui) 来查询 GreptimeDB 中的 traces 数据。当你在使用 Jaeger UI 的时候，可将 `packages/jaeger-ui/vite.config.mts` 的 `proxyConfig` 配置为 GreptimeDB 的地址，比如：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/traces/read-write.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/traces/read-write.md
@@ -45,7 +45,7 @@ docker run --rm \
   -p 4317:4317 \
   -p 4318:4318 \
   -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml \
-  otel/opentelemetry-collector-contrib:0.123.0
+  otel/opentelemetry-collector-contrib:0.159.0
 ```
 
 其中 `config.yaml` 文件内容如下：
@@ -60,7 +60,7 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 exporters:
-  otlphttp:
+  otlp_http:
     endpoint: "http://greptimedb:4000/v1/otlp" # GreptimeDB 的 OTLP 路径
     headers:
       x-greptime-pipeline-name: "greptime_trace_v1"
@@ -72,7 +72,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [otlphttp]
+      exporters: [otlp_http]
 ```
 
 #### 将 Trace 数据写入到 OpenTelemetry Collector

--- a/versioned_docs/version-1.1/user-guide/ingest-data/for-observability/alloy.md
+++ b/versioned_docs/version-1.1/user-guide/ingest-data/for-observability/alloy.md
@@ -15,11 +15,14 @@ Configure GreptimeDB as remote write target:
 ```hcl
 prometheus.remote_write "greptimedb" {
     endpoint {
-        url = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/prometheus/write?db=${GREPTIME_DB:=public}"
+        url = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+          coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+          coalesce(sys.env("GREPTIME_PORT"), "4000") +
+          "/v1/prometheus/write?db=" + coalesce(sys.env("GREPTIME_DB"), "public")
 
         basic_auth {
-            username = "${GREPTIME_USERNAME}"
-            password = "${GREPTIME_PASSWORD}"
+            username = sys.env("GREPTIME_USERNAME")
+            password = sys.env("GREPTIME_PASSWORD")
         }
     }
 }
@@ -40,17 +43,19 @@ GreptimeDB can also be configured as OpenTelemetry collector.
 ```hcl
 otelcol.exporter.otlphttp "greptimedb" {
   client {
-    endpoint = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/otlp/"
+    endpoint = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/otlp/"
     headers  = {
-      "X-Greptime-DB-Name" = "${GREPTIME_DB:=public}",
+      "X-Greptime-DB-Name" = coalesce(sys.env("GREPTIME_DB"), "public"),
     }
     auth     = otelcol.auth.basic.credentials.handler
   }
 }
 
 otelcol.auth.basic "credentials" {
-  username = "${GREPTIME_USERNAME}"
-  password = "${GREPTIME_PASSWORD}"
+  username = sys.env("GREPTIME_USERNAME")
+  password = sys.env("GREPTIME_PASSWORD")
 }
 ```
 
@@ -90,16 +95,18 @@ otelcol.processor.batch "greptimedb_logs" {
 }
 
 otelcol.auth.basic "credentials" {
-  username = "${GREPTIME_USERNAME}"
-  password = "${GREPTIME_PASSWORD}"
+  username = sys.env("GREPTIME_USERNAME")
+  password = sys.env("GREPTIME_PASSWORD")
 }
 
 otelcol.exporter.otlphttp "greptimedb_logs" {
   client {
-    endpoint = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/otlp/"
+    endpoint = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/otlp/"
     headers = {
-      "X-Greptime-DB-Name"          = "${GREPTIME_DB:=public}",
-      "X-Greptime-Log-Table-Name"   = "${GREPTIME_LOG_TABLE_NAME:=demo_logs}",
+      "X-Greptime-DB-Name"          = coalesce(sys.env("GREPTIME_DB"), "public"),
+      "X-Greptime-Log-Table-Name"   = coalesce(sys.env("GREPTIME_LOG_TABLE_NAME"), "demo_logs"),
       "X-Greptime-Log-Extract-Keys" = "filename,log.file.name,loki.attribute.labels",
     }
     auth = otelcol.auth.basic.credentials.handler
@@ -151,15 +158,17 @@ loki.process "greptime" {
 
 loki.write "greptimedb" {
   endpoint {
-    url = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/loki/api/v1/push"
+    url = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/loki/api/v1/push"
     headers = {
-      "X-Greptime-DB-Name"        = "${GREPTIME_DB:=public}",
-      "X-Greptime-Log-Table-Name" = "${GREPTIME_LOG_TABLE_NAME:=loki_demo_logs}",
+      "X-Greptime-DB-Name"        = coalesce(sys.env("GREPTIME_DB"), "public"),
+      "X-Greptime-Log-Table-Name" = coalesce(sys.env("GREPTIME_LOG_TABLE_NAME"), "loki_demo_logs"),
     }
 
     basic_auth {
-      username = "${GREPTIME_USERNAME}"
-      password = "${GREPTIME_PASSWORD}"
+      username = sys.env("GREPTIME_USERNAME")
+      password = sys.env("GREPTIME_PASSWORD")
     }
   }
 }

--- a/versioned_docs/version-1.1/user-guide/ingest-data/for-observability/fluent-bit.md
+++ b/versioned_docs/version-1.1/user-guide/ingest-data/for-observability/fluent-bit.md
@@ -51,46 +51,27 @@ The `greptime_identity` pipeline creates the table directly from the JSON fields
 
 GreptimeDB can also be configured as OpenTelemetry collector. Using Fluent Bit's [OpenTelemetry Output Plugin](https://docs.fluentbit.io/manual/pipeline/outputs/opentelemetry), you can send metrics, logs, and traces to GreptimeDB.
 
-```
-[OUTPUT]
-    Name                 opentelemetry
-    Match                *
-    Host                 127.0.0.1
-    Port                 4000
-    Metrics_uri          /v1/otlp/v1/metrics
-    Logs_uri             /v1/otlp/v1/logs
-    Traces_uri           /v1/otlp/v1/traces
-    Log_response_payload True
-    Tls                  Off
-    Tls.verify           Off
-    logs_body_key message
-    http_User <username>
-    http_Passwd <password>
-```
-
-- `Metrics_uri`, `Logs_uri`, and `Traces_uri`: The endpoint to send metrics, logs, and traces to.
-- `http_user` and `http_passwd`: The [authentication credentials](/user-guide/deployments-administration/authentication/static.md) for GreptimeDB.
-
-We recommend not writing metrics, logs, and traces to a single output simultaneously, as each has specific header options for specifying parameters. We suggest creating a separate OpenTelemetry output for metrics, logs, and traces. for example:
+Use a separate output for each signal because GreptimeDB uses signal-specific headers. Assign a distinct tag to each signal in the Fluent Bit inputs, then match that tag in the corresponding output:
 
 ```
 # Only for metrics
 [OUTPUT]
     Name                 opentelemetry
     Alias                opentelemetry_metrics
-    Match                *
+    Match                <metrics_tag>
     Host                 127.0.0.1
     Port                 4000
     Metrics_uri          /v1/otlp/v1/metrics
     Log_response_payload True
     Tls                  Off
     Tls.verify           Off
+    Header X-Greptime-DB-Name "<dbname>"
 
 # Only for logs
 [OUTPUT]
     Name                 opentelemetry
     Alias                opentelemetry_logs
-    Match                *
+    Match                <logs_tag>
     Host                 127.0.0.1
     Port                 4000
     Logs_uri             /v1/otlp/v1/logs
@@ -98,10 +79,27 @@ We recommend not writing metrics, logs, and traces to a single output simultaneo
     Tls                  Off
     Tls.verify           Off
     Header X-Greptime-Log-Table-Name "<log_table_name>"
-    Header X-Greptime-Log-Pipeline-Name "<pipeline_name>"
+    Header X-Greptime-Pipeline-Name "<pipeline_name>"
+    Header X-Greptime-DB-Name "<dbname>"
+
+# Only for traces
+[OUTPUT]
+    Name                 opentelemetry
+    Alias                opentelemetry_traces
+    Match                <traces_tag>
+    Host                 127.0.0.1
+    Port                 4000
+    Traces_uri           /v1/otlp/v1/traces
+    Log_response_payload True
+    Tls                  Off
+    Tls.verify           Off
+    Header X-Greptime-Pipeline-Name "greptime_trace_v1"
     Header X-Greptime-DB-Name "<dbname>"
 ```
 
+- `Metrics_uri`, `Logs_uri`, and `Traces_uri`: The endpoints for metrics, logs, and traces.
+- `Match`: The signal-specific tag configured on the corresponding Fluent Bit input.
+- `http_user` and `http_passwd`: The [authentication credentials](/user-guide/deployments-administration/authentication/static.md) for GreptimeDB. Add them to each output when authentication is enabled.
 
 In this example, the OpenTelemetry OTLP/HTTP API is used. For signal-specific headers and options, see the OpenTelemetry API sections for [metrics](/user-guide/ingest-data/for-observability/opentelemetry.md#otlphttp-api), [logs](/user-guide/ingest-data/for-observability/opentelemetry.md#otlphttp-api-1), and [traces](/user-guide/ingest-data/for-observability/opentelemetry.md#otlphttp-api-2).
 

--- a/versioned_docs/version-1.1/user-guide/ingest-data/for-observability/loki.md
+++ b/versioned_docs/version-1.1/user-guide/ingest-data/for-observability/loki.md
@@ -17,7 +17,10 @@ To send logs to GreptimeDB through the raw HTTP API, use the following informati
   * `Authorization`: `Basic` authentication, which is a Base64 encoded string of `<username>:<password>`. For more information, please refer to [Authentication](https://docs.greptime.com/user-guide/deployments-administration/authentication/static/) and [HTTP API](https://docs.greptime.com/user-guide/protocols/http#authentication).
   * `X-Greptime-Log-Table-Name`: `<table_name>` (optional) - The table name to store the logs. If not provided, the default table name is `loki_logs`.
 
-The request uses binary protobuf to encode the payload. The defined schema is the same as the [logproto.proto](https://github.com/grafana/loki/blob/main/pkg/logproto/logproto.proto).
+GreptimeDB accepts either of the Loki Push API payload encodings:
+
+* **Protobuf**: Send a Snappy-compressed `PushRequest` matching [logproto.proto](https://github.com/grafana/loki/blob/main/pkg/logproto/logproto.proto) with `Content-Type: application/x-protobuf`.
+* **JSON**: Send a Loki JSON push body with `Content-Type: application/json`.
 
 ### Example Code
 
@@ -35,10 +38,12 @@ loki.source.file "greptime" {
 
 loki.write "greptime_loki" {
     endpoint {
-        url = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/loki/api/v1/push"
+        url = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+          coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+          coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/loki/api/v1/push"
         headers  = {
-          "x-greptime-db-name" = "${GREPTIME_DB:=public}",
-          "x-greptime-log-table-name" = "${GREPTIME_LOG_TABLE_NAME:=loki_demo_logs}",
+          "x-greptime-db-name" = coalesce(sys.env("GREPTIME_DB"), "public"),
+          "x-greptime-log-table-name" = coalesce(sys.env("GREPTIME_LOG_TABLE_NAME"), "loki_demo_logs"),
         }
     }
     external_labels = {
@@ -56,11 +61,11 @@ You can run the following command to check the data in the table:
 
 ```sql
 SELECT * FROM loki_demo_logs;
-+----------------------------+------------------------+--------------+-------+----------+
-| greptime_timestamp         | line                   | filename     | from  | job      |
-+----------------------------+------------------------+--------------+-------+----------+
-| 2024-11-25 11:02:31.256251 | Greptime is very cool! | /tmp/foo.txt | alloy | greptime |
-+----------------------------+------------------------+--------------+-------+----------+
++----------------------------+------------------------+---------------------+--------------+-------+----------+
+| greptime_timestamp         | line                   | structured_metadata | filename     | from  | job      |
++----------------------------+------------------------+---------------------+--------------+-------+----------+
+| 2024-11-25 11:02:31.256251 | Greptime is very cool! | {}                  | /tmp/foo.txt | alloy | greptime |
++----------------------------+------------------------+---------------------+--------------+-------+----------+
 1 row in set (0.01 sec)
 ```
 
@@ -118,6 +123,7 @@ SHOW CREATE TABLE loki_demo_logs\G
 Create Table: CREATE TABLE IF NOT EXISTS `loki_demo_logs` (
   `greptime_timestamp` TIMESTAMP(9) NOT NULL,
   `line` STRING NULL,
+  `structured_metadata` JSON NULL,
   `filename` STRING NULL,
   `from` STRING NULL,
   `job` STRING NULL,
@@ -127,7 +133,10 @@ Create Table: CREATE TABLE IF NOT EXISTS `loki_demo_logs` (
 
 ENGINE=mito
 WITH(
-  append_mode = 'true'
+  'comment' = 'Created on insertion',
+  append_mode = 'true',
+  'greptime.semantic.signal_type' = 'log',
+  'greptime.semantic.source' = 'loki'
 )
 1 row in set (0.00 sec)
 ```

--- a/versioned_docs/version-1.1/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/versioned_docs/version-1.1/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -118,8 +118,13 @@ For more information on the example code, please refer to the official documenta
 GreptimeDB supports a Prometheus-compatible mode for OTLP metrics ingestion.
 If the metrics data is persisted using the Prometheus-compatible format, you should be able to query them using PromQL, just like any Prometheus metrics.
 
-If you have not ingested any OTLP metrics before, it will automatically use the Prometheus-compatible format.
-Otherwise, it will remain the old data format with the existing table, but use the new data format for any newly created tables.
+GreptimeDB selects the ingestion format once for each OTLP export request:
+
+- If none of the referenced metric tables exists, GreptimeDB uses the Prometheus-compatible format.
+- If all referenced existing tables use the same format, GreptimeDB uses that format for every metric in the request, including any tables created by the request.
+- If the request references existing tables in both formats, GreptimeDB rejects the request.
+
+Send legacy and Prometheus-compatible metrics in separate OTLP export requests.
 
 GreptimeDB pre-processes the incoming data before persisting them, including:
 1. Converting the metric names(table names) and the label names to the Prometheus style(e.g: replace `.` with `_`). By default, GreptimeDB also adds Prometheus-style suffixes based on the metric unit and type. See [here](https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/#metric-metadata-1) for details.
@@ -132,7 +137,7 @@ GreptimeDB pre-processes the incoming data before persisting them, including:
    | `memory.usage` | Gauge / `By` | `memory_usage_bytes` |
    | `queue.length` | Gauge / `{item}` | `queue_length` |
    | `http.server.request.duration` | Histogram / `s` | `http_server_request_duration_seconds` |
-   | `rpc.server.duration` | Histogram / `ms` | `rpc_server_duration_seconds` |
+   | `rpc.server.duration` | Histogram / `ms` | `rpc_server_duration_milliseconds` |
    | `http.client.request.size` | Sum (Monotonic) / `By` | `http_client_request_size_bytes_total` |
    | `system.network.io` | Sum (Monotonic) / `By` | `system_network_io_bytes_total` |
    | `http.status_code` (Attribute) | - | `http_status_code` |

--- a/versioned_docs/version-1.1/user-guide/ingest-data/for-observability/otel-collector.md
+++ b/versioned_docs/version-1.1/user-guide/ingest-data/for-observability/otel-collector.md
@@ -24,7 +24,7 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 exporters:
-  otlphttp/traces:
+  otlp_http/traces:
     endpoint: 'http://127.0.0.1:4000/v1/otlp'
     # auth:
     #   authenticator: basicauth/client
@@ -33,7 +33,7 @@ exporters:
       x-greptime-pipeline-name: 'greptime_trace_v1'
     tls:
       insecure: true
-  otlphttp/logs:
+  otlp_http/logs:
     endpoint: 'http://127.0.0.1:4000/v1/otlp'
     # auth:
     #   authenticator: basicauth/client
@@ -41,11 +41,11 @@ exporters:
       # x-greptime-db-name: '<your_db_name>'
       # x-greptime-log-table-name: '<table_name>'
       # x-greptime-pipeline-name: '<pipeline_name>'
-      # x-greptime-pipeline-params: '<key=value,...>'
+      # x-greptime-pipeline-params: '<key1=value1&key2=value2>'
     tls:
       insecure: true
 
-  otlphttp/metrics:
+  otlp_http/metrics:
     endpoint: 'http://127.0.0.1:4000/v1/otlp'
     # auth:
     #   authenticator: basicauth/client
@@ -59,16 +59,16 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [otlphttp/traces]
+      exporters: [otlp_http/traces]
     logs:
       receivers: [otlp]
-      exporters: [otlphttp/logs]
+      exporters: [otlp_http/logs]
     metrics:
       receivers: [otlp]
-      exporters: [otlphttp/metrics]
+      exporters: [otlp_http/metrics]
 ```
 
-In the above configuration, we define a receiver `otlp` that can receive data from OpenTelemetry. We also define three exporters: `otlphttp/traces`, `otlphttp/logs`, and `otlphttp/metrics`, which send data to the OTLP endpoint of GreptimeDB.
+In the above configuration, we define a receiver `otlp` that can receive data from OpenTelemetry. We also define three exporters: `otlp_http/traces`, `otlp_http/logs`, and `otlp_http/metrics`, which send data to the OTLP endpoint of GreptimeDB.
 
 Based on the OTLP/HTTP protocol, we have added some headers to specify certain parameters, such as `x-greptime-pipeline-name` and `x-greptime-log-table-name`:
 * The `x-greptime-pipeline-name` header is used to specify the pipeline name to use, and,

--- a/versioned_docs/version-1.1/user-guide/ingest-data/for-observability/vector.md
+++ b/versioned_docs/version-1.1/user-guide/ingest-data/for-observability/vector.md
@@ -134,7 +134,7 @@ inputs = [ "my_source_id" ]
 compression = "gzip"
 dbname = "public"
 endpoint = "http://<host>:4000"
-extra_headers = { "skip_error" = "true" }
+extra_headers = { "x-greptime-pipeline-params" = "max_nested_levels=10" }
 pipeline_name = "greptime_identity"
 table = "<table>"
 username = "<username>"
@@ -142,7 +142,7 @@ password = "<password>"
 
 [sinks.my_sink_id.extra_params]
 source = "vector"
-x-greptime-pipeline-params = "max_nested_levels=10"
+skip_error = "true"
 ```
 
 This example demonstrates how to use `greptimedb_logs` sink to write generated demo logs data to GreptimeDB. For more information, please refer to [Vector greptimedb_logs sink](https://vector.dev/docs/reference/configuration/sinks/greptimedb_logs/) documentation.

--- a/versioned_docs/version-1.1/user-guide/logs/fulltext-search.md
+++ b/versioned_docs/version-1.1/user-guide/logs/fulltext-search.md
@@ -11,7 +11,7 @@ GreptimeDB allows for flexible querying of data using SQL statements. This secti
 
 ## Pattern Matching Using the `matches_term` Function
 
-In SQL statements, you can use the `matches_term` function to perform exact term/phrase matching, which is especially useful for log analysis. The `matches_term` function supports pattern matching on `String` type columns. You can also use the `@@` operator as a shorthand for `matches_term`. Here's an example of how it can be used:
+In SQL statements, you can use the `matches_term` function to perform script-aware term/phrase matching, which is especially useful for log analysis. The `matches_term` function supports pattern matching on `String` type columns. You can also use the `@@` operator as a shorthand for `matches_term`. Here's an example of how it can be used:
 
 ```sql
 -- Using matches_term function
@@ -21,19 +21,20 @@ SELECT * FROM logs WHERE matches_term(message, 'error') OR matches_term(message,
 SELECT * FROM logs WHERE message @@ 'error' OR message @@ 'fail';
 ```
 
-The `matches_term` function is designed for exact term/phrase matching and uses the following syntax:
+The `matches_term` function finds an exact character sequence and applies boundary rules based on the characters in the search term:
 
 - `text`: The text column to search, which should contain textual data of type `String`.
-- `term`: The search term or phrase to match exactly, following these rules:
+- `term`: The search term or phrase, following these rules:
   - Case-sensitive matching
-  - Matches must have non-alphanumeric boundaries (start/end of text or any non-alphanumeric character)
+  - For terms without Han characters, word-boundary rules apply. ASCII alphanumeric edges cannot be adjacent to ASCII alphanumeric characters; other Unicode alphanumeric edges cannot be adjacent to alphanumeric or Han characters.
+  - Terms containing Han characters match as contiguous substrings without requiring word boundaries.
   - Supports whole-word matching and phrase matching
 
 ## Query Statements
 
 ### Simple Term Matching
 
-The `matches_term` function performs exact word matching, which means it will only match complete words that are properly bounded by non-alphanumeric characters or the start/end of the text. This is particularly useful for finding specific error messages, status codes, version numbers, or paths in logs.
+For terms without Han characters, `matches_term` performs exact word matching. The match must have the boundaries described above or occur at the start or end of the text. This is particularly useful for finding specific error messages, status codes, version numbers, or paths in logs.
 
 Error messages:
 ```sql
@@ -65,6 +66,18 @@ Examples of matches and non-matches for '/start':
 - ❌ "start" - no match because it's missing the leading slash
 - ❌ "start/stop" - no match because "/start" is not a complete term
 
+### Han Term Matching
+
+Terms containing Han characters use contiguous substring matching and do not require word boundaries.
+
+```sql
+SELECT * FROM logs WHERE matches_term(message, '手机');
+```
+
+Examples of matches and non-matches:
+- ✅ "登录手机号18888888888的动态key" - matches because it contains the exact substring "手机"
+- ❌ "手持设备" - no match because it does not contain the exact substring "手机"
+
 ### Multiple Term Searches
 
 You can combine multiple `matches_term` conditions using the `OR` operator to search for logs containing any of several terms. This is useful when you want to find logs that might contain different variations of an error or different types of issues.
@@ -84,7 +97,7 @@ Examples of matches and non-matches:
 - ✅ "An error occurred!" - matches "error"
 - ✅ "critical failure detected" - matches "critical"
 - ❌ "errors" - no match because "error" is part of a larger word
-- ❌ "critical_errors" - no match because terms are part of larger words
+- ✅ "critical_errors" - matches "critical" because an underscore is a non-alphanumeric boundary
 
 ### Exclusion Searches
 

--- a/versioned_docs/version-1.1/user-guide/query-data/jaeger.md
+++ b/versioned_docs/version-1.1/user-guide/query-data/jaeger.md
@@ -17,6 +17,7 @@ GreptimeDB currently supports the following [Jaeger](https://www.jaegertracing.i
 - `/api/operations?service={service}`: Get all operations for a service.
 - `/api/services/{service}/operations`: Get all operations for a service.
 - `/api/traces`: Get traces by query parameters.
+- `/api/traces/{trace_id}`: Get a trace by its ID.
 
 You can use [Grafana's Jaeger plugin](https://grafana.com/docs/grafana/latest/datasources/jaeger/)(Recommended) or [Jaeger UI](https://github.com/jaegertracing/jaeger-ui) to query traces data in GreptimeDB. When using Jaeger UI, you can set the `proxyConfig` in `packages/jaeger-ui/vite.config.mts` to the GreptimeDB address, for example:
 

--- a/versioned_docs/version-1.1/user-guide/traces/read-write.md
+++ b/versioned_docs/version-1.1/user-guide/traces/read-write.md
@@ -49,7 +49,7 @@ docker run --rm \
   -p 4317:4317 \
   -p 4318:4318 \
   -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml \
-  otel/opentelemetry-collector-contrib:0.123.0
+  otel/opentelemetry-collector-contrib:0.159.0
 ```
 
 The content of the `config.yaml` file is as follows:
@@ -64,7 +64,7 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 exporters:
-  otlphttp:
+  otlp_http:
     endpoint: "http://greptimedb:4000/v1/otlp" # Replace greptimedb with your setup
     headers:
       x-greptime-pipeline-name: "greptime_trace_v1"
@@ -76,7 +76,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [otlphttp]
+      exporters: [otlp_http]
 ```
 
 #### Write Trace Data to OpenTelemetry Collector

--- a/versioned_docs/version-1.2/user-guide/ingest-data/for-observability/alloy.md
+++ b/versioned_docs/version-1.2/user-guide/ingest-data/for-observability/alloy.md
@@ -15,11 +15,14 @@ Configure GreptimeDB as remote write target:
 ```hcl
 prometheus.remote_write "greptimedb" {
     endpoint {
-        url = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/prometheus/write?db=${GREPTIME_DB:=public}"
+        url = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+          coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+          coalesce(sys.env("GREPTIME_PORT"), "4000") +
+          "/v1/prometheus/write?db=" + coalesce(sys.env("GREPTIME_DB"), "public")
 
         basic_auth {
-            username = "${GREPTIME_USERNAME}"
-            password = "${GREPTIME_PASSWORD}"
+            username = sys.env("GREPTIME_USERNAME")
+            password = sys.env("GREPTIME_PASSWORD")
         }
     }
 }
@@ -40,17 +43,19 @@ GreptimeDB can also be configured as OpenTelemetry collector.
 ```hcl
 otelcol.exporter.otlphttp "greptimedb" {
   client {
-    endpoint = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/otlp/"
+    endpoint = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/otlp/"
     headers  = {
-      "X-Greptime-DB-Name" = "${GREPTIME_DB:=public}",
+      "X-Greptime-DB-Name" = coalesce(sys.env("GREPTIME_DB"), "public"),
     }
     auth     = otelcol.auth.basic.credentials.handler
   }
 }
 
 otelcol.auth.basic "credentials" {
-  username = "${GREPTIME_USERNAME}"
-  password = "${GREPTIME_PASSWORD}"
+  username = sys.env("GREPTIME_USERNAME")
+  password = sys.env("GREPTIME_PASSWORD")
 }
 ```
 
@@ -90,16 +95,18 @@ otelcol.processor.batch "greptimedb_logs" {
 }
 
 otelcol.auth.basic "credentials" {
-  username = "${GREPTIME_USERNAME}"
-  password = "${GREPTIME_PASSWORD}"
+  username = sys.env("GREPTIME_USERNAME")
+  password = sys.env("GREPTIME_PASSWORD")
 }
 
 otelcol.exporter.otlphttp "greptimedb_logs" {
   client {
-    endpoint = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/otlp/"
+    endpoint = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/otlp/"
     headers = {
-      "X-Greptime-DB-Name"          = "${GREPTIME_DB:=public}",
-      "X-Greptime-Log-Table-Name"   = "${GREPTIME_LOG_TABLE_NAME:=demo_logs}",
+      "X-Greptime-DB-Name"          = coalesce(sys.env("GREPTIME_DB"), "public"),
+      "X-Greptime-Log-Table-Name"   = coalesce(sys.env("GREPTIME_LOG_TABLE_NAME"), "demo_logs"),
       "X-Greptime-Log-Extract-Keys" = "filename,log.file.name,loki.attribute.labels",
     }
     auth = otelcol.auth.basic.credentials.handler
@@ -151,15 +158,17 @@ loki.process "greptime" {
 
 loki.write "greptimedb" {
   endpoint {
-    url = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/loki/api/v1/push"
+    url = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+      coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+      coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/loki/api/v1/push"
     headers = {
-      "X-Greptime-DB-Name"        = "${GREPTIME_DB:=public}",
-      "X-Greptime-Log-Table-Name" = "${GREPTIME_LOG_TABLE_NAME:=loki_demo_logs}",
+      "X-Greptime-DB-Name"        = coalesce(sys.env("GREPTIME_DB"), "public"),
+      "X-Greptime-Log-Table-Name" = coalesce(sys.env("GREPTIME_LOG_TABLE_NAME"), "loki_demo_logs"),
     }
 
     basic_auth {
-      username = "${GREPTIME_USERNAME}"
-      password = "${GREPTIME_PASSWORD}"
+      username = sys.env("GREPTIME_USERNAME")
+      password = sys.env("GREPTIME_PASSWORD")
     }
   }
 }

--- a/versioned_docs/version-1.2/user-guide/ingest-data/for-observability/fluent-bit.md
+++ b/versioned_docs/version-1.2/user-guide/ingest-data/for-observability/fluent-bit.md
@@ -51,46 +51,27 @@ The `greptime_identity` pipeline creates the table directly from the JSON fields
 
 GreptimeDB can also be configured as OpenTelemetry collector. Using Fluent Bit's [OpenTelemetry Output Plugin](https://docs.fluentbit.io/manual/pipeline/outputs/opentelemetry), you can send metrics, logs, and traces to GreptimeDB.
 
-```
-[OUTPUT]
-    Name                 opentelemetry
-    Match                *
-    Host                 127.0.0.1
-    Port                 4000
-    Metrics_uri          /v1/otlp/v1/metrics
-    Logs_uri             /v1/otlp/v1/logs
-    Traces_uri           /v1/otlp/v1/traces
-    Log_response_payload True
-    Tls                  Off
-    Tls.verify           Off
-    logs_body_key message
-    http_User <username>
-    http_Passwd <password>
-```
-
-- `Metrics_uri`, `Logs_uri`, and `Traces_uri`: The endpoint to send metrics, logs, and traces to.
-- `http_user` and `http_passwd`: The [authentication credentials](/user-guide/deployments-administration/authentication/static.md) for GreptimeDB.
-
-We recommend not writing metrics, logs, and traces to a single output simultaneously, as each has specific header options for specifying parameters. We suggest creating a separate OpenTelemetry output for metrics, logs, and traces. for example:
+Use a separate output for each signal because GreptimeDB uses signal-specific headers. Assign a distinct tag to each signal in the Fluent Bit inputs, then match that tag in the corresponding output:
 
 ```
 # Only for metrics
 [OUTPUT]
     Name                 opentelemetry
     Alias                opentelemetry_metrics
-    Match                *
+    Match                <metrics_tag>
     Host                 127.0.0.1
     Port                 4000
     Metrics_uri          /v1/otlp/v1/metrics
     Log_response_payload True
     Tls                  Off
     Tls.verify           Off
+    Header X-Greptime-DB-Name "<dbname>"
 
 # Only for logs
 [OUTPUT]
     Name                 opentelemetry
     Alias                opentelemetry_logs
-    Match                *
+    Match                <logs_tag>
     Host                 127.0.0.1
     Port                 4000
     Logs_uri             /v1/otlp/v1/logs
@@ -98,10 +79,27 @@ We recommend not writing metrics, logs, and traces to a single output simultaneo
     Tls                  Off
     Tls.verify           Off
     Header X-Greptime-Log-Table-Name "<log_table_name>"
-    Header X-Greptime-Log-Pipeline-Name "<pipeline_name>"
+    Header X-Greptime-Pipeline-Name "<pipeline_name>"
+    Header X-Greptime-DB-Name "<dbname>"
+
+# Only for traces
+[OUTPUT]
+    Name                 opentelemetry
+    Alias                opentelemetry_traces
+    Match                <traces_tag>
+    Host                 127.0.0.1
+    Port                 4000
+    Traces_uri           /v1/otlp/v1/traces
+    Log_response_payload True
+    Tls                  Off
+    Tls.verify           Off
+    Header X-Greptime-Pipeline-Name "greptime_trace_v1"
     Header X-Greptime-DB-Name "<dbname>"
 ```
 
+- `Metrics_uri`, `Logs_uri`, and `Traces_uri`: The endpoints for metrics, logs, and traces.
+- `Match`: The signal-specific tag configured on the corresponding Fluent Bit input.
+- `http_user` and `http_passwd`: The [authentication credentials](/user-guide/deployments-administration/authentication/static.md) for GreptimeDB. Add them to each output when authentication is enabled.
 
 In this example, the OpenTelemetry OTLP/HTTP API is used. For signal-specific headers and options, see the OpenTelemetry API sections for [metrics](/user-guide/ingest-data/for-observability/opentelemetry.md#otlphttp-api), [logs](/user-guide/ingest-data/for-observability/opentelemetry.md#otlphttp-api-1), and [traces](/user-guide/ingest-data/for-observability/opentelemetry.md#otlphttp-api-2).
 

--- a/versioned_docs/version-1.2/user-guide/ingest-data/for-observability/loki.md
+++ b/versioned_docs/version-1.2/user-guide/ingest-data/for-observability/loki.md
@@ -17,7 +17,10 @@ To send logs to GreptimeDB through the raw HTTP API, use the following informati
   * `Authorization`: `Basic` authentication, which is a Base64 encoded string of `<username>:<password>`. For more information, please refer to [Authentication](https://docs.greptime.com/user-guide/deployments-administration/authentication/static/) and [HTTP API](https://docs.greptime.com/user-guide/protocols/http#authentication).
   * `X-Greptime-Log-Table-Name`: `<table_name>` (optional) - The table name to store the logs. If not provided, the default table name is `loki_logs`.
 
-The request uses binary protobuf to encode the payload. The defined schema is the same as the [logproto.proto](https://github.com/grafana/loki/blob/main/pkg/logproto/logproto.proto).
+GreptimeDB accepts either of the Loki Push API payload encodings:
+
+* **Protobuf**: Send a Snappy-compressed `PushRequest` matching [logproto.proto](https://github.com/grafana/loki/blob/main/pkg/logproto/logproto.proto) with `Content-Type: application/x-protobuf`.
+* **JSON**: Send a Loki JSON push body with `Content-Type: application/json`.
 
 ### Example Code
 
@@ -35,10 +38,12 @@ loki.source.file "greptime" {
 
 loki.write "greptime_loki" {
     endpoint {
-        url = "${GREPTIME_SCHEME:=http}://${GREPTIME_HOST:=greptimedb}:${GREPTIME_PORT:=4000}/v1/loki/api/v1/push"
+        url = coalesce(sys.env("GREPTIME_SCHEME"), "http") + "://" +
+          coalesce(sys.env("GREPTIME_HOST"), "greptimedb") + ":" +
+          coalesce(sys.env("GREPTIME_PORT"), "4000") + "/v1/loki/api/v1/push"
         headers  = {
-          "x-greptime-db-name" = "${GREPTIME_DB:=public}",
-          "x-greptime-log-table-name" = "${GREPTIME_LOG_TABLE_NAME:=loki_demo_logs}",
+          "x-greptime-db-name" = coalesce(sys.env("GREPTIME_DB"), "public"),
+          "x-greptime-log-table-name" = coalesce(sys.env("GREPTIME_LOG_TABLE_NAME"), "loki_demo_logs"),
         }
     }
     external_labels = {
@@ -56,11 +61,11 @@ You can run the following command to check the data in the table:
 
 ```sql
 SELECT * FROM loki_demo_logs;
-+----------------------------+------------------------+--------------+-------+----------+
-| greptime_timestamp         | line                   | filename     | from  | job      |
-+----------------------------+------------------------+--------------+-------+----------+
-| 2024-11-25 11:02:31.256251 | Greptime is very cool! | /tmp/foo.txt | alloy | greptime |
-+----------------------------+------------------------+--------------+-------+----------+
++----------------------------+------------------------+---------------------+--------------+-------+----------+
+| greptime_timestamp         | line                   | structured_metadata | filename     | from  | job      |
++----------------------------+------------------------+---------------------+--------------+-------+----------+
+| 2024-11-25 11:02:31.256251 | Greptime is very cool! | {}                  | /tmp/foo.txt | alloy | greptime |
++----------------------------+------------------------+---------------------+--------------+-------+----------+
 1 row in set (0.01 sec)
 ```
 
@@ -118,6 +123,7 @@ SHOW CREATE TABLE loki_demo_logs\G
 Create Table: CREATE TABLE IF NOT EXISTS `loki_demo_logs` (
   `greptime_timestamp` TIMESTAMP(9) NOT NULL,
   `line` STRING NULL,
+  `structured_metadata` JSON NULL,
   `filename` STRING NULL,
   `from` STRING NULL,
   `job` STRING NULL,
@@ -127,7 +133,10 @@ Create Table: CREATE TABLE IF NOT EXISTS `loki_demo_logs` (
 
 ENGINE=mito
 WITH(
-  append_mode = 'true'
+  'comment' = 'Created on insertion',
+  append_mode = 'true',
+  'greptime.semantic.signal_type' = 'log',
+  'greptime.semantic.source' = 'loki'
 )
 1 row in set (0.00 sec)
 ```

--- a/versioned_docs/version-1.2/user-guide/ingest-data/for-observability/opentelemetry.md
+++ b/versioned_docs/version-1.2/user-guide/ingest-data/for-observability/opentelemetry.md
@@ -118,8 +118,13 @@ For more information on the example code, please refer to the official documenta
 GreptimeDB supports a Prometheus-compatible mode for OTLP metrics ingestion.
 If the metrics data is persisted using the Prometheus-compatible format, you should be able to query them using PromQL, just like any Prometheus metrics.
 
-If you have not ingested any OTLP metrics before, it will automatically use the Prometheus-compatible format.
-Otherwise, it will remain the old data format with the existing table, but use the new data format for any newly created tables.
+GreptimeDB selects the ingestion format once for each OTLP export request:
+
+- If none of the referenced metric tables exists, GreptimeDB uses the Prometheus-compatible format.
+- If all referenced existing tables use the same format, GreptimeDB uses that format for every metric in the request, including any tables created by the request.
+- If the request references existing tables in both formats, GreptimeDB rejects the request.
+
+Send legacy and Prometheus-compatible metrics in separate OTLP export requests.
 
 GreptimeDB pre-processes the incoming data before persisting them, including:
 1. Converting the metric names(table names) and the label names to the Prometheus style(e.g: replace `.` with `_`). By default, GreptimeDB also adds Prometheus-style suffixes based on the metric unit and type. See [here](https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/#metric-metadata-1) for details.
@@ -132,7 +137,7 @@ GreptimeDB pre-processes the incoming data before persisting them, including:
    | `memory.usage` | Gauge / `By` | `memory_usage_bytes` |
    | `queue.length` | Gauge / `{item}` | `queue_length` |
    | `http.server.request.duration` | Histogram / `s` | `http_server_request_duration_seconds` |
-   | `rpc.server.duration` | Histogram / `ms` | `rpc_server_duration_seconds` |
+   | `rpc.server.duration` | Histogram / `ms` | `rpc_server_duration_milliseconds` |
    | `http.client.request.size` | Sum (Monotonic) / `By` | `http_client_request_size_bytes_total` |
    | `system.network.io` | Sum (Monotonic) / `By` | `system_network_io_bytes_total` |
    | `http.status_code` (Attribute) | - | `http_status_code` |

--- a/versioned_docs/version-1.2/user-guide/ingest-data/for-observability/otel-collector.md
+++ b/versioned_docs/version-1.2/user-guide/ingest-data/for-observability/otel-collector.md
@@ -24,7 +24,7 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 exporters:
-  otlphttp/traces:
+  otlp_http/traces:
     endpoint: 'http://127.0.0.1:4000/v1/otlp'
     # auth:
     #   authenticator: basicauth/client
@@ -33,7 +33,7 @@ exporters:
       x-greptime-pipeline-name: 'greptime_trace_v1'
     tls:
       insecure: true
-  otlphttp/logs:
+  otlp_http/logs:
     endpoint: 'http://127.0.0.1:4000/v1/otlp'
     # auth:
     #   authenticator: basicauth/client
@@ -41,11 +41,11 @@ exporters:
       # x-greptime-db-name: '<your_db_name>'
       # x-greptime-log-table-name: '<table_name>'
       # x-greptime-pipeline-name: '<pipeline_name>'
-      # x-greptime-pipeline-params: '<key=value,...>'
+      # x-greptime-pipeline-params: '<key1=value1&key2=value2>'
     tls:
       insecure: true
 
-  otlphttp/metrics:
+  otlp_http/metrics:
     endpoint: 'http://127.0.0.1:4000/v1/otlp'
     # auth:
     #   authenticator: basicauth/client
@@ -59,16 +59,16 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [otlphttp/traces]
+      exporters: [otlp_http/traces]
     logs:
       receivers: [otlp]
-      exporters: [otlphttp/logs]
+      exporters: [otlp_http/logs]
     metrics:
       receivers: [otlp]
-      exporters: [otlphttp/metrics]
+      exporters: [otlp_http/metrics]
 ```
 
-In the above configuration, we define a receiver `otlp` that can receive data from OpenTelemetry. We also define three exporters: `otlphttp/traces`, `otlphttp/logs`, and `otlphttp/metrics`, which send data to the OTLP endpoint of GreptimeDB.
+In the above configuration, we define a receiver `otlp` that can receive data from OpenTelemetry. We also define three exporters: `otlp_http/traces`, `otlp_http/logs`, and `otlp_http/metrics`, which send data to the OTLP endpoint of GreptimeDB.
 
 Based on the OTLP/HTTP protocol, we have added some headers to specify certain parameters, such as `x-greptime-pipeline-name` and `x-greptime-log-table-name`:
 * The `x-greptime-pipeline-name` header is used to specify the pipeline name to use, and,

--- a/versioned_docs/version-1.2/user-guide/ingest-data/for-observability/vector.md
+++ b/versioned_docs/version-1.2/user-guide/ingest-data/for-observability/vector.md
@@ -134,7 +134,7 @@ inputs = [ "my_source_id" ]
 compression = "gzip"
 dbname = "public"
 endpoint = "http://<host>:4000"
-extra_headers = { "skip_error" = "true" }
+extra_headers = { "x-greptime-pipeline-params" = "max_nested_levels=10" }
 pipeline_name = "greptime_identity"
 table = "<table>"
 username = "<username>"
@@ -142,7 +142,7 @@ password = "<password>"
 
 [sinks.my_sink_id.extra_params]
 source = "vector"
-x-greptime-pipeline-params = "max_nested_levels=10"
+skip_error = "true"
 ```
 
 This example demonstrates how to use `greptimedb_logs` sink to write generated demo logs data to GreptimeDB. For more information, please refer to [Vector greptimedb_logs sink](https://vector.dev/docs/reference/configuration/sinks/greptimedb_logs/) documentation.

--- a/versioned_docs/version-1.2/user-guide/logs/fulltext-search.md
+++ b/versioned_docs/version-1.2/user-guide/logs/fulltext-search.md
@@ -11,7 +11,7 @@ GreptimeDB allows for flexible querying of data using SQL statements. This secti
 
 ## Pattern Matching Using the `matches_term` Function
 
-In SQL statements, you can use the `matches_term` function to perform exact term/phrase matching, which is especially useful for log analysis. The `matches_term` function supports pattern matching on `String` type columns. You can also use the `@@` operator as a shorthand for `matches_term`. Here's an example of how it can be used:
+In SQL statements, you can use the `matches_term` function to perform script-aware term/phrase matching, which is especially useful for log analysis. The `matches_term` function supports pattern matching on `String` type columns. You can also use the `@@` operator as a shorthand for `matches_term`. Here's an example of how it can be used:
 
 ```sql
 -- Using matches_term function
@@ -21,19 +21,20 @@ SELECT * FROM logs WHERE matches_term(message, 'error') OR matches_term(message,
 SELECT * FROM logs WHERE message @@ 'error' OR message @@ 'fail';
 ```
 
-The `matches_term` function is designed for exact term/phrase matching and uses the following syntax:
+The `matches_term` function finds an exact character sequence and applies boundary rules based on the characters in the search term:
 
 - `text`: The text column to search, which should contain textual data of type `String`.
-- `term`: The search term or phrase to match exactly, following these rules:
+- `term`: The search term or phrase, following these rules:
   - Case-sensitive matching
-  - Matches must have non-alphanumeric boundaries (start/end of text or any non-alphanumeric character)
+  - For terms without Han characters, word-boundary rules apply. ASCII alphanumeric edges cannot be adjacent to ASCII alphanumeric characters; other Unicode alphanumeric edges cannot be adjacent to alphanumeric or Han characters.
+  - Terms containing Han characters match as contiguous substrings without requiring word boundaries.
   - Supports whole-word matching and phrase matching
 
 ## Query Statements
 
 ### Simple Term Matching
 
-The `matches_term` function performs exact word matching, which means it will only match complete words that are properly bounded by non-alphanumeric characters or the start/end of the text. This is particularly useful for finding specific error messages, status codes, version numbers, or paths in logs.
+For terms without Han characters, `matches_term` performs exact word matching. The match must have the boundaries described above or occur at the start or end of the text. This is particularly useful for finding specific error messages, status codes, version numbers, or paths in logs.
 
 Error messages:
 ```sql
@@ -65,6 +66,18 @@ Examples of matches and non-matches for '/start':
 - ❌ "start" - no match because it's missing the leading slash
 - ❌ "start/stop" - no match because "/start" is not a complete term
 
+### Han Term Matching
+
+Terms containing Han characters use contiguous substring matching and do not require word boundaries.
+
+```sql
+SELECT * FROM logs WHERE matches_term(message, '手机');
+```
+
+Examples of matches and non-matches:
+- ✅ "登录手机号18888888888的动态key" - matches because it contains the exact substring "手机"
+- ❌ "手持设备" - no match because it does not contain the exact substring "手机"
+
 ### Multiple Term Searches
 
 You can combine multiple `matches_term` conditions using the `OR` operator to search for logs containing any of several terms. This is useful when you want to find logs that might contain different variations of an error or different types of issues.
@@ -84,7 +97,7 @@ Examples of matches and non-matches:
 - ✅ "An error occurred!" - matches "error"
 - ✅ "critical failure detected" - matches "critical"
 - ❌ "errors" - no match because "error" is part of a larger word
-- ❌ "critical_errors" - no match because terms are part of larger words
+- ✅ "critical_errors" - matches "critical" because an underscore is a non-alphanumeric boundary
 
 ### Exclusion Searches
 

--- a/versioned_docs/version-1.2/user-guide/query-data/jaeger.md
+++ b/versioned_docs/version-1.2/user-guide/query-data/jaeger.md
@@ -17,6 +17,7 @@ GreptimeDB currently supports the following [Jaeger](https://www.jaegertracing.i
 - `/api/operations?service={service}`: Get all operations for a service.
 - `/api/services/{service}/operations`: Get all operations for a service.
 - `/api/traces`: Get traces by query parameters.
+- `/api/traces/{trace_id}`: Get a trace by its ID.
 
 You can use [Grafana's Jaeger plugin](https://grafana.com/docs/grafana/latest/datasources/jaeger/)(Recommended) or [Jaeger UI](https://github.com/jaegertracing/jaeger-ui) to query traces data in GreptimeDB. When using Jaeger UI, you can set the `proxyConfig` in `packages/jaeger-ui/vite.config.mts` to the GreptimeDB address, for example:
 

--- a/versioned_docs/version-1.2/user-guide/traces/read-write.md
+++ b/versioned_docs/version-1.2/user-guide/traces/read-write.md
@@ -49,7 +49,7 @@ docker run --rm \
   -p 4317:4317 \
   -p 4318:4318 \
   -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml \
-  otel/opentelemetry-collector-contrib:0.123.0
+  otel/opentelemetry-collector-contrib:0.159.0
 ```
 
 The content of the `config.yaml` file is as follows:
@@ -64,7 +64,7 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 exporters:
-  otlphttp:
+  otlp_http:
     endpoint: "http://greptimedb:4000/v1/otlp" # Replace greptimedb with your setup
     headers:
       x-greptime-pipeline-name: "greptime_trace_v1"
@@ -76,7 +76,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [otlphttp]
+      exporters: [otlp_http]
 ```
 
 #### Write Trace Data to OpenTelemetry Collector


### PR DESCRIPTION
## What changed

This pull request updates the English and Chinese documentation for logs, traces, and OTLP across Nightly, 1.2, and 1.1.
- Corrects Alloy, Fluent Bit, OpenTelemetry Collector, and Vector configuration examples.
- Documents Loki JSON and Protobuf payloads, including `structured_metadata`.
- Clarifies OTLP metric compatibility behavior and unit suffixes.
- Documents Han-character matching and Jaeger trace-by-ID queries.
- Refreshes the Collector example while preserving the unsigned OTLP schemas used by GreptimeDB 1.1 and 1.2.

## Scope

- Documentation versions: nightly, 1.2 and 1.1
- Languages: English and Chinese

## Verification

<!-- List commands run and any manual checks. -->

## Checklist

- [ ] I verified the content against the applicable GreptimeDB version.
- [ ] I updated the relevant documentation versions and languages, or explained why not.
- [ ] I checked changed links and anchors.
- [ ] I updated navigation when the document structure changed.
