### PR TITLE
docs: complete v1.2 feature documentation

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/faq-and-others/faq.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/faq-and-others/faq.md
@@ -87,7 +87,7 @@ GreptimeDB 使用三种语义列类型：**Tag**、**Timestamp** 和 **Field**�
    ALTER TABLE my_table SET 'ttl' = '7d';
    ALTER TABLE my_table SET 'append_mode' = 'true';
    ```
-   注意 `merge_mode` 和 `skip_wal` 不支持建表后修改，必须在建表时指定。所有支持的选项和约束参见 [ALTER TABLE](/reference/sql/alter.md#修改表的参数)。
+   `merge_mode` 不支持建表后修改，必须在建表时指定。`skip_wal` 仅支持通过 `ALTER TABLE` 在建表后从 `false` 改为 `true`；该修改是单向的，不能撤销或执行 `UNSET`。它只能单独设置在 Mito 或 Metric 引擎的物理表上，Metric 引擎逻辑表和其他引擎的表均不支持。所有支持的选项和约束参见 [ALTER TABLE](/reference/sql/alter.md#修改表的参数)。
 
 3. **设置数据库级别的默认选项**：创建或修改数据库时指定默认选项，后续自动创建的表会继承这些值：
    ```sql

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/sql/admin.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/sql/admin.md
@@ -1,6 +1,6 @@
 ---
-keywords: [管理函数, ADMIN 语句, SQL ADMIN, 数据库管理, 表管理, 数据管理, 构建索引]
-description: ADMIN 语句用于运行管理函数来管理数据库和数据。
+keywords: [管理函数, ADMIN 语句, SQL ADMIN, 数据库管理, 表管理, 数据管理, 丢弃未刷盘数据, 构建索引]
+description: ADMIN 语句用于运行管理函数，包括刷盘、丢弃未刷盘数据、压缩和构建索引等数据库管理操作。
 ---
 
 # ADMIN
@@ -17,6 +17,7 @@ GreptimeDB 提供了一些管理函数来管理数据库和数据：
 
 * `flush_table(table_name)` 根据表名将表的 Memtable 刷新到 SST 文件中。
 * `flush_region(region_id)` 根据 Region ID 将 Region 的 Memtable 刷新到 SST 文件中。通过 [PARTITIONS](./information-schema/partitions.md) 表查找 Region ID。
