### PR TITLE
docs: list missing GreptimeDB skills

### DIFF
--- a/docs/faq-and-others/vibecoding.md
+++ b/docs/faq-and-others/vibecoding.md
@@ -66,6 +66,14 @@ skill uses `dryrun_pipeline` to verify a config before applying it).
 - **`self-monitoring-export`** — for cluster incidents: infer the log export
   time range from the user's description, then export cluster self-monitoring
   logs and metrics for investigation.
+- **`greptimedb-performance-diagnosis`** — find the bottleneck behind slow
+  queries, lagging or stalled ingestion, or high CPU and memory usage.
+- **`greptimedb-performance-tuning`** — tune server configuration and table
+  options, including caches, write buffers, WAL, and ingestion throughput.
+- **`greptimedb-table-design`** — design or improve table schemas, primary
+  keys, indexes, append-only or merge mode, and partitioning.
+- **`greptimedb-cluster-health-check`** — verify a deployment after a deploy or
+  restart by checking readiness, object-store access, logs, and key metrics.
 - **`influxql-to-greptimedb-sql`** — convert InfluxQL queries to GreptimeDB SQL
   while identifying semantic differences in windows, fills, and series limits.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/faq-and-others/vibecoding.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/faq-and-others/vibecoding.md
@@ -56,6 +56,14 @@ flow、trigger——安装一个 Skill 能把完整工作流教给 agent，效�
   `CREATE TRIGGER`（企业版）。
 - **`self-monitoring-export`** —— 用于集群故障排查：从用户描述中推断日志导出的时间范围，
   然后导出集群自监控日志和指标供工程排查。
+- **`greptimedb-performance-diagnosis`** —— 定位查询缓慢、写入延迟或停滞，以及 CPU、
+  内存占用过高等性能问题的瓶颈。
+- **`greptimedb-performance-tuning`** —— 调整服务端配置和表选项，包括缓存、写缓冲、
+  WAL 和写入吞吐量。
+- **`greptimedb-table-design`** —— 设计或优化表结构、主键、索引、仅追加或合并模式，
+  以及分区策略。
+- **`greptimedb-cluster-health-check`** —— 部署或重启后检查服务就绪状态、对象存储访问、
+  日志和关键指标，确认集群健康。
 - **`influxql-to-greptimedb-sql`** —— 将 InfluxQL 查询转换为 GreptimeDB SQL，
   同时识别时间窗口、填充和逐序列 `LIMIT` 的语义差异。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/faq-and-others/vibecoding.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/faq-and-others/vibecoding.md
@@ -56,6 +56,14 @@ flow、trigger——安装一个 Skill 能把完整工作流教给 agent，效�
   `CREATE TRIGGER`（企业版）。
 - **`self-monitoring-export`** —— 用于集群故障排查：从用户描述中推断日志导出的时间范围，
   然后导出集群自监控日志和指标供工程排查。
+- **`greptimedb-performance-diagnosis`** —— 定位查询缓慢、写入延迟或停滞，以及 CPU、
+  内存占用过高等性能问题的瓶颈。
+- **`greptimedb-performance-tuning`** —— 调整服务端配置和表选项，包括缓存、写缓冲、
+  WAL 和写入吞吐量。
+- **`greptimedb-table-design`** —— 设计或优化表结构、主键、索引、仅追加或合并模式，
+  以及分区策略。
+- **`greptimedb-cluster-health-check`** —— 部署或重启后检查服务就绪状态、对象存储访问、
+  日志和关键指标，确认集群健康。
 - **`influxql-to-greptimedb-sql`** —— 将 InfluxQL 查询转换为 GreptimeDB SQL，
   同时识别时间窗口、填充和逐序列 `LIMIT` 的语义差异。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/faq-and-others/vibecoding.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/faq-and-others/vibecoding.md
@@ -56,6 +56,14 @@ flow、trigger——安装一个 Skill 能把完整工作流教给 agent，效�
   `CREATE TRIGGER`（企业版）。
 - **`self-monitoring-export`** —— 用于集群故障排查：从用户描述中推断日志导出的时间范围，
   然后导出集群自监控日志和指标供工程排查。
