### PR TITLE
docs: port discard_unflushed docs to v1.2

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/sql/admin.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/sql/admin.md
@@ -1,6 +1,6 @@
 ---
-keywords: [管理函数, ADMIN 语句, SQL ADMIN, 数据库管理, 表管理, 数据管理, 构建索引]
-description: ADMIN 语句用于运行管理函数来管理数据库和数据。
+keywords: [管理函数, ADMIN 语句, SQL ADMIN, 数据库管理, 表管理, 数据管理, 丢弃未刷盘数据, 构建索引]
+description: ADMIN 语句用于运行管理函数，包括刷盘、丢弃未刷盘数据、压缩和构建索引等数据库管理操作。
 ---
 
 # ADMIN
@@ -17,6 +17,7 @@ GreptimeDB 提供了一些管理函数来管理数据库和数据：
 
 * `flush_table(table_name)` 根据表名将表的 Memtable 刷新到 SST 文件中。
 * `flush_region(region_id)` 根据 Region ID 将 Region 的 Memtable 刷新到 SST 文件中。通过 [PARTITIONS](./information-schema/partitions.md) 表查找 Region ID。
+* `discard_unflushed(table_name_or_region_id)` 永久丢弃表中所有物理 Region 或指定 Region 的未刷盘数据。
 * `compact_table(table_name, [type], [options])` 为表启动一个 compaction 任务，详细信息请阅读 [compaction](/user-guide/deployments-administration/manage-data/compaction.md#严格窗口压缩策略swcs和手动压缩)。
 * `compact_region(region_id)` 为 Region 启动一个 compaction 任务。
 * `build_index(table_name)` 在新增或修改索引定义后，为表已有的 SST 文件补建缺失的物理索引。
@@ -34,6 +35,12 @@ GreptimeDB 提供了一些管理函数来管理数据库和数据：
 ```sql
 -- 刷新表 test --
 admin flush_table("test");
+
+-- 丢弃表 test 所有物理 Region 中的未刷盘数据 --
+admin discard_unflushed("test");
+
+-- 丢弃指定 Region 中的未刷盘数据 --
+admin discard_unflushed(4398046511104);
 
 -- 为表 test 启动 compaction 任务，默认并行度为 1 --
 admin compact_table("test");
@@ -71,6 +78,31 @@ admin gc_regions(1, 2, 3, true);
 -- 永久 purge 一个 soft-dropped table --
 admin purge_table("test");
 ```
+
+## 丢弃未刷盘数据
+
+当 Memtable 中的数据导致 flush 反复失败、写缓冲区被占满并阻塞后续写入时，可以使用 `admin discard_unflushed` 进行紧急恢复。
+
+:::danger 危险操作
+
+该操作会永久删除目标 Region 中尚未持久化到 SST 文件的所有数据，并将对应的 WAL 条目标记为过期，因此重启 Datanode 也无法恢复这些数据。已经持久化到 SST 文件的数据不受影响。
+
+:::
+
+该函数只接受一个表名或 Region ID：
+
+```sql
+ADMIN discard_unflushed('table_name');
+ADMIN discard_unflushed(region_id);
+```
+
+使用表名时，该操作会作用于表的所有物理 Region。表名可以是未限定名、schema 限定名或完整限定名；省略的限定部分将根据当前查询上下文解析。
+
+使用数值类型的 Region ID 时，该操作只作用于指定 Region。可以查询 [`information_schema.PARTITIONS`](./information-schema/partitions.md) 表获取 Region ID。
+
+Metric Engine 逻辑表不支持该操作，因为多个逻辑表共享相同的物理 Region。使用 Metric Engine 物理表名或物理 Region ID 会丢弃其逻辑表共享的未刷盘数据，因此请仔细确认操作目标。
+
+该函数只能通过 `ADMIN` 语句调用，在 `SELECT` 语句中调用会被拒绝。如果目标中已没有未刷盘数据，重复执行该操作是安全的，不会产生影响。
 
 ## 构建索引
 

--- a/versioned_docs/version-1.2/reference/sql/admin.md
+++ b/versioned_docs/version-1.2/reference/sql/admin.md
@@ -1,6 +1,6 @@
 ---
-keywords: [ADMIN statement, SQL, administration functions, flush table, compact table, build index, migrate region, gc table, gc regions]
-description: Describes the `ADMIN` statement used to run administration functions, including examples for flushing tables, scheduling compactions, building indexes, migrating regions, querying procedure states, and garbage collecting orphaned files.
+keywords: [ADMIN statement, SQL, administration functions, flush table, discard unflushed data, compact table, build index, migrate region, gc table, gc regions]
+description: Describes the `ADMIN` statement used to run administration functions, including examples for flushing tables, discarding unflushed data, scheduling compactions, building indexes, migrating regions, querying procedure states, and garbage collecting orphaned files.
 ---
 
 # ADMIN
@@ -18,6 +18,7 @@ GreptimeDB provides some administration functions to manage the database and dat
 
 * `flush_table(table_name)` to flush a table's memtables into SST file by table name.
 * `flush_region(region_id)` to flush a region's memtables into SST file by region id. Find the region id through [PARTITIONS](./information-schema/partitions.md) table.
+* `discard_unflushed(table_name_or_region_id)` to permanently discard unflushed data from every physical region of a table or from one region.
 * `compact_table(table_name, [type], [options])` to schedule a compaction task for a table by table name, read [compaction](/user-guide/deployments-administration/manage-data/compaction.md#strict-window-compaction-strategy-swcs-and-manual-compaction) for more details.
 * `compact_region(region_id)` to schedule a compaction task for a region by region id.
 * `build_index(table_name)` to build missing physical indexes for a table's existing SST files after adding or changing index definitions.
@@ -35,6 +36,12 @@ For example:
 ```sql
 -- Flush the table test --
 admin flush_table("test");
+
+-- Discard unflushed data from all physical regions of table test --
+admin discard_unflushed("test");
+
+-- Discard unflushed data from one region --
+admin discard_unflushed(4398046511104);
 
 -- Schedule a compaction for table test with default parallelism (1) --
 admin compact_table("test");
@@ -72,6 +79,31 @@ admin gc_regions(1, 2, 3, true);
 -- Permanently purge a soft-dropped table --
 admin purge_table("test");
 ```
+
+## Discard Unflushed Data
+
+Use `admin discard_unflushed` as an emergency recovery operation when data in a Memtable repeatedly prevents flushing, fills the write buffer, and blocks further writes.
+
+:::danger
+
+This operation permanently deletes all data in the target regions that has not been persisted to SST files. It also makes the corresponding WAL entries obsolete, so restarting a Datanode does not restore the discarded data. Data already persisted in SST files remains available.
+
+:::
+
+The function takes exactly one table name or Region ID:
+
+```sql
+ADMIN discard_unflushed('table_name');
+ADMIN discard_unflushed(region_id);
+```
+
+A table name targets all physical regions of the table. It can be unqualified, schema-qualified, or fully qualified; omitted qualifiers are resolved from the current query context.
+
+A numeric Region ID targets only that Region. Query the [`information_schema.PARTITIONS`](./information-schema/partitions.md) table to find Region IDs.
+
+Metric Engine logical tables are not supported because multiple logical tables share the same physical regions. Using a physical Metric Engine table name or physical Region ID discards unflushed data shared by its logical tables, so verify the target carefully.
+
+This function is available only through the `ADMIN` statement. Calling it in a `SELECT` statement is rejected. Repeating the same operation when no unflushed data remains is safe and has no effect.
 
 ## Build Index
 


### PR DESCRIPTION
## What changed

- Port the `discard_unflushed` ADMIN documentation to the English and Chinese v1.2 reference pages.
- Document the table and Region ID forms, data-loss warning, supported targets, and usage constraints.

## Scope

- Documentation versions: 1.2
- Languages: English, Chinese

## Verification

- `git diff --check`
- Builds and link checks were not run, per request.

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] I updated navigation when the document structure changed. (Not applicable; no navigation changes.)