### PR TITLE
docs: update JSON2 documentation

### DIFF
--- a/docs/reference/pipeline/pipeline-config.md
+++ b/docs/reference/pipeline/pipeline-config.md
@@ -1064,7 +1064,7 @@ GreptimeDB currently provides the following built-in transformation types:
 - `time`: Time type, which will be converted to GreptimeDB `timestamp(9)` type.
 - `epoch`: Timestamp type, which will be converted to GreptimeDB `timestamp(n)` type. The value of `n` depends on the precision of the epoch. When the precision is `s`, `n` is 0; when the precision is `ms`, `n` is 3; when the precision is `us`, `n` is 6; when the precision is `ns`, `n` is 9.
 - `json`: JSON type. The field value must be a JSON object or array, such as one produced by the [`json_parse`](#json_parse) processor, and it is stored as a JSON column in the table. Scalar values (for example, strings, numbers) cannot be converted to the `json` type.
-- `json2`: [JSON2](/user-guide/logs/json2.md) type. The field may be missing or `null`. A non-null value must be a non-empty JSON object, such as one produced by the [`json_parse`](#json_parse) processor. Root arrays and scalar values cannot be converted to `json2`.
+- `json2`: [JSON2](/user-guide/logs/json2.md) type. The field may be missing or `null`. A non-null value must be a JSON object, including an empty object, such as one produced by the [`json_parse`](#json_parse) processor. Root arrays and scalar values cannot be converted to `json2`.
 
 If a field obtains an illegal value during the transformation process, the Pipeline will throw an exception. For example, when converting a string `abc` to an integer, an exception will be thrown because the string is not a valid integer.
 

--- a/docs/reference/sql/data-types.md
+++ b/docs/reference/sql/data-types.md
@@ -1,6 +1,6 @@
 ---
-keywords: [SQL data types, SQL column types, SQL syntax, SQL examples, SQL type compatibility]
-description: Provides an overview of SQL data types supported by GreptimeDB, including string, binary, numeric, decimal, date and time, interval, JSON, and boolean types, with examples and compatibility with MySQL and PostgreSQL.
+keywords: [SQL data types, SQL column types, SQL syntax, SQL examples, SQL type compatibility, JSON2]
+description: Provides an overview of SQL data types supported by GreptimeDB, including string, binary, numeric, decimal, date and time, interval, JSON, JSON2, and boolean types, with examples and compatibility with MySQL and PostgreSQL.
 ---
 
 # Data Types
@@ -282,6 +282,16 @@ Output:
 | GreptimeDB                                        |
 +---------------------------------------------------+
 ```
+
+## JSON2 Type (Beta)
+
+`JSON2` stores fields from JSON objects in a structured, columnar layout while
+preserving fields with dynamic schemas. It is intended for frequently queried
+logs and other semi-structured data. JSON2 columns currently require an
+append-only table, and each non-NULL root value must be a JSON object.
+
+For table syntax, type hints, path access, array subscripts, storage settings,
+and current limitations, see the [JSON2 type documentation](/user-guide/logs/json2.md).
 
 
 ## Boolean Type

--- a/docs/reference/sql/functions/json.md
+++ b/docs/reference/sql/functions/json.md
@@ -1,5 +1,5 @@
 ---
-keywords: [JSON functions, JSON conversion, JSON extraction, JSON validation, SQL functions]
+keywords: [JSON functions, JSON2, JSON conversion, JSON extraction, JSON validation, SQL functions]
 description: Lists and describes JSON functions available in GreptimeDB, including their usage and examples.
 ---
 
@@ -49,6 +49,10 @@ Extracts values with specific types from JSON values through specific paths.
 * `json_object_keys(json)` to return the outermost keys of a JSON object as a string list. Returns `[]` for an empty object and `NULL` for non-object JSON values or `NULL` input.
 
 The `path` argument to `json_get` must be a string literal. The return value is NULL when the path does not select a value or the selected value cannot be converted to the requested type.
+
+`json_to_string`, `json_get`, `json_get_string`, `json_get_int`,
+`json_get_float`, and `json_get_bool` also accept
+[JSON2](/user-guide/logs/json2.md) columns.
 
 `path` is a string that selects elements from a JSON value. The following path operators are supported:
 

--- a/docs/user-guide/logs/json2.md
+++ b/docs/user-guide/logs/json2.md
@@ -41,8 +41,11 @@ CREATE TABLE application_logs (
 
 ### Insert JSON data
 
-When writing to a JSON2 column, you can insert a JSON object. The following data
-includes one successful request, one slow request, and one failed request:
+When writing to a JSON2 column, you can insert a JSON object, including an empty
+object (`{}`). SQL `NULL` and an omitted JSON2 column are also accepted and are
+distinct from an empty object. Root arrays, scalar JSON values, and the JSON
+literal `null` are not supported. The following data includes one successful
+request, one slow request, and one failed request:
 
 ```sql
 INSERT INTO application_logs
@@ -99,6 +102,14 @@ The query result is:
 | 1970-01-01 00:00:00.001 | checkout | 8f3a1c | Alice | 200 | 42.8 | NULL |
 | 1970-01-01 00:00:00.002 | checkout | 8f3a1d | Bob | 200 | 386.4 | NULL |
 | 1970-01-01 00:00:00.003 | checkout | 8f3a1e | NULL | 500 | 71.2 | true |
+
+You can also select the complete JSON2 value:
+
+```sql
+SELECT ts, attrs
+FROM application_logs
+ORDER BY ts;
+```
 
 You can also use JSON functions and cast the return type explicitly:
 
@@ -226,12 +237,18 @@ FROM application_logs
 WHERE json_get(attrs, 'http.status')::BIGINT >= 500;
 ```
 
+The typed extraction functions `json_get_string`, `json_get_int`,
+`json_get_float`, and `json_get_bool` also accept JSON2 values. See
+[JSON functions](/reference/sql/functions/json.md#extraction) for details.
+
 ### Dot syntax
 
-You can read JSON2 subpaths directly with dot syntax:
+You can read JSON2 subpaths directly with dot syntax and use zero-based
+subscripts to access array elements:
 
 ```sql
 json_column.path.to.field
+json_column.path[0].field
 ```
 
 Dot syntax can be used in `SELECT`, `WHERE`, `GROUP BY`, and other SQL clauses
@@ -241,27 +258,66 @@ that accept expressions. For example:
 SELECT
     attrs.trace_id,
     attrs.http.status,
-    attrs.latency_ms
+    attrs.latency_ms,
+    attrs.items[0].name
 FROM application_logs
 WHERE attrs.http.status >= 500;
 ```
 
-## Roadmap
+A missing path, an out-of-range subscript, or a type mismatch returns `NULL`.
 
-JSON2 is currently in Beta and still has the following limitations. Future
-releases will continue to improve these capabilities:
+### Use paths in SQL functions
 
-- Support JSON2 in non-append-only tables.
-- Support writing non-object or empty-object JSON root values such as arrays,
-  strings, numbers, booleans, `null`, and `{}`.
-- Support querying the JSON2 root column itself. For now, query specific
-  subpaths such as `attrs.http.status` or `json_get(attrs, 'http.status')`.
-- Support subscript access to elements inside JSON arrays. For now, you can
-  query `attrs.items`, but not `attrs.items[0]` or `json_get(attrs, 'items[0]')`.
-- Support functions such as `json_get_string`, `json_get_int`,
-  `json_get_float`, and `json_get_bool` for JSON2.
-- Extend supported type hint data types, such as time-related types like
-  `TIMESTAMP`.
-- Support index options such as `INVERTED INDEX` and `SKIPPING INDEX` for type
-  hints.
-- Support writing JSON2 through OTLP without a custom pipeline.
+JSON2 paths can be passed directly to scalar, aggregate, and window functions.
+GreptimeDB infers the SQL type expected by the function and converts compatible
+values. Values that cannot be converted to the expected type return `NULL`.
+
+```sql
+SELECT ABS(attrs.latency_ms) AS latency_ms
+FROM application_logs;
+
+SELECT SUM(attrs.latency_ms) AS total_latency_ms
+FROM application_logs;
+
+SELECT LAG(attrs.latency_ms) OVER (ORDER BY ts) AS previous_latency_ms
+FROM application_logs;
+```
+
+Add an explicit cast when the surrounding expression does not provide the type
+you need, for example `attrs.latency_ms::DOUBLE`.
+
+### Control automatic path expansion
+
+JSON2 automatically stores up to 100 unhinted leaf paths as structured columns.
+Use `max_auto_expanded_paths` to change this limit:
+
+```sql
+CREATE TABLE application_logs (
+    ts TIMESTAMP TIME INDEX,
+    attrs JSON2 (
+        max_auto_expanded_paths = 20,
+        trace_id STRING
+    )
+) WITH (
+    'append_mode' = 'true'
+);
+```
+
+Set the option to `0` to disable automatic expansion. Type-hinted paths do not
+count against this limit. Fields beyond the limit remain in a special
+`remainder` field and can still be queried, so the option controls storage
+layout and performance, not the logical JSON schema.
+
+<AnchorAlias id="roadmap" />
+
+## Current limitations
+
+JSON2 is currently in Beta and has the following limitations:
+
+- JSON2 columns can only be used in append-only tables.
+- The JSON root must be an object. Root arrays, strings, numbers, booleans, and
+  the JSON literal `null` are not supported.
+- Type hints support only the types listed above and cannot traverse arrays.
+- Structured expansion and type hint paths support at most 50 nested path
+  segments. Deeper unhinted values remain queryable in the special `remainder`
+  field.

--- a/docs/user-guide/logs/json2.md
+++ b/docs/user-guide/logs/json2.md
@@ -55,21 +55,21 @@ VALUES
         'checkout',
         'INFO',
         'request completed',
-        '{"trace_id":"8f3a1c","user":{"id":1001,"name":"Alice"},"http":{"method":"POST","path":"/v1/orders","status":200},"latency_ms":42.8}'
+        '{"trace_id":"8f3a1c","user":{"id":1001,"name":"Alice"},"http":{"method":"POST","path":"/v1/orders","status":200},"items":[{"name":"book"}],"latency_ms":42.8}'
     ),
     (
         2,
         'checkout',
         'WARN',
         'slow request',
-        '{"trace_id":"8f3a1d","user":{"id":1002,"name":"Bob"},"http":{"method":"POST","path":"/v1/orders","status":200},"latency_ms":386.4}'
+        '{"trace_id":"8f3a1d","user":{"id":1002,"name":"Bob"},"http":{"method":"POST","path":"/v1/orders","status":200},"items":[{"name":"pen"}],"latency_ms":386.4}'
     ),
     (
         3,
         'checkout',
         'ERROR',
         'request failed',
-        '{"trace_id":"8f3a1e","user":{"id":1003},"http":{"method":"POST","path":"/v1/orders","status":500},"latency_ms":71.2,"error":true}'
+        '{"trace_id":"8f3a1e","user":{"id":1003},"http":{"method":"POST","path":"/v1/orders","status":500},"items":[{"name":"notebook"}],"latency_ms":71.2,"error":true}'
     );
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/pipeline/pipeline-config.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/pipeline/pipeline-config.md
@@ -1082,7 +1082,7 @@ GreptimeDB 目前内置了以下几种转换类型：
 - `time`: 时间类型。将被转换为 GreptimeDB `timestamp(9)` 类型。
 - `epoch`: 时间戳类型。将被转换为 GreptimeDB `timestamp(n)` 类型。n 为时间戳精度，n 的值视 epoch 精度而定。当精度为 `s` 时，n 为 0；当精度为 `ms` 时，n 为 3；当精度为 `us` 时，n 为 6；当精度为 `ns` 时，n 为 9。
 - `json`: JSON 类型。字段值必须是 JSON 对象或数组（例如由 [`json_parse`](#json_parse) 处理器生成），将被存储为表中的 JSON 列。标量值（例如字符串、数字）无法转换为 `json` 类型。
-- `json2`: [JSON2](/user-guide/logs/json2.md) 类型。字段可以不存在或为 `null`；存在且非 `null` 时，字段值必须是非空 JSON 对象（例如由 [`json_parse`](#json_parse) 处理器生成）。以数组为 root 的 JSON 和标量值无法转换为 `json2`。
+- `json2`: [JSON2](/user-guide/logs/json2.md) 类型。字段可以不存在或为 `null`；存在且非 `null` 时，字段值必须是 JSON 对象，包括空对象（例如由 [`json_parse`](#json_parse) 处理器生成）。以数组为 root 的 JSON 和标量值无法转换为 `json2`。
 
 如果字段在转换过程中获得了非法值，Pipeline 将会抛出异常。例如将一个字符串 `abc` 转换为整数时，由于该字符串不是一个合法的整数，Pipeline 将会抛出异常。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/data-types.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/data-types.md
@@ -1,6 +1,6 @@
 ---
-keywords: [SQL 数据类型, 字符串类型, 数值类型, 日期和时间类型, 布尔类型, JSON 类型]
-description: SQL 数据类型定义了列可以存储的数据类型，包括字符串、二进制、数值、日期和时间、布尔和 JSON 类型。
+keywords: [SQL 数据类型, 字符串类型, 数值类型, 日期和时间类型, 布尔类型, JSON 类型, JSON2]
+description: SQL 数据类型定义了列可以存储的数据类型，包括字符串、二进制、数值、日期和时间、布尔、JSON 和 JSON2 类型。
 ---
 
 # 数据类型
@@ -285,6 +285,12 @@ SELECT json_get_string(my_json, '$.name') as name FROM json_data;
 | GreptimeDB                                        |
 +---------------------------------------------------+
 ```
+
+## JSON2 类型（Beta）
+
+`JSON2` 将 JSON object 中的字段以结构化列式布局存储，同时保留动态 schema 的字段，适合需要频繁查询的日志和其他半结构化数据。JSON2 列目前只能用于 append-only 表，且每个非 `NULL` root 值都必须是 JSON object。
+
+建表语法、type hint、路径访问、array 下标、存储配置和当前限制请参考 [JSON2 类型文档](/user-guide/logs/json2.md)。
 
 
 ## 布尔类型

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/functions/json.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/functions/json.md
@@ -1,5 +1,5 @@
 ---
-keywords: [JSON函数, 数据转换, SQL 查询, 数据库 JSON, JSON 操作]
+keywords: [JSON函数, JSON2, 数据转换, SQL 查询, 数据库 JSON, JSON 操作]
 description: 列出了 GreptimeDB 中的所有 JSON 函数，包括函数的定义、使用方法和相关的 SQL 查询示例。
 ---
 
@@ -49,6 +49,8 @@ SELECT json_to_string(json_object('host', 'web-1', 'cpu', 0.42, 'healthy', true)
 * `json_object_keys(json)` 返回 JSON 对象最外层的所有键，并以字符串列表的形式返回。空对象返回 `[]`，非对象 JSON 值或 `NULL` 输入返回 `NULL`。
 
 `json_get` 的 `path` 参数必须是字符串字面量。路径未选中值或选中的值无法转换为目标类型时返回 NULL。
+
+`json_to_string`、`json_get`、`json_get_string`、`json_get_int`、`json_get_float` 和 `json_get_bool` 也支持 [JSON2](/user-guide/logs/json2.md) 列。
 
 `path` 是一个用于从 JSON 值中选择和提取元素的字符串。`path` 中支持的操作符有：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/json2.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/json2.md
@@ -45,21 +45,21 @@ VALUES
         'checkout',
         'INFO',
         'request completed',
-        '{"trace_id":"8f3a1c","user":{"id":1001,"name":"Alice"},"http":{"method":"POST","path":"/v1/orders","status":200},"latency_ms":42.8}'
+        '{"trace_id":"8f3a1c","user":{"id":1001,"name":"Alice"},"http":{"method":"POST","path":"/v1/orders","status":200},"items":[{"name":"book"}],"latency_ms":42.8}'
     ),
     (
         2,
         'checkout',
         'WARN',
         'slow request',
-        '{"trace_id":"8f3a1d","user":{"id":1002,"name":"Bob"},"http":{"method":"POST","path":"/v1/orders","status":200},"latency_ms":386.4}'
+        '{"trace_id":"8f3a1d","user":{"id":1002,"name":"Bob"},"http":{"method":"POST","path":"/v1/orders","status":200},"items":[{"name":"pen"}],"latency_ms":386.4}'
     ),
     (
         3,
         'checkout',
         'ERROR',
         'request failed',
-        '{"trace_id":"8f3a1e","user":{"id":1003},"http":{"method":"POST","path":"/v1/orders","status":500},"latency_ms":71.2,"error":true}'
+        '{"trace_id":"8f3a1e","user":{"id":1003},"http":{"method":"POST","path":"/v1/orders","status":500},"items":[{"name":"notebook"}],"latency_ms":71.2,"error":true}'
     );
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/json2.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/logs/json2.md
@@ -35,7 +35,7 @@ CREATE TABLE application_logs (
 
 ### 写入 JSON 数据
 
-写入 JSON2 列时，可以写入 JSON object。下面的数据包含一次成功请求、一次慢请求和一次失败请求：
+写入 JSON2 列时，可以写入 JSON object，包括空对象（`{}`）。SQL `NULL` 和省略 JSON2 列也可以正常写入，且两者与空对象的语义不同。目前不支持以 array、标量 JSON 值或 JSON literal `null` 作为 root。下面的数据包含一次成功请求、一次慢请求和一次失败请求：
 
 ```sql
 INSERT INTO application_logs
@@ -90,6 +90,14 @@ ORDER BY ts;
 | 1970-01-01 00:00:00.001 | checkout | 8f3a1c | Alice | 200 | 42.8 | NULL |
 | 1970-01-01 00:00:00.002 | checkout | 8f3a1d | Bob | 200 | 386.4 | NULL |
 | 1970-01-01 00:00:00.003 | checkout | 8f3a1e | NULL | 500 | 71.2 | true |
+
+也可以直接查询完整的 JSON2 值：
+
+```sql
+SELECT ts, attrs
+FROM application_logs
+ORDER BY ts;
+```
 
 也可以使用 JSON 函数直接指定返回类型：
 
@@ -205,12 +213,15 @@ FROM application_logs
 WHERE json_get(attrs, 'http.status')::BIGINT >= 500;
 ```
 
+类型明确的提取函数 `json_get_string`、`json_get_int`、`json_get_float` 和 `json_get_bool` 也支持 JSON2 值。详细说明请参考 [JSON 函数](/reference/sql/functions/json.md#提取)。
+
 ### 点号语法
 
-可以直接通过点号语法读取 JSON2 中的子路径：
+可以直接通过点号语法读取 JSON2 中的子路径，并通过从 0 开始的下标访问 array 元素：
 
 ```sql
 json_column.path.to.field
+json_column.path[0].field
 ```
 
 点号语法可以用于 `SELECT`、`WHERE`、`GROUP BY` 等接受表达式的 SQL 子句。例如：
@@ -219,20 +230,56 @@ json_column.path.to.field
 SELECT
     attrs.trace_id,
     attrs.http.status,
-    attrs.latency_ms
+    attrs.latency_ms,
+    attrs.items[0].name
 FROM application_logs
 WHERE attrs.http.status >= 500;
 ```
 
-## 未来规划
+路径不存在、下标越界或类型不匹配时返回 `NULL`。
 
-JSON2 目前处于 Beta 阶段，仍有以下限制。后续版本会继续完善相关能力：
+### 在 SQL 函数中使用路径
 
-- 支持在非 append-only 表中使用 JSON2。
-- 支持写入 array、string、number、boolean、`null` 和 `{}` 等非 object 或空 object 的 JSON root 值。
-- 支持查询 JSON2 root 列本身。目前请查询具体子路径，例如 `attrs.http.status` 或 `json_get(attrs, 'http.status')`。
-- 支持通过下标访问 JSON array 中的元素。目前可以查询 `attrs.items`，但暂不支持 `attrs.items[0]` 或 `json_get(attrs, 'items[0]')`。
-- 支持 `json_get_string`、`json_get_int`、`json_get_float` 和 `json_get_bool` 等函数处理 JSON2 类型。
-- 扩展 type hint 支持的类型，例如 `TIMESTAMP` 等时间类型。
-- 为 type hint 支持 `INVERTED INDEX`、`SKIPPING INDEX` 等索引选项。
-- 支持在不使用自定义 pipeline 的情况下通过 OTLP 写入 JSON2。
+JSON2 路径可以直接传给 scalar、aggregate 和 window function。GreptimeDB 会根据函数期望的 SQL 类型转换兼容的值；无法转换为期望类型的值返回 `NULL`。
+
+```sql
+SELECT ABS(attrs.latency_ms) AS latency_ms
+FROM application_logs;
+
+SELECT SUM(attrs.latency_ms) AS total_latency_ms
+FROM application_logs;
+
+SELECT LAG(attrs.latency_ms) OVER (ORDER BY ts) AS previous_latency_ms
+FROM application_logs;
+```
+
+如果上下文无法提供所需类型，可以显式转换，例如 `attrs.latency_ms::DOUBLE`。
+
+### 控制路径自动展开
+
+JSON2 默认最多将 100 个未声明 type hint 的 leaf path 自动存储为结构化列。可以通过 `max_auto_expanded_paths` 调整这一数量：
+
+```sql
+CREATE TABLE application_logs (
+    ts TIMESTAMP TIME INDEX,
+    attrs JSON2 (
+        max_auto_expanded_paths = 20,
+        trace_id STRING
+    )
+) WITH (
+    'append_mode' = 'true'
+);
+```
+
+将该选项设为 `0` 可以关闭自动展开。声明了 type hint 的路径不占用这一数量。超出限制的字段仍会保留在特殊的 `remainder` 字段中并可正常查询，因此该选项控制的是存储布局和性能，而不是 JSON 的逻辑 schema。
+
+<AnchorAlias id="未来规划" />
+
+## 当前限制
+
+JSON2 目前处于 Beta 阶段，存在以下限制：
+
+- JSON2 列只能用于 append-only 表。
+- JSON root 必须是 object，不支持以 array、string、number、boolean 或 JSON literal `null` 作为 root。
+- Type hint 仅支持上文列出的类型，且路径不能穿过 array。
+- 结构化展开和 type hint path 最多支持 50 层嵌套。更深且未声明 type hint 的值仍保留在特殊的 `remainder` 字段中并可查询。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/sql/data-types.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/sql/data-types.md
@@ -1,6 +1,6 @@
 ---
-keywords: [SQL 数据类型, 字符串类型, 数值类型, 日期和时间类型, 布尔类型, JSON 类型]
-description: SQL 数据类型定义了列可以存储的数据类型，包括字符串、二进制、数值、日期和时间、布尔和 JSON 类型。
+keywords: [SQL 数据类型, 字符串类型, 数值类型, 日期和时间类型, 布尔类型, JSON 类型, JSON2]
+description: SQL 数据类型定义了列可以存储的数据类型，包括字符串、二进制、数值、日期和时间、布尔、JSON 和 JSON2 类型。
 ---
 
 # 数据类型
@@ -285,6 +285,12 @@ SELECT json_get_string(my_json, '$.name') as name FROM json_data;
 | GreptimeDB                                        |
 +---------------------------------------------------+
 ```
+
+## JSON2 类型（Beta）
+
+`JSON2` 将 JSON object 中的字段以结构化列式布局存储，同时保留动态 schema 的字段，适合需要频繁查询的日志和其他半结构化数据。JSON2 列只能用于 append-only 表，且每个非 `NULL` root 值都必须是非空 JSON object。
+
+建表语法、type hint、路径访问、存储配置和当前限制请参考 [JSON2 类型文档](/user-guide/logs/json2.md)。
 
 
 ## 布尔类型

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/sql/functions/json.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/sql/functions/json.md
@@ -1,5 +1,5 @@
 ---
-keywords: [JSON函数, 数据转换, SQL 查询, 数据库 JSON, JSON 操作]
+keywords: [JSON函数, JSON2, 数据转换, SQL 查询, 数据库 JSON, JSON 操作]
 description: 列出了 GreptimeDB 中的所有 JSON 函数，包括函数的定义、使用方法和相关的 SQL 查询示例。
 ---
 
@@ -40,6 +40,8 @@ SELECT json_to_string(parse_json('{"a": 1, "b": 2}'));
 * `json_get(json, path)` 以字符串形式提取值。要提取为其他 SQL 标量类型，可转换函数结果，例如 `json_get(value, 'a')::INT`。
 
 `json_get` 的 `path` 参数必须是字符串字面量。路径未选中值或选中的值无法转换为目标类型时返回 NULL。
+
+`json_to_string`、`json_get`、`json_get_string`、`json_get_int`、`json_get_float` 和 `json_get_bool` 也支持 [JSON2](/user-guide/logs/json2.md) 列。
 
 `path` 是一个用于从 JSON 值中选择和提取元素的字符串。`path` 中支持的操作符有：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/logs/json2.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/logs/json2.md
@@ -88,6 +88,14 @@ ORDER BY ts;
 | 1970-01-01 00:00:00.002 | checkout | 8f3a1d | Bob | 200 | 386.4 | NULL |
 | 1970-01-01 00:00:00.003 | checkout | 8f3a1e | NULL | 500 | 71.2 | true |
 
+也可以直接查询完整的 JSON2 值：
+
+```sql
+SELECT ts, attrs
+FROM application_logs
+ORDER BY ts;
+```
+
 也可以使用 JSON 函数直接指定返回类型：
 
 ```sql
@@ -202,6 +210,8 @@ FROM application_logs
 WHERE json_get(attrs, 'http.status')::BIGINT >= 500;
 ```
 
+类型明确的提取函数 `json_get_string`、`json_get_int`、`json_get_float` 和 `json_get_bool` 也支持 JSON2 值。详细说明请参考 [JSON 函数](/reference/sql/functions/json.md#提取)。
+
 ### 点号语法
 
 可以直接通过点号语法读取 JSON2 中的子路径：
@@ -221,15 +231,32 @@ FROM application_logs
 WHERE attrs.http.status >= 500;
 ```
 
-## 未来规划
+### 控制路径自动展开
 
-JSON2 目前处于 Beta 阶段，仍有以下限制。后续版本会继续完善相关能力：
+JSON2 默认会将类型兼容且未声明 type hint 的 leaf path 自动展开为结构化列。可以通过 `max_auto_expanded_paths` 限制展开的路径数量：
 
-- 支持在非 append-only 表中使用 JSON2。
-- 支持写入 array、string、number、boolean、`null` 和 `{}` 等非 object 或空 object 的 JSON root 值。
-- 支持查询 JSON2 root 列本身。目前请查询具体子路径，例如 `attrs.http.status` 或 `json_get(attrs, 'http.status')`。
-- 支持通过下标访问 JSON array 中的元素。目前可以查询 `attrs.items`，但暂不支持 `attrs.items[0]` 或 `json_get(attrs, 'items[0]')`。
-- 支持 `json_get_string`、`json_get_int`、`json_get_float` 和 `json_get_bool` 等函数处理 JSON2 类型。
-- 扩展 type hint 支持的类型，例如 `TIMESTAMP` 等时间类型。
-- 为 type hint 支持 `INVERTED INDEX`、`SKIPPING INDEX` 等索引选项。
-- 支持通过 OTLP 和其他 ingestion path 写入 JSON2。
+```sql
+CREATE TABLE application_logs (
+    ts TIMESTAMP TIME INDEX,
+    attrs JSON2 (
+        max_auto_expanded_paths = 20,
+        trace_id STRING
+    )
+) WITH (
+    'append_mode' = 'true'
+);
+```
+
+将该选项设为 `0` 可以关闭自动展开。声明了 type hint 的路径不占用这一数量。超出限制的字段仍会保留在特殊的 `remainder` 字段中并可正常查询，因此该选项控制的是存储布局和性能，而不是 JSON 的逻辑 schema。
+
+<AnchorAlias id="未来规划" />
+
+## 当前限制
+
+JSON2 目前处于 Beta 阶段，存在以下限制：
+
+- JSON2 列只能用于 append-only 表。
+- 每个非 `NULL` JSON root 必须是非空 object，不支持以 array、string、number、boolean、JSON literal `null` 或空 object 作为 root。
+- 无法使用下标语法访问 array 元素。
+- Type hint 仅支持上文列出的类型，且路径不能穿过 array。
+- 结构化展开和 type hint path 最多支持 50 层嵌套。更深且未声明 type hint 的值仍保留在特殊的 `remainder` 字段中并可查询。

--- a/versioned_docs/version-1.2/reference/sql/data-types.md
+++ b/versioned_docs/version-1.2/reference/sql/data-types.md
@@ -1,6 +1,6 @@
 ---
-keywords: [SQL data types, SQL column types, SQL syntax, SQL examples, SQL type compatibility]
-description: Provides an overview of SQL data types supported by GreptimeDB, including string, binary, numeric, decimal, date and time, interval, JSON, and boolean types, with examples and compatibility with MySQL and PostgreSQL.
+keywords: [SQL data types, SQL column types, SQL syntax, SQL examples, SQL type compatibility, JSON2]
+description: Provides an overview of SQL data types supported by GreptimeDB, including string, binary, numeric, decimal, date and time, interval, JSON, JSON2, and boolean types, with examples and compatibility with MySQL and PostgreSQL.
 ---
 
 # Data Types
@@ -282,6 +282,16 @@ Output:
 | GreptimeDB                                        |
 +---------------------------------------------------+
 ```
+
+## JSON2 Type (Beta)
+
+`JSON2` stores fields from JSON objects in a structured, columnar layout while
+preserving fields with dynamic schemas. It is intended for frequently queried
+logs and other semi-structured data. JSON2 columns require an append-only
+table, and each non-NULL root value must be a non-empty JSON object.
+
+For table syntax, type hints, path access, storage settings, and current
+limitations, see the [JSON2 type documentation](/user-guide/logs/json2.md).
 
 
 ## Boolean Type

--- a/versioned_docs/version-1.2/reference/sql/functions/json.md
+++ b/versioned_docs/version-1.2/reference/sql/functions/json.md
@@ -1,5 +1,5 @@
 ---
-keywords: [JSON functions, JSON conversion, JSON extraction, JSON validation, SQL functions]
+keywords: [JSON functions, JSON2, JSON conversion, JSON extraction, JSON validation, SQL functions]
 description: Lists and describes JSON functions available in GreptimeDB, including their usage and examples.
 ---
 
@@ -40,6 +40,10 @@ Extracts values with specific types from JSON values through specific paths.
 * `json_get(json, path)` to extract a value as a string. Cast the function result to extract a scalar with another SQL type, for example `json_get(value, 'a')::INT`.
 
 The `path` argument to `json_get` must be a string literal. The return value is NULL when the path does not select a value or the selected value cannot be converted to the requested type.
+
+`json_to_string`, `json_get`, `json_get_string`, `json_get_int`,
+`json_get_float`, and `json_get_bool` also accept
+[JSON2](/user-guide/logs/json2.md) columns.
 
 `path` is a string that selects elements from a JSON value. The following path operators are supported:
 

--- a/versioned_docs/version-1.2/user-guide/logs/json2.md
+++ b/versioned_docs/version-1.2/user-guide/logs/json2.md
@@ -95,6 +95,14 @@ The query result is:
 | 1970-01-01 00:00:00.002 | checkout | 8f3a1d | Bob | 200 | 386.4 | NULL |
 | 1970-01-01 00:00:00.003 | checkout | 8f3a1e | NULL | 500 | 71.2 | true |
 
+You can also select the complete JSON2 value:
+
+```sql
+SELECT ts, attrs
+FROM application_logs
+ORDER BY ts;
+```
+
 You can also use JSON functions and cast the return type explicitly:
 
 ```sql
@@ -221,6 +229,10 @@ FROM application_logs
 WHERE json_get(attrs, 'http.status')::BIGINT >= 500;
 ```
 
+The typed extraction functions `json_get_string`, `json_get_int`,
+`json_get_float`, and `json_get_bool` also accept JSON2 values. See
+[JSON functions](/reference/sql/functions/json.md#extraction) for details.
+
 ### Dot syntax
 
 You can read JSON2 subpaths directly with dot syntax:
@@ -241,22 +253,40 @@ FROM application_logs
 WHERE attrs.http.status >= 500;
 ```
 
-## Roadmap
+### Control automatic path expansion
 
-JSON2 is currently in Beta and still has the following limitations. Future
-releases will continue to improve these capabilities:
+By default, JSON2 expands compatible unhinted leaf paths into structured
+columns. Use `max_auto_expanded_paths` to limit how many paths are expanded:
 
-- Support JSON2 in non-append-only tables.
-- Support writing non-object or empty-object JSON root values such as arrays,
-  strings, numbers, booleans, `null`, and `{}`.
-- Support querying the JSON2 root column itself. For now, query specific
-  subpaths such as `attrs.http.status` or `json_get(attrs, 'http.status')`.
-- Support subscript access to elements inside JSON arrays. For now, you can
-  query `attrs.items`, but not `attrs.items[0]` or `json_get(attrs, 'items[0]')`.
-- Support functions such as `json_get_string`, `json_get_int`,
-  `json_get_float`, and `json_get_bool` for JSON2.
-- Extend supported type hint data types, such as time-related types like
-  `TIMESTAMP`.
-- Support index options such as `INVERTED INDEX` and `SKIPPING INDEX` for type
-  hints.
-- Support writing JSON2 through OTLP and other ingestion paths.
+```sql
+CREATE TABLE application_logs (
+    ts TIMESTAMP TIME INDEX,
+    attrs JSON2 (
+        max_auto_expanded_paths = 20,
+        trace_id STRING
+    )
+) WITH (
+    'append_mode' = 'true'
+);
+```
+
+Set the option to `0` to disable automatic expansion. Type-hinted paths do not
+count against this limit. Fields beyond the limit remain in a special
+`remainder` field and can still be queried, so the option controls storage
+layout and performance, not the logical JSON schema.
+
+<AnchorAlias id="roadmap" />
+
+## Current limitations
+
+JSON2 is currently in Beta and has the following limitations:
+
+- JSON2 columns can only be used in append-only tables.
+- Each non-NULL JSON root must be a non-empty object. Root arrays, strings,
+  numbers, booleans, the JSON literal `null`, and empty objects are not
+  supported.
+- Array elements cannot be accessed with subscript syntax.
+- Type hints support only the types listed above and cannot traverse arrays.
+- Structured expansion and type hint paths support at most 50 nested path
+  segments. Deeper unhinted values remain queryable in the special `remainder`
+  field.


### PR DESCRIPTION
## What changed

- Update the Nightly JSON2 guide for empty objects, whole-value queries, array subscripts, SQL function type inference, automatic path expansion, and current limitations.
- Update the 1.2 guide only for capabilities available on the release/v1.2 branch, retaining its array-subscript and non-empty-root limitations.
- Document JSON2 support in the SQL data type and JSON function references, and correct the Nightly pipeline description.
- Keep English and Chinese documentation aligned and preserve the previous Roadmap anchors.

## Scope

- Documentation versions: Nightly, 1.2
- Languages: English, Chinese

## Verification

- git diff --check
- pnpm build
- DOC_LANG=zh pnpm build
- DOC_LANG=en pnpm check:links
- DOC_LANG=zh pnpm check:links

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] I updated navigation when the document structure changed.