### PR TITLE
docs: document parquetbench usage

### DIFF
--- a/docs/reference/command-lines/datanode.md
+++ b/docs/reference/command-lines/datanode.md
@@ -169,7 +169,7 @@ greptime datanode scanbench --config ./datanode.toml --region-id 1024:0 --table-
 
 ## parquetbench
 
-The `parquetbench` subcommand benchmarks reads from a single GreptimeDB Parquet SST, either a local file or a file in the object store configured for a datanode or standalone deployment. It is available in normal builds and does not require the `dev-tools` feature.
+The `parquetbench` subcommand benchmarks reads from a single GreptimeDB Parquet SST, either a local file or a file in the object store configured for a datanode or standalone deployment.
 
 The file must contain GreptimeDB region metadata. A general Parquet file without this metadata cannot be benchmarked with this command.
 

--- a/docs/reference/command-lines/datanode.md
+++ b/docs/reference/command-lines/datanode.md
@@ -166,3 +166,97 @@ Example `scanconfig.json`:
 ```sh
 greptime datanode scanbench --config ./datanode.toml --region-id 1024:0 --table-dir greptime/public/1024 --iterations 5 --pprof-file ./scanbench.svg --pprof-after-warmup
 ```
+
+## parquetbench
+
+The `parquetbench` subcommand benchmarks reads from a single GreptimeDB Parquet SST, either a local file or a file in the object store configured for a datanode or standalone deployment. It is available in normal builds and does not require the `dev-tools` feature.
+
+The file must contain GreptimeDB region metadata. A general Parquet file without this metadata cannot be benchmarked with this command.
+
+### Options
+
+Print the options supported by the current binary:
+
+```sh
+greptime datanode parquetbench --help
+```
+
+| Option | Description |
+| --- | --- |
+| `--file-path <FILE>` | Local GreptimeDB SST file. Supports only the `direct` reader. |
+| `--config <FILE>` | Datanode/standalone TOML configuration for object-store access. Required in region mode. |
+| `--region-id <REGION_ID>` | Region ID as a packed unsigned integer or `<table_id>:<region_number>`, for example `1024:0`. Required in region mode. |
+| `--table-dir <TABLE_DIR>` | Table directory relative to data home, for example `data/greptime/public/1024`. Required in region mode. |
+| `--file-id <FILE_ID>` | SST file UUID. Required in region mode. |
+| `--reader <direct\|flat-prune>` | Reader implementation. Defaults to `direct`. `flat-prune` uses the storage engine's flat pruning reader and is available only in region mode. |
+| `--path-type <bare\|data\|metadata>` | Region path type in region mode. Defaults to `bare`. |
+| `--scan-config <FILE>` | JSON file selecting columns and row groups. |
+| `--iterations <N>` | Number of benchmark iterations. Defaults to `1`. |
+| `--batch-size <ROWS>` | Rows per record batch for the `direct` reader. Must be positive; defaults to `8192`. |
+| `--pk-as-binary` | Read `__primary_key` as binary rather than a dictionary array with the `direct` reader. Disabled by default. |
+| `--pprof-file <FILE>` | Output SVG flamegraph path (Unix only). |
+| `--pprof-after-warmup` | Start profiling after the first iteration. Use with `--pprof-file` and at least two iterations. Disabled by default. |
+| `-v`/`--verbose` | Enable verbose output. |
+
+Local-file mode cannot be combined with `--config`, `--region-id`, `--table-dir`, or `--file-id`. Without `--file-path`, all four region-mode arguments are required.
+
+### Benchmark a local SST
+
+```sh
+greptime datanode parquetbench \
+  --file-path /tmp/source.parquet \
+  --reader direct \
+  --iterations 5 \
+  --batch-size 8192
+```
+
+The command reports row and record-batch counts, elapsed time, and throughput for each iteration. When running multiple iterations, it also reports averages.
+
+### Benchmark an SST in object storage
+
+```sh
+greptime datanode parquetbench \
+  --config ./datanode.toml \
+  --region-id 1024:0 \
+  --table-dir data/greptime/public/1024 \
+  --file-id 00020380-009c-426d-953e-b4e34c15af34 \
+  --path-type bare \
+  --reader flat-prune \
+  --iterations 5
+```
+
+Use the configuration, region ID, table directory, file ID, and path type that correspond to the SST you want to benchmark.
+
+### Select columns and row groups
+
+Save the following as `parquet-scan.json`, adjusting the column names and row-group indexes to match the SST:
+
+```json
+{
+  "projection_names": ["host", "value", "ts"],
+  "row_groups": [0, 2]
+}
+```
+
+Both fields are optional. Omitting `projection_names` reads all columns; omitting `row_groups` reads all row groups. Row-group indexes are zero-based and must exist in the file. Column names are case-sensitive. With the `direct` reader, names refer to the SST schema; with `flat-prune`, names refer to region columns and internal column names are ignored.
+
+```sh
+greptime datanode parquetbench \
+  --file-path /tmp/source.parquet \
+  --scan-config ./parquet-scan.json \
+  --iterations 5
+```
+
+### Profile after a warmup iteration
+
+On Unix, write a flamegraph while excluding the first iteration from profiling:
+
+```sh
+greptime datanode parquetbench \
+  --file-path /tmp/source.parquet \
+  --iterations 5 \
+  --pprof-file ./parquetbench.svg \
+  --pprof-after-warmup
+```
+
+The first iteration still contributes to the reported averages.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/command-lines/datanode.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/command-lines/datanode.md
@@ -169,7 +169,7 @@ greptime datanode scanbench --config ./datanode.toml --region-id 1024:0 --table-
 
 ## parquetbench
 
