### PR TITLE
chore: update GreptimeDB documentation version to v1.2.0

### DIFF
--- a/variables/variables-1.2.ts
+++ b/variables/variables-1.2.ts
@@ -1,5 +1,5 @@
 export const variables = {
-  greptimedbVersion: 'v1.2.0-beta.2',
+  greptimedbVersion: 'v1.2.0',
   prometheusVersion: 'v2.52.0',
   nodeExporterVersion: 'v1.8.0',
   goSdkVersion: 'v0.7.2',


### PR DESCRIPTION
## What changed

Update only `variables/variables-1.2.ts`, setting `greptimedbVersion` from `v1.2.0-beta.2` to `v1.2.0` with the existing `.github/scripts/release-patch.sh 1.2.0` script.

**Merge effect: this promotes documentation version 1.2 to the default site root for both languages, removes its pre-release banner, and changes canonical/sitemap routing.** This is a proposed change only; merge timing must be coordinated with the release owner. GitHub v1.2.0 still remains Pre-release, and this PR does not change GitHub Latest.

The 1.2 versioned documentation already exists: no new-minor generator was run and no version snapshots, sidebars, or navigation files were changed.

Release notes are separate: https://github.com/GreptimeTeam/docs/pull/2839
Release: https://github.com/GreptimeTeam/greptimedb/releases/tag/v1.2.0
Tracking: https://github.com/GreptimeTeam/greptimedb/issues/9015

## Scope

- Documentation versions: shared 1.2 release variable and resulting default-version routing.
- Languages: English and Chinese.

## Verification

- `git diff --check`: passed.
- `pnpm test`: passed (39 tests in 6 files, including site-version routing tests).
- `DOC_LANG=en pnpm check:links`: passed.
- `DOC_LANG=zh pnpm check:links`: passed.
- `pnpm typecheck`: fails with missing `@docusaurus/theme-classic` and `node` type definitions in this environment. The same two errors were reproduced on the unchanged-dependency notes branch; no dependency or tsconfig changes were added to this version-only PR.
- Reviewed `resolveLastVersion` and confirmed that this variable makes 1.2 the root version. No website deployment or merge was performed locally.

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [ ] I updated navigation when the document structure changed. (Not applicable: no structural change; version routing derives from the shared variable.)
