### PR TITLE
docs: document widening the time index timestamp unit via ALTER TABLE

### DIFF
--- a/docs/faq-and-others/faq.md
+++ b/docs/faq-and-others/faq.md
@@ -121,7 +121,13 @@ Yes. Use `ALTER TABLE ... MODIFY COLUMN` to change a field column's data type:
 ALTER TABLE monitor MODIFY COLUMN load_15 STRING;
 ```
 
-The column must be a field (not a tag or time index) and must be nullable, so that values that cannot be cast return `NULL` instead of failing.
+The column must be a field (not a tag) and must be nullable, so that values that cannot be cast return `NULL` instead of failing.
+
+The time index column is the exception: its timestamp unit can be widened to a finer one (for example, from milliseconds to microseconds) on tables that are not using the metric engine:
+
+```sql
+ALTER TABLE monitor MODIFY COLUMN ts TIMESTAMP_US;
+```
 
 For the full `ALTER TABLE` syntax, see the [SQL reference](/reference/sql/alter.md).
 

--- a/docs/reference/sql/alter.md
+++ b/docs/reference/sql/alter.md
@@ -155,7 +155,15 @@ Modify the date type of a column
 ALTER TABLE monitor MODIFY COLUMN load_15 STRING;
 ```
 
-The modified column cannot be a tag (primary key) or time index, and it must be nullable to ensure that the data can be safely converted (returns `NULL` on cast failures).
+A modified field column cannot be a tag (primary key), and it must be nullable to ensure that the data can be safely converted (returns `NULL` on cast failures).
+
+The time index column is the exception: you can widen its timestamp unit to a finer one, for example, from `TIMESTAMP` (milliseconds) to `TIMESTAMP_US` (microseconds):
+
+```sql
+ALTER TABLE monitor MODIFY COLUMN ts TIMESTAMP_US;
+```
+
+Widening the time index unit is lossless — existing data is read in the new unit without rewriting, and new writes can use the finer precision. Narrowing the unit (for example, from microseconds back to milliseconds) or changing the time index to a non-timestamp type is not allowed. This operation is not supported on tables using the [metric engine](/reference/about-greptimedb-engines.md).
 
 ### Set column default value
 

--- a/docs/user-guide/deployments-administration/manage-data/basic-table-operations.md
+++ b/docs/user-guide/deployments-administration/manage-data/basic-table-operations.md
@@ -110,8 +110,9 @@ CREATE TABLE monitor (
 ```
 
 :::warning NOTE
-GreptimeDB does not currently support changing the TIME INDEX after a table has been created.
+GreptimeDB does not currently support changing the TIME INDEX column to another column after a table has been created.
 Therefore, it is important to carefully choose your TIME INDEX column before creating tables.
+However, you can use `ALTER TABLE ... MODIFY COLUMN` to widen the time index's timestamp unit to a finer one (for example, from milliseconds to microseconds) on tables that are not using the metric engine. For more information, see the [ALTER reference](/reference/sql/alter.md#modify-column-type).
 :::
 
 ### `CREATE TABLE` syntax

--- a/i18n/zh/docusaurus-plugin-content-docs/current/faq-and-others/faq.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/faq-and-others/faq.md
@@ -121,7 +121,13 @@ default_column_prefix = ""
 ALTER TABLE monitor MODIFY COLUMN load_15 STRING;
 ```
 
-目标列必须是 Field 列（不能是 Tag 或时间索引），且必须可为空（nullable），这样类型转换失败时返回 `NULL` 而非报错。
+目标列必须是 Field 列（不能是 Tag），且必须可为空（nullable），这样类型转换失败时返回 `NULL` 而非报错。
+
+时间索引列是个例外：对于未使用 metric engine 的表，可以将其时间戳单位拓宽为更精细的单位（例如从毫秒拓宽为微秒）：
+
+```sql
+ALTER TABLE monitor MODIFY COLUMN ts TIMESTAMP_US;
+```
 
 完整的 `ALTER TABLE` 语法参见 [SQL 参考](/reference/sql/alter.md)。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/alter.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/alter.md
@@ -155,7 +155,15 @@ ALTER TABLE monitor DROP COLUMN load_15;
 ALTER TABLE monitor MODIFY COLUMN load_15 STRING;
 ```
 
-被修改的列不能是 tag 列（primary key）或 time index 列，同时该列必须允许空值 `NULL` 存在来保证数据能够安全地进行转换（转换失败时返回 `NULL`）。
+被修改的列不能是 tag 列（primary key），同时该列必须允许空值 `NULL` 存在来保证数据能够安全地进行转换（转换失败时返回 `NULL`）。
+
+时间索引列是个例外：你可以将时间索引的时间戳单位拓宽为更精细的单位，例如从 `TIMESTAMP`（毫秒）改为 `TIMESTAMP_US`（微秒）：
+
+```sql
+ALTER TABLE monitor MODIFY COLUMN ts TIMESTAMP_US;
+```
+
+拓宽时间索引单位是无损的——已有数据在读取时按新单位解释，无需重写；新写入的数据可以使用更精细的精度。但收窄单位（例如从微秒改回毫秒）或将时间索引改为非时间戳类型是不允许的。该操作不支持使用 [metric engine](/reference/about-greptimedb-engines.md) 的表。
 
 ### 设置列默认值
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/manage-data/basic-table-operations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/manage-data/basic-table-operations.md
@@ -111,8 +111,9 @@ CREATE TABLE monitor (
 
 
 :::warning NOTE
-GreptimeDB 目前不支持在创建表后更改 TIME INDEX 约束，
+GreptimeDB 目前不支持在创建表后将 TIME INDEX 约束更改为其他列，
 因此，在创建表之前，仔细选择适当的 TIME INDEX 列。
+但对于未使用 metric engine 的表，你可以使用 `ALTER TABLE ... MODIFY COLUMN` 将时间索引的时间戳单位拓宽为更精细的单位（例如从毫秒拓宽为微秒）。更多信息参见 [ALTER 参考](/reference/sql/alter.md#修改列类型)。
 :::
 
 ### `CREATE TABLE` 语法


### PR DESCRIPTION
## What's changed

GreptimeDB now allows `ALTER TABLE ... MODIFY COLUMN` to **widen the time index column's timestamp unit** to a finer one (e.g. `TIMESTAMP` milliseconds → `TIMESTAMP_US` microseconds) on non-metric-engine tables (greptimedb #8894). This PR updates the docs that previously stated the time index could not be modified at all:

- **`reference/sql/alter.md`** (Modify column type): field columns still can't be tags and must be nullable; the time index is now the documented exception — widening is allowed (with example), is lossless (existing data is read in the new unit without rewriting), while narrowing, non-timestamp targets, and metric engine tables remain unsupported.
- **`user-guide/.../basic-table-operations.md`**: the warning now says the TIME INDEX *column* can't be moved to another column, but its timestamp unit can be widened via `MODIFY COLUMN` on non-metric-engine tables, linking to the ALTER reference anchor.
- **`faq-and-others/faq.md`**: the "Can I change a column's type after table creation?" answer drops "or time index" and adds the widening exception with an example.

English (`docs/`, nightly) and Chinese (`i18n/zh/.../current/`) updated together with equivalent meaning. No released-version changes since the feature is unreleased.

## Checklist

- [x] `DOC_LANG=en pnpm check:links`
- [x] `DOC_LANG=zh pnpm check:links` (caught and fixed a zh anchor — the link now uses the Chinese heading anchor `#修改列类型`)
- [x] `git diff --check` clean; no lockfile or generated-file changes