### PR TITLE
docs: release notes for greptimedb-enterprise 26.05.1

### DIFF
--- a/docs/enterprise/release-notes/release-26_05.md
+++ b/docs/enterprise/release-notes/release-26_05.md
@@ -1,0 +1,118 @@
+---
+keywords: [release notes, greptimedb enterprise]
+description: Release notes for the GreptimeDB Enterprise 26.05 series, highlighting scheduled compaction, Apache Iceberg data lake (early preview), multidimensional region balancing and finer-grained access control.
+---
+
+# GreptimeDB Enterprise 26.05
+
+## 26.05.1
+
+We are pleased to announce the **26.05.1** release of GreptimeDB Enterprise —
+a minor update to the 26.05 line that brings major new operational capabilities:
+scheduled compaction, an early preview of Apache Iceberg data-lake support,
+multidimensional region balancing, and finer-grained access control. This
+release also moves the GreptimeDB engine base to **v1.2**.
+
+_This release is based on GreptimeDB (open source engine) v1.2._
+
+### Feature Highlights
+
+#### Scheduled Compaction (Compaction Cronjob)
+
+Compaction can now run on a schedule managed by the meta server, instead of only
+on demand. The new compaction cronjob resolves compaction targets across regions,
+submits and tracks jobs, persists state in a KV store, and automatically cancels
+stale running jobs. A set of admin HTTP endpoints lets operators inspect and
+control scheduled compaction. This makes it straightforward to keep storage
+healthy on a predictable cadence with less manual intervention.
+
+#### Apache Iceberg Data Lake (Early Preview)
+
+This release introduces an **early preview** of Apache Iceberg data-lake
+support, beginning to cover the table lifecycle end to end:
+
+- **Repartition, truncate, and drop** for Iceberg-backed tables, with full table
+  state lifecycle management.
+- **Bulk ingestion** and region-edit hooks, plus remote-compaction hooks so
+  Iceberg data can be compacted through the enterprise compaction pipeline.
+- **Histogram data type** support and **metric-engine physical-table** support
+  for Iceberg tables.
+
+#### Multidimensional Region Balancing
+
+Region balancing now reasons about more than write load. The balancer tracks
+per-region query CPU-rate history and evaluates read-load stability with
+separate eligibility rules, and supports multidimensional balancing state.
+The result is more stable region placement under mixed read/write workloads and
+during planned maintenance.
+
+#### Finer-Grained Access Control
+
+Enterprise RBAC gains several new controls for tighter, more expressive
+authorization:
+
+- **Named permission actions** for custom roles.
+- **Regex-based database ACLs**, and automatic database-ACL grants to the user
+  who creates a database.
+- An optional **query guard** that can ban `DROP TABLE` / `DROP DATABASE` for all
+  users, protecting against accidental destructive operations.
+
+#### Table Soft Drop
+
+`DROP TABLE` can be configured to **soft drop** (opt-in): the table's data is
+retained and recoverable with `UNDROP TABLE` rather than destroyed immediately.
+Soft-dropped tables keep occupying storage until they are undropped or purged.
+
+#### Operational Improvements
+
+- Configurable **query spill** for enterprise workloads.
+- Per-component **maximum CPU** options.
+- Enterprise **Flight schemas aligned by default** for consistent wire formats,
+  and Flight **bulk inserts can now auto-create** their target tables.
+- **Ansible playbooks** for deploying GreptimeDB and a monitoring stack.
+
+#### From the GreptimeDB v1.2 Engine
+
+- **`JSON2`** — an improved data type for working with JSON, optimized for
+  columnar storage.
+- **Manual compaction with a time range**, complementing the new scheduled
+  compaction.
+- **Lifecycle event recording** — structured procedure events for
+  database/table/view DDL, Flow DDL, repartition, GC, and WAL prune, for much
+  better observability of cluster operations. Available from the Enterprise
+  Dashboard UI.
+- **Performance**: dictionary-encoded series keys for faster queries,
+  range-select input-projection pruning, and an asynchronous compaction picker
+  that no longer blocks the region worker.
+
+### Important Bug Fixes
+
+**Enterprise:**
+
+- Bulk writes now correctly validate the incoming data type for `JSONB` columns,
+  preventing malformed data from being written.
+- Ingestion merge batch sizing corrected for the v1.2 engine.
+- Remote dynamic-filter controls handled correctly; region-balancer stability
+  option names normalized.
+
+**From the GreptimeDB v1.2 engine:**
+
+- `PromQL` `or` queries no longer return incorrect results when operands are
+  empty.
+- The MySQL protocol now **fails closed** on timestamps it cannot represent,
+  instead of silently mishandling them.
+- Prometheus remote-write timeouts are now **retryable**, improving ingestion
+  resilience under transient failures.
+- **Index-build reliability**: asynchronous index builds are fenced by schema
+  generation and their publication made conditional, fixing races that could
+  occur when index builds and schema changes ran concurrently.
+- **Legacy WAL options remain compatible** when upgrading, so existing
+  configurations keep working.
+
+### Security Updates
+
+- **Dedicated HTTP API server port** — the HTTP API is now served on a dedicated
+  port, isolating the API surface from other server traffic.
+- **Sandboxed SQL local-filesystem access** — SQL execution is sandboxed so it can
+  no longer read the local filesystem, closing a local-file-access vector.
+- `quinn-proto`: 0.11.14 → 0.11.16 _(dependency update)_