-`parquetbench` 子命令用于对单个 GreptimeDB Parquet SST 文件的读取性能进行基准测试，支持本地文件和 datanode 或 standalone 配置中指定的对象存储。该命令包含在常规构建中，不需要启用 `dev-tools` feature。
+`parquetbench` 子命令用于对单个 GreptimeDB Parquet SST 文件的读取性能进行基准测试，支持本地文件和 datanode 或 standalone 配置中指定的对象存储。
 
 文件必须包含 GreptimeDB region 元数据。不含这些元数据的普通 Parquet 文件无法使用此命令进行基准测试。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/command-lines/datanode.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/command-lines/datanode.md
@@ -166,3 +166,97 @@ greptime datanode scanbench --config ./datanode.toml --region-id 1024:0 --table-
 ```sh
 greptime datanode scanbench --config ./datanode.toml --region-id 1024:0 --table-dir greptime/public/1024 --iterations 5 --pprof-file ./scanbench.svg --pprof-after-warmup
 ```
+
+## parquetbench
+
+`parquetbench` 子命令用于对单个 GreptimeDB Parquet SST 文件的读取性能进行基准测试，支持本地文件和 datanode 或 standalone 配置中指定的对象存储。该命令包含在常规构建中，不需要启用 `dev-tools` feature。
+
+文件必须包含 GreptimeDB region 元数据。不含这些元数据的普通 Parquet 文件无法使用此命令进行基准测试。
+
+### 选项
+
+查看当前二进制支持的选项：
+
+```sh
+greptime datanode parquetbench --help
+```
+
+| 选项 | 描述 |
+| --- | --- |
+| `--file-path <FILE>` | 本地 GreptimeDB SST 文件。仅支持 `direct` reader。 |
+| `--config <FILE>` | 用于访问对象存储的 datanode/standalone TOML 配置文件。region 模式下必填。 |
+| `--region-id <REGION_ID>` | Region ID，支持打包后的无符号整数或 `<table_id>:<region_number>` 格式，例如 `1024:0`。region 模式下必填。 |
+| `--table-dir <TABLE_DIR>` | 相对于 data home 的表目录，例如 `data/greptime/public/1024`。region 模式下必填。 |
+| `--file-id <FILE_ID>` | SST 文件的 UUID。region 模式下必填。 |
+| `--reader <direct\|flat-prune>` | Reader 实现，默认为 `direct`。`flat-prune` 使用存储引擎的 flat pruning reader，仅支持 region 模式。 |
+| `--path-type <bare\|data\|metadata>` | region 模式下的路径类型，默认为 `bare`。 |
+| `--scan-config <FILE>` | 用于选择列和行组的 JSON 文件。 |
+| `--iterations <N>` | 基准测试迭代次数，默认为 `1`。 |
+| `--batch-size <ROWS>` | `direct` reader 每个 record batch 的行数，必须大于零，默认为 `8192`。 |
+| `--pk-as-binary` | 使用 `direct` reader 时，将 `__primary_key` 读取为二进制数组而非字典数组。默认关闭。 |
+| `--pprof-file <FILE>` | SVG 火焰图的输出路径（仅 Unix）。 |
+| `--pprof-after-warmup` | 在第一次迭代后开始性能分析。需配合 `--pprof-file` 使用，且迭代次数至少为 2。默认关闭。 |
+| `-v`/`--verbose` | 启用详细输出。 |
+
+本地文件模式不能与 `--config`、`--region-id`、`--table-dir` 或 `--file-id` 同时使用。不指定 `--file-path` 时，必须提供这四个 region 模式参数。
+
+### 对本地 SST 进行基准测试
+
+```sh
+greptime datanode parquetbench \
+  --file-path /tmp/source.parquet \
+  --reader direct \
+  --iterations 5 \
+  --batch-size 8192
+```
+
+命令会输出每次迭代的行数、record batch 数、耗时和吞吐量。执行多次迭代时，还会输出平均值。
+
+### 对对象存储中的 SST 进行基准测试
+
+```sh
+greptime datanode parquetbench \
+  --config ./datanode.toml \
+  --region-id 1024:0 \
+  --table-dir data/greptime/public/1024 \
+  --file-id 00020380-009c-426d-953e-b4e34c15af34 \
+  --path-type bare \
+  --reader flat-prune \
+  --iterations 5
+```
+
+请使用与目标 SST 对应的配置文件、Region ID、表目录、文件 ID 和路径类型。
+
+### 选择列和行组
+
+将以下内容保存为 `parquet-scan.json`，并根据 SST 的实际内容调整列名和行组索引：
+
+```json
+{
+  "projection_names": ["host", "value", "ts"],
+  "row_groups": [0, 2]
+}
+```
+
+两个字段都是可选的。不设置 `projection_names` 时读取所有列，不设置 `row_groups` 时读取所有行组。行组索引从 0 开始，且必须在文件中存在。列名区分大小写。使用 `direct` reader 时，列名对应 SST schema 中的列；使用 `flat-prune` 时，列名对应 region 中的列，内部列名会被忽略。
+
+```sh
+greptime datanode parquetbench \
+  --file-path /tmp/source.parquet \
+  --scan-config ./parquet-scan.json \
+  --iterations 5
+```
+
+### 预热后进行性能分析
+
+在 Unix 上生成火焰图，并跳过第一次迭代的性能分析：
+
+```sh
+greptime datanode parquetbench \
+  --file-path /tmp/source.parquet \
+  --iterations 5 \
+  --pprof-file ./parquetbench.svg \
+  --pprof-after-warmup
+```
+
+第一次迭代仍计入输出的平均值。


### PR DESCRIPTION
## What changed

Add a `parquetbench` section to the Datanode CLI reference, covering local SST benchmarking with `--file-path`, object-store mode, reader and argument restrictions, column/row-group selection, and profiling after warmup. Explain that the SST must contain GreptimeDB region metadata.

This PR documents only `parquetbench` from GreptimeTeam/greptimedb#8939, as requested for this issue.

Closes #2780

## Scope

- Documentation versions: Nightly
- Languages: English, Chinese

Local-file support is not included in the existing 1.2 or older documentation releases. This extends existing pages and requires no navigation changes.

## Verification

- `DOC_LANG=en pnpm check:links` (includes the English production build)
- `DOC_LANG=zh pnpm check:links` (includes the Chinese production build)
- `git diff --check`
- Verified options, defaults, input restrictions, projection/row-group handling, and warmup behavior against upstream source.
- Parsed the JSON example and checked that English and Chinese code examples match.
- No benchmark was run against a deployment.

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] Navigation does not require an update because this extends an existing page.