+* `discard_unflushed(table_name_or_region_id)` 永久丢弃表中所有物理 Region 或指定 Region 的未刷盘数据。
 * `compact_table(table_name, [type], [options])` 为表启动一个 compaction 任务，详细信息请阅读 [compaction](/user-guide/deployments-administration/manage-data/compaction.md#严格窗口压缩策略swcs和手动压缩)。
 * `compact_region(region_id)` 为 Region 启动一个 compaction 任务。
 * `build_index(table_name)` 在新增或修改索引定义后，为表已有的 SST 文件补建缺失的物理索引。
@@ -34,6 +35,12 @@ GreptimeDB 提供了一些管理函数来管理数据库和数据：
 ```sql
 -- 刷新表 test --
 admin flush_table("test");
+
+-- 丢弃表 test 所有物理 Region 中的未刷盘数据 --
+admin discard_unflushed("test");
+
+-- 丢弃指定 Region 中的未刷盘数据 --
+admin discard_unflushed(4398046511104);
 
 -- 为表 test 启动 compaction 任务，默认并行度为 1 --
 admin compact_table("test");
@@ -71,6 +78,31 @@ admin gc_regions(1, 2, 3, true);
 -- 永久 purge 一个 soft-dropped table --
 admin purge_table("test");
 ```
+
+## 丢弃未刷盘数据
+
+当 Memtable 中的数据导致 flush 反复失败、写缓冲区被占满并阻塞后续写入时，可以使用 `admin discard_unflushed` 进行紧急恢复。
+
+:::danger 危险操作
+
+该操作会永久删除目标 Region 中尚未持久化到 SST 文件的所有数据，并将对应的 WAL 条目标记为过期，因此重启 Datanode 也无法恢复这些数据。已经持久化到 SST 文件的数据不受影响。
+
+:::
+
+该函数只接受一个表名或 Region ID：
+
+```sql
+ADMIN discard_unflushed('table_name');
+ADMIN discard_unflushed(region_id);
+```
+
+使用表名时，该操作会作用于表的所有物理 Region。表名可以是未限定名、schema 限定名或完整限定名；省略的限定部分将根据当前查询上下文解析。
+
+使用数值类型的 Region ID 时，该操作只作用于指定 Region。可以查询 [`information_schema.PARTITIONS`](./information-schema/partitions.md) 表获取 Region ID。
+
+Metric Engine 逻辑表不支持该操作，因为多个逻辑表共享相同的物理 Region。使用 Metric Engine 物理表名或物理 Region ID 会丢弃其逻辑表共享的未刷盘数据，因此请仔细确认操作目标。
+
+该函数只能通过 `ADMIN` 语句调用，在 `SELECT` 语句中调用会被拒绝。如果目标中已没有未刷盘数据，重复执行该操作是安全的，不会产生影响。
 
 ## 构建索引
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/sql/admin.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/sql/admin.md
@@ -36,12 +36,6 @@ GreptimeDB 提供了一些管理函数来管理数据库和数据：
 -- 刷新表 test --
 admin flush_table("test");
 
--- 丢弃表 test 所有物理 Region 中的未刷盘数据 --
-admin discard_unflushed("test");
-
--- 丢弃指定 Region 中的未刷盘数据 --
-admin discard_unflushed(4398046511104);
-
 -- 为表 test 启动 compaction 任务，默认并行度为 1 --
 admin compact_table("test");
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/sql/alter.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/sql/alter.md
@@ -195,6 +195,7 @@ ALTER TABLE monitor MODIFY COLUMN load_15 DROP DEFAULT;
 - `sst_format`: 表的 SST 格式。值可以是 `flat` 或 `primary_key`。表支持双向格式转换：`primary_key` 转换为 `flat`，以及 `flat` 转换为 `primary_key`。
 - `write_buffer_size`: 表的单 region 写缓冲区阻塞阈值。设置为 `512MB` 等正值后，mutable memtable 内存用量达到该值的一半时，GreptimeDB 会调度 flush；达到该值时会阻塞写入，达到该值的 2 倍时会拒绝写入。该表选项会覆盖 `region_engine.mito.default_region_write_buffer_size`。即使引擎默认值非零，显式设置为 `0` 也会禁用单 region 限制。取消设置会移除表级覆盖，并回退到引擎默认值。
 - `auto_flush_interval`: 该表的 region 最长多久没有 flush 就触发一次 flush。值是一个[时间范围字符串](/reference/time-durations.md)，必须大于 0。该表选项会覆盖引擎级的 `region_engine.mito.auto_flush_interval`。
+- `skip_wal`：是否为该表禁用预写日志（WAL）。设置为 `'true'` 后，写入不会持久化到 WAL，可以提升写入吞吐；但进程重启时，所有尚未 flush 的数据都可能丢失。仅当数据源本身能够确保可靠性时使用此选项。该修改是单向的：可以将 `skip_wal` 从 `false` 改为 `true`，但不能改回 `false` 或执行 `UNSET`。`ALTER TABLE` 只能单独设置 `skip_wal`，不能与其他表选项组合。该表必须是使用 Mito 或 Metric 引擎的物理表；Metric 引擎逻辑表和其他引擎均不支持。
 - `max_row_group_row_count`: Parquet row group 的最大行数。取值必须在 `1` 到 `10485760`（`10 * 1024 * 1024`）之间，设置为零会被拒绝。修改或取消该选项时，GreptimeDB 会先使用旧的 row group 大小 flush 尚未落盘的数据，再应用新值。新值，或取消设置后的默认值 `102400`（`100 * 1024`），会应用于后续生成的 SST。ALTER 操作不会立即重写已有 SST；后续 compaction 可能会使用当前的 row group 大小重写这些 SST。
 
 ```sql
@@ -215,6 +216,8 @@ ALTER TABLE monitor SET 'sst_format'='primary_key';
 ALTER TABLE monitor SET 'write_buffer_size'='512MB';
 
 ALTER TABLE monitor SET 'auto_flush_interval'='5m';
+
+ALTER TABLE monitor SET 'skip_wal'='true';
 
 ALTER TABLE monitor SET 'max_row_group_row_count'='2048';
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/sql/information-schema/flows.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/sql/information-schema/flows.md
@@ -38,3 +38,44 @@ DESC TABLE INFORMATION_SCHEMA.FLOWS;
 * `sink_table_name`: Flow 任务的目标表名称。
 * `flownode_ids`: Flow 任务使用的 flownode id。
 * `options`: Flow 任务的其他额外选项。
+## Flow 运行时统计信息
+
+`information_schema.flow_statistics` 表提供 Flow 任务的运行时统计信息。
+`SHOW FLOW STATUS` 是该表的便捷查询方式，并支持对 `flow_name` 使用可选的
+`LIKE` 过滤条件。
+
+```sql
+DESC TABLE INFORMATION_SCHEMA.FLOW_STATISTICS;
+```
+
+```text
++---------------------+----------------------+-----+------+---------+---------------+
+| Column              | Type                 | Key | Null | Default | Semantic Type |
++---------------------+----------------------+-----+------+---------+---------------+
+| flow_id             | UInt32               |     | NO   |         | FIELD         |
+| flow_name           | String               |     | NO   |         | FIELD         |
+| start_time          | TimestampMillisecond |     | YES  |         | FIELD         |
+| last_execution_time | TimestampMillisecond |     | YES  |         | FIELD         |
+| uptime_seconds      | Int64                |     | YES  |         | FIELD         |
+| state_size          | UInt64               |     | YES  |         | FIELD         |
++---------------------+----------------------+-----+------+---------+---------------+
+6 rows in set (0.00 sec)
+```
+
+各列含义如下：
+
+- `flow_id`：Flow 任务的唯一 ID。
+- `flow_name`：Flow 任务的名称。
+- `start_time`：Flow 首次执行的时间。
+- `last_execution_time`：最近一次执行的时间。
+- `uptime_seconds`：自 `start_time` 起经过的时间，单位为秒。
+- `state_size`：内存中状态的大小，单位为字节，可作为内存使用量的参考。
+
+```sql
+SHOW FLOW STATUS;
+SHOW FLOW STATUS LIKE 'orders%';
+```
+
+在 standalone 模式下，如果相应的运行时数据可用，六列都会填充。在分布式模式下，
+v1.2 的跨节点 FlowStat heartbeat 不包含 start-time 信息，因此
+`start_time` 和 `uptime_seconds` 不可用，会返回 SQL `NULL`。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/configuration.md
@@ -206,6 +206,9 @@ HTTP 协议配置适用于所有 GreptimeDB 组件：`frontend`、`datanode`、`
 addr = "127.0.0.1:4000"
 timeout = "0s"
 body_limit = "64MB"
+# 实验性：启用 Prometheus Remote Write v2 native histogram 写入。
+# 默认禁用。
+experimental_enable_prometheus_native_histogram = false
 enable_cors = true
 # cors_allowed_origins = ["https://example.com"]  # Optional: customize allowed origins
 experimental_enable_explain_analyze_stream = true
@@ -267,7 +270,7 @@ trace_ingest_chunk_size = 512
 enable = true
 with_metric_engine = true
 prom_validation_mode = "strict"
-experimental_enable_prometheus_native_histogram = false
+
 pending_rows_flush_interval = "0s"
 max_batch_rows = 100000
 max_concurrent_flushes = 256
@@ -283,6 +286,7 @@ max_inflight_requests = 3000
 |            | addr               | 字符串 | 服务器地址，默认为 "127.0.0.1:4000"                          |
 |            | timeout            | 字符串 | HTTP 请求超时时间。设为 "0s" 可禁用超时（默认值为 "0s"）。启用 Prometheus Remote Write [批量写入模式](/user-guide/ingest-data/for-observability/prometheus.md#批量写入模式) 时，非零且不超过 `prom_store.pending_rows_flush_interval` 加 1 秒的超时值会被自动调整为该值。                              |
 |            | body_limit         | 字符串 | HTTP 最大体积大小，默认为 "64MB"                             |
+|            | experimental_enable_prometheus_native_histogram | 布尔值 | 实验性：启用 Prometheus Remote Write v2 native histogram 写入。该选项默认禁用；设置为 `true` 后才会接受 native histogram。 |
 |            | enable_cors        | 布尔值 | 是否启用 HTTP CORS 支持，默认为 true。 |
 |            | cors_allowed_origins | 数组 | 自定义 HTTP CORS 允许的来源。 |
 |            | experimental_enable_explain_analyze_stream | 布尔值 | 实验性：启用 `POST /v1/sql/analyze/stream`，用于流式返回 `EXPLAIN ANALYZE VERBOSE` 指标，默认为 true。 |
@@ -313,7 +317,6 @@ max_inflight_requests = 3000
 |            | enable                       | 布尔值 | 是否在 HTTP API 中启用 Prometheus 远程读写，默认为 true                                                                                                                                                         |
 |            | with_metric_engine           | 布尔值 | 是否在 Prometheus 远程写入中使用 Metric Engine，默认为 true                                                                                                                                                     |
 |            | prom_validation_mode     | 字符串 | 在 Prometheus Remote Write 协议中是否检查字符串是否为有效的 UTF-8 字符串。可用选项：`strict`（拒绝任何包含无效 UTF-8 字符串的请求），`lossy`（用 [UTF-8 REPLACEMENT CHARACTER](https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-23/#G24272)（即 `�` ） 替换无效字符），`unchecked`（不验证字符串有效性）。 |
-|            | experimental_enable_prometheus_native_histogram | 布尔值 | 实验性：启用 Prometheus remote write v2 native histogram 写入，默认为 false。 |
 |            | pending_rows_flush_interval  | 字符串 | Prometheus Remote Write 批量刷写的时间间隔。设为非零值（如 `500ms`）以启用[批量写入模式](/user-guide/ingest-data/for-observability/prometheus.md#批量写入模式)，默认为 `0s`（禁用）                         |
 |            | max_batch_rows               | 整数   | 触发刷写的最大批量行数，默认为 100000                                                                                                                                                                           |
 |            | max_concurrent_flushes       | 整数   | 同时执行的最大刷写操作数量，默认为 256                                                                                                                                                                          |
@@ -532,10 +535,16 @@ create_database, alter_database, drop_database,
 create_flow, drop_flow,
 create_table, create_logical_tables, alter_table, alter_logical_tables,
 drop_table, undrop_table, purge_dropped_table, truncate_table,
-create_view, drop_view
+create_view, drop_view, admin_function
 ```
 
 `undrop_table` 和 `purge_dropped_table` 仅 GreptimeDB 企业版支持。
+
+在分布式部署中，Frontend 支持以下事件类型：
+
+```text
+admin_function
+```
 
 Metasrv 支持以下事件类型：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/monitoring/events/event-data-model.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/monitoring/events/event-data-model.md
@@ -12,7 +12,16 @@ description: 了解 GreptimeDB events 表的数据模型。
 | `type`          | 事件类型，例如 `create_table` 或 `region_migration`。 |
 | `timestamp`     | 记录该行的时间。                                      |
 | `payload`       | 与事件类型相关的 JSON 数据。                          |
+| `actor`         | 记录为操作发起人的数据库用户；事件没有关联用户请求时为 SQL `NULL`。 |
 | `event_context` | 有上下文时，用于描述事件触发原因的 JSON。             |
+
+## 事件发起人（actor） {#actor}
+
+`actor` 是 GreptimeDB 记录的操作发起数据库用户，可用于查找谁执行了
+`ADMIN` 语句或提交了 Procedure。当操作启动 Procedure 时，该 Procedure 及其子
+Procedure 在整个生命周期中保留相同的 `actor`。没有关联用户请求的事件，其
+`actor` 为 SQL `NULL`。启用鉴权时，该字段是通过鉴权的数据库用户；未启用鉴权时，
+它不能用于确认实际发送请求的用户。
 
 ## Procedure 事件列
 
@@ -45,6 +54,19 @@ Procedure 事件还有以下列：
 | `RollingBack`    | 开始回滚 Procedure。                                                                                                                                                |
 | `Failed`         | Procedure 到达失败终态。请检查 `procedure_error` 中的失败详情。                                                                                                     |
 | `Poisoned`       | Procedure 无法继续。请检查 `procedure_error` 中的失败详情。                                                                                                         |
+
+## ADMIN 函数事件列
+
+`admin_function` 事件记录 `ADMIN` 语句返回的结果。
+
+| 列                       | 含义                                                                                         |
+| ------------------------ | -------------------------------------------------------------------------------------------- |
+| `admin_function_name`    | 执行的 ADMIN 函数名称。                                                                      |
+| `admin_function_status`  | 执行状态：`Succeeded` 或 `Failed`。                                                          |
+| `admin_function_output`  | JSON 数据。函数成功时包含 `result`，函数失败时包含 `error`。                                 |
+
+事件的 `payload` 包含函数参数。如果返回结果是 Procedure ID，可使用该 ID 查询相关
+Procedure 事件以查看执行进度。
 
 ## 查询 JSON 字段
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/ingest-data/for-observability/prometheus.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/ingest-data/for-observability/prometheus.md
@@ -24,6 +24,9 @@ remote_write:
 #    username: greptime_user
 #    password: greptime_pwd
 
+# Prometheus 默认发送 v1 protobuf 消息。如需选择 Remote Write v2，请显式设置：
+#  protobuf_message: io.prometheus.write.v2.Request
+
 remote_read:
 - url: http://localhost:4000/v1/prometheus/read?db=public
 # 如果启用了身份验证，请取消注释并设置鉴权信息
@@ -35,6 +38,7 @@ remote_read:
 - URL 中的 host 和 port 表示 GreptimeDB 服务器。在此示例中，服务器运行在 `localhost:4000` 上。你可以将其替换为你自己的服务器地址。有关 GreptimeDB 中 HTTP 协议的配置，请参阅 [协议选项](/user-guide/deployments-administration/configuration.md#protocol-options)。
 - URL 中的 `db` 参数表示要写入的数据库。它是可选的。默认情况下，数据库设置为 `public`。
 - `basic_auth` 是身份鉴权配置。如果 GreptimeDB 启用了鉴权，请填写用户名和密码。请参阅 [鉴权认证文档](/user-guide/deployments-administration/authentication/overview.md)。
+- Remote Write v2 的 native histogram 写入是实验性功能，默认禁用。如需启用，请在 `[http]` 配置中设置 `experimental_enable_prometheus_native_histogram = true`；详见[配置参考](/user-guide/deployments-administration/configuration.md#protocol-options)。
 
 ### Grafana Alloy 配置文件
 

--- a/versioned_docs/version-1.2/faq-and-others/faq.md
+++ b/versioned_docs/version-1.2/faq-and-others/faq.md
@@ -87,7 +87,7 @@ There are three ways to control table options such as `ttl`, `append_mode`, `mer
    ALTER TABLE my_table SET 'ttl' = '7d';
    ALTER TABLE my_table SET 'append_mode' = 'true';
    ```
-   Note that `merge_mode` and `skip_wal` cannot be altered after creation — they must be set at table creation time. See [ALTER TABLE](/reference/sql/alter.md#alter-table-options) for all supported options and constraints.
+   `merge_mode` cannot be altered after creation and must be set when the table is created. `skip_wal` can be changed after creation only from `false` to `true` with `ALTER TABLE`; this is a one-way change and cannot be reverted or unset. It can only be set by itself on physical Mito or Metric tables, not on Metric logical tables or tables using other engines. See [ALTER TABLE](/reference/sql/alter.md#alter-table-options) for all supported options and constraints.
 
 3. **Set database-level defaults**: Create or alter the database with default options. New auto-created tables will inherit these values:
    ```sql

--- a/versioned_docs/version-1.2/reference/sql/admin.md
+++ b/versioned_docs/version-1.2/reference/sql/admin.md
@@ -1,6 +1,6 @@
 ---
-keywords: [ADMIN statement, SQL, administration functions, flush table, compact table, build index, migrate region, gc table, gc regions]
-description: Describes the `ADMIN` statement used to run administration functions, including examples for flushing tables, scheduling compactions, building indexes, migrating regions, querying procedure states, and garbage collecting orphaned files.
+keywords: [ADMIN statement, SQL, administration functions, flush table, discard unflushed data, compact table, build index, migrate region, gc table, gc regions]
+description: Describes the `ADMIN` statement used to run administration functions, including examples for flushing tables, discarding unflushed data, scheduling compactions, building indexes, migrating regions, querying procedure states, and garbage collecting orphaned files.
 ---
 
 # ADMIN
@@ -18,6 +18,7 @@ GreptimeDB provides some administration functions to manage the database and dat
 
 * `flush_table(table_name)` to flush a table's memtables into SST file by table name.
 * `flush_region(region_id)` to flush a region's memtables into SST file by region id. Find the region id through [PARTITIONS](./information-schema/partitions.md) table.
+* `discard_unflushed(table_name_or_region_id)` to permanently discard unflushed data from every physical region of a table or from one region.
 * `compact_table(table_name, [type], [options])` to schedule a compaction task for a table by table name, read [compaction](/user-guide/deployments-administration/manage-data/compaction.md#strict-window-compaction-strategy-swcs-and-manual-compaction) for more details.
 * `compact_region(region_id)` to schedule a compaction task for a region by region id.
 * `build_index(table_name)` to build missing physical indexes for a table's existing SST files after adding or changing index definitions.
@@ -35,6 +36,12 @@ For example:
 ```sql
 -- Flush the table test --
 admin flush_table("test");
+
+-- Discard unflushed data from all physical regions of table test --
+admin discard_unflushed("test");
+
+-- Discard unflushed data from one region --
+admin discard_unflushed(4398046511104);
 
 -- Schedule a compaction for table test with default parallelism (1) --
 admin compact_table("test");
@@ -72,6 +79,31 @@ admin gc_regions(1, 2, 3, true);
 -- Permanently purge a soft-dropped table --
 admin purge_table("test");
 ```
+
+## Discard Unflushed Data
+
+Use `admin discard_unflushed` as an emergency recovery operation when data in a Memtable repeatedly prevents flushing, fills the write buffer, and blocks further writes.
+
+:::danger
+
+This operation permanently deletes all data in the target regions that has not been persisted to SST files. It also makes the corresponding WAL entries obsolete, so restarting a Datanode does not restore the discarded data. Data already persisted in SST files remains available.
+
+:::
+
+The function takes exactly one table name or Region ID:
+
+```sql
+ADMIN discard_unflushed('table_name');
+ADMIN discard_unflushed(region_id);
+```
+
+A table name targets all physical regions of the table. It can be unqualified, schema-qualified, or fully qualified; omitted qualifiers are resolved from the current query context.
+
+A numeric Region ID targets only that Region. Query the [`information_schema.PARTITIONS`](./information-schema/partitions.md) table to find Region IDs.
+
+Metric Engine logical tables are not supported because multiple logical tables share the same physical regions. Using a physical Metric Engine table name or physical Region ID discards unflushed data shared by its logical tables, so verify the target carefully.
+
+This function is available only through the `ADMIN` statement. Calling it in a `SELECT` statement is rejected. Repeating the same operation when no unflushed data remains is safe and has no effect.
 
 ## Build Index
 

--- a/versioned_docs/version-1.2/reference/sql/admin.md
+++ b/versioned_docs/version-1.2/reference/sql/admin.md
@@ -37,12 +37,6 @@ For example:
 -- Flush the table test --
 admin flush_table("test");
 
--- Discard unflushed data from all physical regions of table test --
-admin discard_unflushed("test");
-
--- Discard unflushed data from one region --
-admin discard_unflushed(4398046511104);
-
 -- Schedule a compaction for table test with default parallelism (1) --
 admin compact_table("test");
 

--- a/versioned_docs/version-1.2/reference/sql/alter.md
+++ b/versioned_docs/version-1.2/reference/sql/alter.md
@@ -195,6 +195,7 @@ Currently following options are supported:
 - `sst_format`: the SST format of the table. The value can be `flat` or `primary_key`. A table supports changing the format in both directions: `primary_key` to `flat` and `flat` to `primary_key`.
 - `write_buffer_size`: the per-region write buffer stall threshold of the table. For a positive value such as `512MB`, GreptimeDB schedules a flush when mutable memtable usage reaches half the value, stalls writes at the value, and rejects writes at twice the value. The table option overrides `region_engine.mito.default_region_write_buffer_size`. Setting it to `0` explicitly disables the per-region limit even when the engine default is nonzero. Unsetting it removes the table override and falls back to the engine default.
 - `auto_flush_interval`: how long a region of this table may go without a flush before one is triggered. The value is a [time duration string](/reference/time-durations.md) and must be greater than zero. The table option overrides the engine-wide `region_engine.mito.auto_flush_interval`.
+- `skip_wal`: whether to disable Write-Ahead-Log for this table. When set to `'true'`, writes are not persisted to the WAL, which can improve write throughput, but any unflushed data can be lost when the process restarts. Use this only when the data source can ensure reliability. This change is one-way: you can change `skip_wal` from `false` to `true`, but you cannot change it back to `false` or unset it. `ALTER TABLE` can set `skip_wal` only by itself; it cannot be combined with other table options. The table must be a physical table using the Mito or Metric engine. Metric engine logical tables and other engines are not supported.
 - `max_row_group_row_count`: the maximum number of rows in a Parquet row group. The value must be from `1` through `10485760` (`10 * 1024 * 1024`); zero is rejected. Changing or unsetting this option flushes pending rows using the old row group size before applying the new value. The new value, or the default of `102400` (`100 * 1024`) after unsetting, applies to subsequently produced SSTs. The ALTER operation does not immediately rewrite existing SSTs; later compactions may rewrite them using the current row group size.
 
 ```sql
@@ -215,6 +216,8 @@ ALTER TABLE monitor SET 'sst_format'='primary_key';
 ALTER TABLE monitor SET 'write_buffer_size'='512MB';
 
 ALTER TABLE monitor SET 'auto_flush_interval'='5m';
+
+ALTER TABLE monitor SET 'skip_wal'='true';
 
 ALTER TABLE monitor SET 'max_row_group_row_count'='2048';
 ```

--- a/versioned_docs/version-1.2/reference/sql/information-schema/flows.md
+++ b/versioned_docs/version-1.2/reference/sql/information-schema/flows.md
@@ -38,3 +38,46 @@ The columns in table:
 * `sink_table_name`: the sink table name of the flow task.
 * `flownode_ids`: the flownode ids used by the flow task.
 * `options`: extra options of the flow task.
+## Flow runtime statistics
+
+The `information_schema.flow_statistics` table provides runtime statistics for
+Flow tasks. `SHOW FLOW STATUS` is a convenient equivalent view and supports an
+optional `LIKE` filter on `flow_name`.
+
+```sql
+DESC TABLE INFORMATION_SCHEMA.FLOW_STATISTICS;
+```
+
+```text
++---------------------+----------------------+-----+------+---------+---------------+
+| Column              | Type                 | Key | Null | Default | Semantic Type |
++---------------------+----------------------+-----+------+---------+---------------+
+| flow_id             | UInt32               |     | NO   |         | FIELD         |
+| flow_name           | String               |     | NO   |         | FIELD         |
+| start_time          | TimestampMillisecond |     | YES  |         | FIELD         |
+| last_execution_time | TimestampMillisecond |     | YES  |         | FIELD         |
+| uptime_seconds      | Int64                |     | YES  |         | FIELD         |
+| state_size          | UInt64               |     | YES  |         | FIELD         |
++---------------------+----------------------+-----+------+---------+---------------+
+6 rows in set (0.00 sec)
+```
+
+The columns are:
+
+- `flow_id`: The unique ID of the Flow task.
+- `flow_name`: The name of the Flow task.
+- `start_time`: The time when the Flow first executed.
+- `last_execution_time`: The time of the last execution.
+- `uptime_seconds`: The elapsed time since `start_time`, in seconds.
+- `state_size`: The in-memory state size, in bytes, as a proxy for memory usage.
+
+```sql
+SHOW FLOW STATUS;
+SHOW FLOW STATUS LIKE 'orders%';
+```
+
+In standalone mode, all six columns are populated when their corresponding
+runtime data is available. In distributed mode, `start_time` and
+`uptime_seconds` are not available in v1.2 because the cross-node FlowStat
+heartbeat does not carry start-time information; these columns return SQL
+`NULL`.

--- a/versioned_docs/version-1.2/user-guide/deployments-administration/configuration.md
+++ b/versioned_docs/version-1.2/user-guide/deployments-administration/configuration.md
@@ -207,6 +207,9 @@ Note that HTTP and gRPC protocols cannot be disabled for the database to functio
 addr = "127.0.0.1:4000"
 timeout = "0s"
 body_limit = "64MB"
+# Experimental: enable Prometheus Remote Write v2 native histogram ingestion.
+# Disabled by default.
+experimental_enable_prometheus_native_histogram = false
 enable_cors = true
 # cors_allowed_origins = ["https://example.com"]  # Optional: customize allowed origins
 experimental_enable_explain_analyze_stream = true
@@ -268,7 +271,7 @@ trace_ingest_chunk_size = 512
 enable = true
 with_metric_engine = true
 prom_validation_mode = "strict"
-experimental_enable_prometheus_native_histogram = false
+
 pending_rows_flush_interval = "0s"
 max_batch_rows = 100000
 max_concurrent_flushes = 256
@@ -284,6 +287,7 @@ The following table describes the options in detail:
 |            | addr                 | String  | Server address, "127.0.0.1:4000" by default                                                                                                                                                                                                                                                                                                                                                |
 |            | timeout              | String  | HTTP request timeout. Set to `0s` to disable timeout (default: "0s"). When Prometheus Remote Write [batching mode](/user-guide/ingest-data/for-observability/prometheus.md#batching-mode) is enabled, a non-zero timeout less than or equal to `prom_store.pending_rows_flush_interval` plus 1 second is adjusted to that value.                                                                                                                                                                                                                                                                                                                                                     |
 |            | body_limit           | String  | HTTP max body size, "64MB" by default                                                                                                                                                                                                                                                                                                                                                      |
+|            | experimental_enable_prometheus_native_histogram | Boolean | Experimental: enable Prometheus Remote Write v2 native histogram ingestion. It is disabled by default; set it to `true` to accept native histograms. |
 |            | enable_cors          | Boolean | Whether to enable HTTP CORS support, true by default. |
 |            | cors_allowed_origins | Array   | Customized allowed origins for HTTP CORS. |
 |            | experimental_enable_explain_analyze_stream | Boolean | Experimental: enable `POST /v1/sql/analyze/stream` for streaming `EXPLAIN ANALYZE VERBOSE` metrics, true by default. |
@@ -314,7 +318,6 @@ The following table describes the options in detail:
 |            | enable                       | Boolean | Whether to enable Prometheus Remote Write and read in HTTP API, true by default                                                                                                                                                                                                                                                                                                            |
 |            | with_metric_engine           | Boolean | Whether to use the metric engine on Prometheus Remote Write, true by default                                                                                                                                                                                                                                                                                                               |
 |            | prom_validation_mode         | String  | Whether to check if strings are valid UTF-8 strings in Prometheus remote write requests. Available options: `strict`(reject any request with invalid UTF-8 strings), `lossy`(replace invalid characters with [UTF-8 REPLACEMENT CHARACTER U+FFFD, which looks like �](https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-23/#G24272)), `unchecked`(do not validate strings). |
-|            | experimental_enable_prometheus_native_histogram | Boolean | Experimental: enable Prometheus remote write v2 native histogram ingestion, false by default. |
 |            | pending_rows_flush_interval  | String  | Interval between batch flushes for Prometheus Remote Write. Set to a non-zero duration (e.g. `500ms`) to enable [batching mode](/user-guide/ingest-data/for-observability/prometheus.md#batching-mode). `0s` by default (disabled)                                                                                                                                                     |
 |            | max_batch_rows               | Integer | Maximum number of rows per batch before a flush is triggered, 100000 by default                                                                                                                                                                                                                                                                                                            |
 |            | max_concurrent_flushes       | Integer | Maximum number of concurrent flush operations, 256 by default                                                                                                                                                                                                                                                                                                                              |
@@ -530,10 +533,16 @@ create_database, alter_database, drop_database,
 create_flow, drop_flow,
 create_table, create_logical_tables, alter_table, alter_logical_tables,
 drop_table, undrop_table, purge_dropped_table, truncate_table,
-create_view, drop_view
+create_view, drop_view, admin_function
 ```
 
 `undrop_table` and `purge_dropped_table` require GreptimeDB Enterprise.
+
+In distributed deployments, the Frontend supports the following event type:
+
+```text
+admin_function
+```
 
 Metasrv supports the following event types:
 

--- a/versioned_docs/version-1.2/user-guide/deployments-administration/monitoring/events/event-data-model.md
+++ b/versioned_docs/version-1.2/user-guide/deployments-administration/monitoring/events/event-data-model.md
@@ -12,7 +12,18 @@ description: Understand the GreptimeDB events table data model.
 | `type`          | Event type, such as `create_table` or `region_migration`.   |
 | `timestamp`     | Time at which the row was recorded.                         |
 | `payload`       | JSON data for the event type.                               |
+| `actor`         | Database user recorded as the operation's initiator; SQL `NULL` when the event is not associated with a user request. |
 | `event_context` | JSON describing why the event was triggered when available. |
+
+## Event actor {#actor}
+
+The `actor` is the database user recorded as the initiator of an operation. Use
+it to identify who ran an `ADMIN` statement or submitted a Procedure. When an
+operation starts a Procedure, the Procedure and its child Procedures keep the
+same `actor` throughout their lifecycle. Events not associated with a user
+request have a SQL `NULL` actor. When authentication is enabled, this is the
+authenticated database user; without authentication, it does not verify who
+sent the request.
 
 ## Procedure event columns
 
@@ -49,6 +60,19 @@ not guaranteed to appear in the order shown:
 | `RollingBack`    | Procedure rollback is starting.                                                                                                                                                          |
 | `Failed`         | The Procedure reached a failed terminal state. Inspect `procedure_error` for failure details.                                                                                            |
 | `Poisoned`       | The Procedure cannot proceed. Inspect `procedure_error` for the failure details.                                                                                                         |
+
+## ADMIN function event columns
+
+An `admin_function` event records the result returned by an `ADMIN` statement.
+
+| Column                   | Meaning                                                                                         |
+| ------------------------ | ----------------------------------------------------------------------------------------------- |
+| `admin_function_name`    | The name of the executed ADMIN function.                                                        |
+| `admin_function_status`  | The execution status: `Succeeded` or `Failed`.                                                  |
+| `admin_function_output`  | JSON containing `result` when the function succeeds or `error` when it fails.                  |
+
+The event `payload` contains the function arguments. If the result is a
+Procedure ID, use it to query the related Procedure events and monitor progress.
 
 ## Query JSON fields
 

--- a/versioned_docs/version-1.2/user-guide/ingest-data/for-observability/prometheus.md
+++ b/versioned_docs/version-1.2/user-guide/ingest-data/for-observability/prometheus.md
@@ -23,6 +23,10 @@ remote_write:
 #    username: greptime_user
 #    password: greptime_pwd
 
+# Prometheus sends the v1 protobuf message by default. To select Remote Write
+# v2, set protobuf_message explicitly:
+#  protobuf_message: io.prometheus.write.v2.Request
+
 remote_read:
 - url: http://localhost:4000/v1/prometheus/read?db=public
 # Uncomment and set credentials if authentication is enabled
@@ -34,6 +38,7 @@ remote_read:
 - The host and port in the URL represent the GreptimeDB server. In this example, the server is running on `localhost:4000`. You can replace it with your own server address. For the HTTP protocol configuration in GreptimeDB, please refer to the [protocol options](/user-guide/deployments-administration/configuration.md#protocol-options).
 - The `db` parameter in the URL represents the database to which we want to write data. It is optional. By default, the database is set to `public`.
 - `basic_auth` is the authentication configuration. Fill in the username and password if GreptimeDB authentication is enabled. Please refer to the [authentication document](/user-guide/deployments-administration/authentication/overview.md).
+- Remote Write v2 native histogram ingestion is experimental and disabled by default. To enable it, set `experimental_enable_prometheus_native_histogram = true` in the `[http]` configuration; this option is documented in the [configuration reference](/user-guide/deployments-administration/configuration.md#protocol-options).
 
 ### Grafana Alloy configuration file
 


### PR DESCRIPTION
## What changed

Complete missing GreptimeDB v1.2 English and Chinese documentation for behavior already present on `release/v1.2`:

- document `ADMIN discard_unflushed` and its destructive semantics;
- document one-way `ALTER TABLE ... SET 'skip_wal'='true'` and correct the contradictory FAQ;
- document `SHOW FLOW STATUS` and `information_schema.flow_statistics`;
- document event `actor` and `admin_function` fields and configuration;
- document Prometheus Remote Write v2 and the experimental native-histogram switch.

The content was checked against GreptimeDB `release/v1.2` at `c42f595225fc0c327d82983b45041364daafece6`. This PR intentionally does not change Nightly/current or any other version.

Related release tracking: GreptimeTeam/greptimedb#9015.

## Scope

- Documentation versions: 1.2 only
- Languages: English and Chinese

## Verification

- `git diff --check upstream/main`
- `pnpm build`
- `DOC_LANG=en pnpm check:links`
- `DOC_LANG=zh pnpm build`
- `DOC_LANG=zh pnpm check:links`
- Verified that every changed path is under the English or Chinese `version-1.2` tree.
- Verified that `pnpm-lock.yaml` is unchanged.
- Independent content review: approved after correcting configuration placement and Flow schema/semantics.

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] Navigation was not changed because no document structure changed.