--- a/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/release-notes/release-26_05.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/enterprise/release-notes/release-26_05.md
@@ -1,0 +1,78 @@
+---
+keywords: [release notes, greptimedb enterprise]
+description: GreptimeDB 企业版 26.05 系列发布说明，新功能包括定时 Compaction、Apache Iceberg 数据湖（早期预览）、多维度 Region 均衡以及更细粒度的访问控制等。
+---
+
+# GreptimeDB 企业版 26.05
+
+## 26.05.1
+
+我们很高兴地宣布 GreptimeDB 企业版 **26.05.1** 发布。这是 26.05 系列的一次更新，带来了多项重要的运维能力：定时 Compaction、Apache Iceberg 数据湖支持的早期预览、多维度 Region 均衡以及更细粒度的访问控制。此版本同时将底层的 GreptimeDB 引擎升级到 **v1.2**。
+
+_本版本基于 GreptimeDB 开源引擎 v1.2 构建。_
+
+### 特性亮点
+
+#### 定时 Compaction（Compaction Cronjob）
+
+Compaction 现在可以按照由 Metasrv 管理的调度计划定时执行，而不再只能按需手动触发。新的 compaction cronjob 会在所有 Region 中解析 compaction 目标，提交并跟踪任务，将状态持久化到 KV 存储中，并自动取消过期的仍在运行的任务。同时还提供了一组管理用的 HTTP 接口，方便运维人员查看和控制定时 compaction。这样一来，就可以按可预期的节奏维护存储健康状态，减少人工介入。
+
+#### Apache Iceberg 数据湖（早期预览）
+
+本版本引入了 Apache Iceberg 数据湖支持的**早期预览**，开始覆盖完整的表生命周期：
+
+- 支持 Iceberg 表的 **repartition、truncate 和 drop**，并管理完整的表状态生命周期。
+- 支持**批量写入（bulk ingestion）**和 region 编辑钩子，并提供远程 compaction 钩子，使 Iceberg 数据可以通过企业版的 compaction 管道进行压缩。
+- Iceberg 表支持**直方图（histogram）数据类型**以及 **Metric 引擎物理表**。
+
+#### 多维度 Region 均衡
+
+Region 均衡不再只考虑写入负载。均衡器会记录每个 Region 的查询 CPU 速率历史，并以独立的准入规则评估读负载的稳定性，同时支持多维度的均衡状态。其效果是在读写混合负载以及计划内维护期间，Region 的分布更加稳定。
+
+#### 更细粒度的访问控制
+
+企业版 RBAC 新增了多项控制能力，授权更严格、更具表达力：
+
+- 支持为自定义角色指定**具名权限动作（named permission actions）**。
+- 支持**基于正则表达式的数据库 ACL**，并在创建数据库时自动为创建者授予该数据库的 ACL。
+- 提供可选的**查询防护（query guard）**，可以对所有用户禁用 `DROP TABLE` / `DROP DATABASE`，防止误执行破坏性操作。
+
+#### 表的 Soft Drop
+
+`DROP TABLE` 可以配置为 **soft drop**（需显式开启）：表的数据将被保留，并可通过 `UNDROP TABLE` 恢复，而不是立即销毁。Soft-dropped 的表在被恢复（undrop）或清除（purge）之前，会持续占用存储空间。
+
+#### 运维改进
+
+- 面向企业版负载的、可配置的**查询 spill**。
+- 按组件设置**最大 CPU** 的选项。
+- 企业版 **Flight schema 默认对齐**，保证通信格式一致；Flight **批量写入支持自动建表**。
+- 提供用于部署 GreptimeDB 及监控组件的 **Ansible playbook**。
+
+#### 来自 GreptimeDB v1.2 引擎的更新
+
+- **`JSON2`**——改进的 JSON 数据类型，为列式存储优化。
+- 支持**带时间范围的手动 compaction**，与新的定时 compaction 互为补充。
+- **生命周期事件记录**——为数据库/表/视图 DDL、Flow DDL、repartition、GC 和 WAL 清理记录结构化的事件过程，大幅提升集群操作的可观测性。可在企业版 Dashboard 界面中查看。
+- **性能**：采用字典编码的 series key 提升查询性能；range 查询的输入投影裁剪；compaction picker 改为异步执行，不再阻塞 region worker。
+
+### 重要缺陷修复
+
+**企业版：**
+
+- 批量写入现在会正确校验 `JSONB` 列的写入数据类型，避免写入非法数据。
+- 修正了 v1.2 引擎上的 ingestion merge 批大小。
+- 正确处理远程动态过滤的开关；规范了 region 均衡器稳定性相关的选项名。
+
+**来自 GreptimeDB v1.2 引擎的修复：**
+
+- `PromQL` 的 `or` 查询在操作数为空时不再返回错误结果。
+- MySQL 协议现在对无法表示的时间戳**直接报错（fail closed）**，而不是静默地错误处理。
+- Prometheus remote-write 超时现在是**可重试的**，提升了瞬时故障下数据写入的韧性。
+- **索引构建可靠性**：异步索引构建以 schema generation 进行隔离，并按条件发布，修复了索引构建与 schema 变更并发执行时可能出现的竞争问题。
+- 升级时**保持对旧版 WAL 选项的兼容**，已有配置可以继续工作。
+
+### 安全更新
+
+- **独立的 HTTP API 服务端口**——HTTP API 现在运行在专用端口上，将 API 流量与其他服务流量隔离。
+- **SQL 本地文件系统访问沙箱化**——SQL 执行被沙箱化，无法再读取本地文件系统，封堵了本地文件访问漏洞。
+- `quinn-proto`: 0.11.14 → 0.11.16 _（依赖更新）_

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -569,6 +569,7 @@ const sidebars: SidebarsConfig = {
           type: 'category',
           label: 'Releases',
           items: [
+            'enterprise/release-notes/release-26_05',
             'enterprise/release-notes/release-25_11',
             'enterprise/release-notes/release-25_05',
             'enterprise/release-notes/release-24_11',


### PR DESCRIPTION
## What changed

Prepare release notes for 26.05.1

Will backport to v1.2 folders when it's ready.

## Scope

- Documentation versions: <!-- e.g. Nightly, 1.1 -->
- Languages: <!-- e.g. English, Chinese -->

## Verification

<!-- List commands run and any manual checks. -->

## Checklist

- [ ] I verified the content against the applicable GreptimeDB version.
- [ ] I updated the relevant documentation versions and languages, or explained why not.
- [ ] I checked changed links and anchors.
- [ ] I updated navigation when the document structure changed.