+- **`greptimedb-performance-diagnosis`** —— 定位查询缓慢、写入延迟或停滞，以及 CPU、
+  内存占用过高等性能问题的瓶颈。
+- **`greptimedb-performance-tuning`** —— 调整服务端配置和表选项，包括缓存、写缓冲、
+  WAL 和写入吞吐量。
+- **`greptimedb-table-design`** —— 设计或优化表结构、主键、索引、仅追加或合并模式，
+  以及分区策略。
+- **`greptimedb-cluster-health-check`** —— 部署或重启后检查服务就绪状态、对象存储访问、
+  日志和关键指标，确认集群健康。
 - **`influxql-to-greptimedb-sql`** —— 将 InfluxQL 查询转换为 GreptimeDB SQL，
   同时识别时间窗口、填充和逐序列 `LIMIT` 的语义差异。
 

--- a/versioned_docs/version-1.1/faq-and-others/vibecoding.md
+++ b/versioned_docs/version-1.1/faq-and-others/vibecoding.md
@@ -66,6 +66,14 @@ skill uses `dryrun_pipeline` to verify a config before applying it).
 - **`self-monitoring-export`** — for cluster incidents: infer the log export
   time range from the user's description, then export cluster self-monitoring
   logs and metrics for investigation.
+- **`greptimedb-performance-diagnosis`** — find the bottleneck behind slow
+  queries, lagging or stalled ingestion, or high CPU and memory usage.
+- **`greptimedb-performance-tuning`** — tune server configuration and table
+  options, including caches, write buffers, WAL, and ingestion throughput.
+- **`greptimedb-table-design`** — design or improve table schemas, primary
+  keys, indexes, append-only or merge mode, and partitioning.
+- **`greptimedb-cluster-health-check`** — verify a deployment after a deploy or
+  restart by checking readiness, object-store access, logs, and key metrics.
 - **`influxql-to-greptimedb-sql`** — convert InfluxQL queries to GreptimeDB SQL
   while identifying semantic differences in windows, fills, and series limits.
 

--- a/versioned_docs/version-1.2/faq-and-others/vibecoding.md
+++ b/versioned_docs/version-1.2/faq-and-others/vibecoding.md
@@ -66,6 +66,14 @@ skill uses `dryrun_pipeline` to verify a config before applying it).
 - **`self-monitoring-export`** — for cluster incidents: infer the log export
   time range from the user's description, then export cluster self-monitoring
   logs and metrics for investigation.
+- **`greptimedb-performance-diagnosis`** — find the bottleneck behind slow
+  queries, lagging or stalled ingestion, or high CPU and memory usage.
+- **`greptimedb-performance-tuning`** — tune server configuration and table
+  options, including caches, write buffers, WAL, and ingestion throughput.
+- **`greptimedb-table-design`** — design or improve table schemas, primary
+  keys, indexes, append-only or merge mode, and partitioning.
+- **`greptimedb-cluster-health-check`** — verify a deployment after a deploy or
+  restart by checking readiness, object-store access, logs, and key metrics.
 - **`influxql-to-greptimedb-sql`** — convert InfluxQL queries to GreptimeDB SQL
   while identifying semantic differences in windows, fills, and series limits.
 


### PR DESCRIPTION
## What changed

Add the four missing GreptimeDB performance and health-check skills to the For AI Agents page in canonical order:

- `greptimedb-performance-diagnosis`
- `greptimedb-performance-tuning`
- `greptimedb-table-design`
- `greptimedb-cluster-health-check`

Keep the English and Chinese descriptions aligned with the canonical skill sources.

## Scope

- Documentation versions: Nightly, 1.1, 1.2
- Languages: English, Chinese

## Verification

- `DOC_LANG=en pnpm check:links`
- `DOC_LANG=zh pnpm check:links`
- `git diff --check`
- Manually verified the ten-skill ordering across all six changed pages

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] I updated navigation when the document structure changed. (No navigation changes required.)