### PR TITLE
feat: serve the root doc version under its version prefix

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -7,7 +7,7 @@ import versionNoindex from './src/plugins/version-noindex';
 import robotsTxtGenerator from './src/plugins/robots-txt-generator';
 import faqSchema from './src/plugins/faq-schema';
 import { resolveLastmod } from './src/plugins/sitemap-lastmod';
-import { resolveLastVersion } from './src/site-versions';
+import { resolveLastVersion, stableVersionAliasPath } from './src/site-versions';
 import versions from './versions.json';
 
 // Prism theme: our light mode uses a dark code-block background.
@@ -336,6 +336,15 @@ const config: Config = {
       ],
     }],
     [versionNoindex, { lastVersion }],
+    // Serve the root version under /<lastVersion>/ too, so a URL written with
+    // an explicit version number resolves instead of returning 404. Each alias
+    // is a redirect page pointing back at the root path, which stays canonical.
+    ['@docusaurus/plugin-client-redirects', {
+      createRedirects(existingPath: string) {
+        const alias = stableVersionAliasPath(existingPath, lastVersion, prefixedVersions);
+        return alias ? [alias] : undefined;
+      },
+    }],
     robotsTxtGenerator,
     [faqSchema, { lastVersion }],
     function injectLocaleSwitchScript() {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@actions/core": "^1.11.1",
     "@actions/github": "^6.0.0",
     "@docusaurus/core": "3.4.0",
+    "@docusaurus/plugin-client-redirects": "3.4.0",
     "@docusaurus/preset-classic": "3.4.0",
     "@docusaurus/theme-mermaid": "^3.4.0",
     "@fontsource/geist": "^5.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   '@docusaurus/core':
     specifier: 3.4.0
     version: 3.4.0(@docusaurus/types@3.4.0)(eslint@8.56.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+  '@docusaurus/plugin-client-redirects':
+    specifier: 3.4.0
+    version: 3.4.0(@docusaurus/types@3.4.0)(eslint@8.56.0)(postcss@8.5.20)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
   '@docusaurus/preset-classic':
     specifier: 3.4.0
     version: 3.4.0(@algolia/client-search@5.56.0)(@types/react@19.2.17)(eslint@8.56.0)(postcss@8.5.20)(react-dom@18.3.1)(react@18.3.1)(search-insights@2.17.3)(typescript@5.2.2)
@@ -2645,6 +2648,50 @@ packages:
       - supports-color
       - uglify-js
       - webpack-cli
+
+  /@docusaurus/plugin-client-redirects@3.4.0(@docusaurus/types@3.4.0)(eslint@8.56.0)(postcss@8.5.20)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
+    resolution: {integrity: sha512-Pr8kyh/+OsmYCvdZhc60jy/FnrY6flD2TEAhl4rJxeVFxnvvRgEhoaIVX8q9MuJmaQoh6frPk94pjs7/6YgBDQ==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    dependencies:
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0)(eslint@8.56.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/logger': 3.4.0
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0)(clean-css@5.3.3)(cssnano@6.1.2)(html-minifier-terser@7.2.0)(postcss@8.5.20)(typescript@5.2.2)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0)(clean-css@5.3.3)(cssnano@6.1.2)(html-minifier-terser@7.2.0)(postcss@8.5.20)(typescript@5.2.2)
+      eta: 2.2.0
+      fs-extra: 11.3.6
+      lodash: 4.18.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@docusaurus/types'
+      - '@minify-html/node'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - bufferutil
+      - clean-css
+      - cssnano
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+    dev: false
 
   /@docusaurus/plugin-content-blog@3.10.2(@docusaurus/plugin-content-docs@3.10.2)(@mdx-js/react@3.1.1)(postcss@8.5.20)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
     resolution: {integrity: sha512-0cbEnNKf0InmLkhj/+nVRmqEnWEoOE8Mh+2x1qOXI0qYpCnphq4RXknVJ8BvybKRXqYVvbmdMfiJSup+k4tm5w==}

--- a/src/__tests__/site-versions.test.ts
+++ b/src/__tests__/site-versions.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { resolveLastVersion } from '../site-versions';
+import { resolveLastVersion, stableVersionAliasPath } from '../site-versions';
 
 let rootDir: string;
 
@@ -53,5 +53,34 @@ describe('resolveLastVersion', () => {
     writeVariables('1.2', 'v1.2.0-beta.1');
     writeVariables('1.1', 'v1.1.0-rc.1');
     expect(resolveLastVersion(['1.2', '1.1'], rootDir)).toBe('1.2');
+  });
+});
+
+describe('stableVersionAliasPath', () => {
+  const alias = (routePath: string) =>
+    stableVersionAliasPath(routePath, '1.2', ['1.1', '1.0']);
+
+  it('aliases a root-version doc page', () => {
+    expect(alias('/user-guide/overview/')).toBe('/1.2/user-guide/overview/');
+  });
+
+  it('aliases the root page', () => {
+    expect(alias('/')).toBe('/1.2/');
+  });
+
+  it('skips nightly and prefixed versions', () => {
+    expect(alias('/nightly/user-guide/overview/')).toBeNull();
+    expect(alias('/1.1/user-guide/overview/')).toBeNull();
+    expect(alias('/1.0/')).toBeNull();
+  });
+
+  it('skips non-doc routes', () => {
+    expect(alias('/release-notes/')).toBeNull();
+    expect(alias('/search')).toBeNull();
+    expect(alias('/404.html')).toBeNull();
+  });
+
+  it('matches whole path segments only', () => {
+    expect(alias('/nightly-builds/')).toBe('/1.2/nightly-builds/');
   });
 });

