### PR TITLE
docs: document the pipeline cache TTL option

### DIFF
--- a/docs/user-guide/deployments-administration/configuration.md
+++ b/docs/user-guide/deployments-administration/configuration.md
@@ -507,6 +507,17 @@ default_ratio = 1.0
 
 How to use distributed tracing, please reference [Tracing](/user-guide/deployments-administration/monitoring/tracing.md#tutorial-use-jaeger-to-trace-greptimedb)
 
+### Pipeline options
+
+`frontend` and `standalone` cache pipeline definitions in memory. The cache is configured in the `[pipeline]` section:
+
+```toml
+[pipeline]
+cache_ttl = "10s"
+```
+
+- `cache_ttl`: Time to live of the local pipeline cache, `10s` by default. In a cluster, a pipeline created or deleted on one Frontend takes effect on the other Frontends after at most this duration. A longer TTL reduces reads of the `greptime_private.pipelines` table and increases that delay.
+
 ### Event recording
 
 Recorded events are stored in the `greptime_private.events` system table.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/configuration.md
@@ -509,6 +509,17 @@ default_ratio = 1.0
 
 如何使用分布式追踪，请参考 [Tracing](/user-guide/deployments-administration/monitoring/tracing.md#教程使用-jaeger-追踪-greptimedb-调用链路)
 
+### Pipeline 选项
+
+frontend 和 standalone 会在内存中缓存 Pipeline 定义，缓存配置位于 `[pipeline]` 部分：
+
+```toml
+[pipeline]
+cache_ttl = "10s"
+```
+
+- `cache_ttl`：本地 Pipeline 缓存的存活时间，默认值为 `10s`。在集群中，在某个 Frontend 上创建或删除 Pipeline 后，最多经过该时间才会在其他 Frontend 上生效。调大该值会减少对 `greptime_private.pipelines` 表的读取，同时增加上述延迟。
+
 ### 事件记录配置
 
 记录的事件保存在 `greptime_private.events` 系统表中。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/configuration.md
@@ -508,6 +508,17 @@ default_ratio = 1.0
 
 如何使用分布式追踪，请参考 [Tracing](/user-guide/deployments-administration/monitoring/tracing.md#教程使用-jaeger-追踪-greptimedb-调用链路)
 
+### Pipeline 选项
+
+frontend 和 standalone 会在内存中缓存 Pipeline 定义，缓存配置位于 `[pipeline]` 部分：
+
+```toml
+[pipeline]
+cache_ttl = "10s"
+```
+
+- `cache_ttl`：本地 Pipeline 缓存的存活时间，默认值为 `10s`。在集群中，在某个 Frontend 上创建或删除 Pipeline 后，最多经过该时间才会在其他 Frontend 上生效。调大该值会减少对 `greptime_private.pipelines` 表的读取，同时增加上述延迟。
+
 ### 事件记录配置
 
 记录的事件保存在 `greptime_private.events` 系统表中。

--- a/versioned_docs/version-1.2/user-guide/deployments-administration/configuration.md
+++ b/versioned_docs/version-1.2/user-guide/deployments-administration/configuration.md
@@ -506,6 +506,17 @@ default_ratio = 1.0
 
 How to use distributed tracing, please reference [Tracing](/user-guide/deployments-administration/monitoring/tracing.md#tutorial-use-jaeger-to-trace-greptimedb)
 
+### Pipeline options
+
+`frontend` and `standalone` cache pipeline definitions in memory. The cache is configured in the `[pipeline]` section:
+
+```toml
+[pipeline]
+cache_ttl = "10s"
+```
+
+- `cache_ttl`: Time to live of the local pipeline cache, `10s` by default. In a cluster, a pipeline created or deleted on one Frontend takes effect on the other Frontends after at most this duration. A longer TTL reduces reads of the `greptime_private.pipelines` table and increases that delay.
+
 ### Event recording
 
 Recorded events are stored in the `greptime_private.events` system table.


### PR DESCRIPTION
## What changed

Document the `[pipeline] cache_ttl` option added by GreptimeTeam/greptimedb#9022 (backported to `release/v1.2` in #9023). New `Pipeline options` section in the configuration page, covering the default `10s`, that it applies to `frontend` and `standalone`, and that a pipeline created or deleted on one Frontend takes effect on the others after at most this duration.

Closes #2818

## Scope

- Documentation versions: Nightly, 1.2
- Languages: English, Chinese

## Verification

- `pnpm build`
- `DOC_LANG=zh pnpm build`
- `git diff --check`

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] I updated navigation when the document structure changed.