--- a/src/site-versions.ts
+++ b/src/site-versions.ts
@@ -43,3 +43,39 @@ export function resolveLastVersion(
   });
   return stable ?? versions[0];
 }
+
+/** Top-level routes that are not documentation pages of the root version. */
+const NON_DOC_SEGMENTS = ['release-notes', 'search', 'nightly'];
+
+function isUnderSegment(routePath: string, segment: string): boolean {
+  return routePath === `/${segment}` || routePath.startsWith(`/${segment}/`);
+}
+
+/**
+ * Maps a route of the root version to its `/<lastVersion>/` alias.
+ *
+ * The version served at the root has no version prefix, so a URL written with
+ * an explicit version number (`/1.2/user-guide/overview`) does not resolve.
+ * The alias is a client-side redirect back to the root path, keeping one
+ * canonical URL per page. When the next version is promoted to the root, the
+ * previous number stops being aliased and becomes a real prefixed version.
+ *
+ * @param routePath a route emitted by the build, with a leading slash
+ * @param lastVersion the version served at the site root
+ * @param otherVersions every version served under a `/<version>/` prefix
+ * @returns the alias path, or null when the route is not a root-version doc
+ */
+export function stableVersionAliasPath(
+  routePath: string,
+  lastVersion: string,
+  otherVersions: string[],
+): string | null {
+  if (routePath === '/404.html') {
+    return null;
+  }
+  const excluded = [...NON_DOC_SEGMENTS, ...otherVersions];
+  if (excluded.some((segment) => isUnderSegment(routePath, segment))) {
+    return null;
+  }
+  return `/${lastVersion}${routePath}`;
+}


### PR DESCRIPTION
## What changed

The version served at the site root (currently 1.2) has no version prefix, so a URL written with an explicit version number — `/1.2/user-guide/overview/` — returns 404. Only the older versions resolve under `/<version>/`.

`@docusaurus/plugin-client-redirects` now generates a redirect page for every root-version route at `/<lastVersion>/<path>`, pointing back at the root path. The content keeps one canonical URL; query strings and anchors are forwarded, so `/1.2/user-guide/overview/#foo` lands on the root page with the anchor intact.

The alias set is derived from `lastVersion`, so promoting the next version needs no config change: once 1.3 is GA, `/1.3/*` becomes the alias and `/1.2/` goes back to being a real prefixed version directory.

Redirect pages are build output rather than `_redirects` rules, so both deployments — Cloudflare Pages (.com) and S3 + CloudFront (.cn) — behave the same.

Alias pages carry only `rel=canonical`, not `noindex`: the two are conflicting signals to Google, and canonical alone points at the root path.

## Scope

- Documentation versions: none (site configuration only; affects the version served at the root)
- Languages: English and Chinese

## Verification

- `pnpm build` and `DOC_LANG=zh pnpm build`: both succeed, 329 alias pages each
- Alias coverage compared against build output: the 329 root-version doc pages map 1:1 to `build/1.2/`, no gaps and no extras
- `sitemap.xml`: 391 URLs, none under `/1.2/` (alias pages are written in `postBuild`, so they are not routes)
- `llms.txt`: no `/1.2/` prefix
- `version-noindex` still processes only `nightly, 1.1, 1.0, 0.17, 0.16, 0.15, 0.14`
- `DOC_LANG=en pnpm check:links` and `DOC_LANG=zh pnpm check:links`: both pass
- `pnpm test`: 44 passed, including 5 new cases for `stableVersionAliasPath`

`pnpm typecheck` fails on `main` as well, with `TS2688: Cannot find type definition file for '@docusaurus/theme-classic' / 'node'` — the packages named in the inherited `types` option are only present under `node_modules/.pnpm/node_modules/`, where tsc does not resolve them. Not caused by this change and not run in CI. The two changed files were type-checked separately with `tsc --noEmit --strict` and a `typeRoots` override.

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] I updated navigation when the document structure changed.
