### PR TITLE
docs: document ALTER limits for semantic options and the create_options column

### DIFF
--- a/docs/reference/sql/information-schema/tables.md
+++ b/docs/reference/sql/information-schema/tables.md
@@ -108,4 +108,5 @@ The description of columns in the `TABLES` table is as follows:
 - `version`:  Version. The value is `11` by default.
 - `create_time`: The table created timestamp.
 - `table_comment`: The table comment.
+- `create_options`: The table options as space-separated `key=value` pairs, covering the options set in `CREATE TABLE ... WITH (...)` or by `ALTER TABLE`. Empty when the table carries no option.
 - Other columns such as `auto_increment`, `row_format` etc. are not supported, just for compatibility with MySQL. GreptimeDB may support some of them in the future.

--- a/docs/user-guide/semantic-layer/table-semantics.md
+++ b/docs/user-guide/semantic-layer/table-semantics.md
@@ -91,6 +91,10 @@ ALTER TABLE my_metrics SET 'greptime.semantic.metric.unit' = 's';
 ALTER TABLE my_metrics UNSET 'greptime.semantic.metric.unit';
 ```
 
+A single `SET` or `UNSET` statement cannot mix `greptime.semantic.*` keys with regular table options such as `ttl`. Changing both takes two statements.
+
+Logical tables of the metric engine accept `SET` and `UNSET` for `greptime.semantic.*` options; they still reject regular table options.
+
 The options appear in `SHOW CREATE TABLE` output and in the `table_semantics` view.
 
 ## Discovering semantic metadata

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/information-schema/tables.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/sql/information-schema/tables.md
@@ -109,6 +109,7 @@ SHOW TABLES
 - `version`: 版本。固定值为 `11`。
 - `create_time`: 表创建的时间戳。
 - `table_comment`: 表的注释。
+- `create_options`: 表的选项，格式为空格分隔的 `key=value`，包含在 `CREATE TABLE ... WITH (...)` 或 `ALTER TABLE` 中设置的选项。表没有任何选项时为空。
 - 其他列如 `table_rows`， `row_format` 等不支持，仅用于兼容 MySQL。GreptimeDB 未来可能会支持其中的一些列。
 
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/semantic-layer/table-semantics.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/semantic-layer/table-semantics.md
@@ -91,6 +91,10 @@ ALTER TABLE my_metrics SET 'greptime.semantic.metric.unit' = 's';
 ALTER TABLE my_metrics UNSET 'greptime.semantic.metric.unit';
 ```
 
+同一条 `SET` 或 `UNSET` 语句不能同时包含 `greptime.semantic.*` 键和 `ttl` 这类常规表选项，两者要分成两条语句修改。
+
+Metric engine 的逻辑表支持对 `greptime.semantic.*` 选项执行 `SET` 和 `UNSET`，但仍然不支持修改常规表选项。
+
 这些选项会出现在 `SHOW CREATE TABLE` 的输出和 `table_semantics` 视图里。
 
 ## 查询语义元数据


### PR DESCRIPTION
## What changed

Two gaps found while auditing the semantic layer docs against GreptimeDB `main` (`c65a4e545e`).

**`ALTER TABLE` limits on `greptime.semantic.*` options.** The user guide showed only working `SET`/`UNSET` examples, so following it leads to `ALTER TABLE t SET 'greptime.semantic.source' = 'prometheus', 'ttl' = '7d'`, which fails with `1004(InvalidArguments)`. Two limits are now stated:

- a single `SET`/`UNSET` statement cannot mix semantic keys with regular table options (`src/common/grpc-expr/src/alter.rs`, `annotation_family_of_keys`, applied to both `SetTableOptions` and `UnsetTableOptions`)
- metric engine logical tables accept `SET`/`UNSET` for semantic options but still reject regular ones (`tests/cases/standalone/common/information_schema/table_semantics.result`)

**`information_schema.TABLES.create_options`.** The column had no entry in the column description list, so it fell under the closing "not supported, just for compatibility with MySQL" note. GreptimeDB actually fills it from `table_info.meta.options.to_string()` (`src/catalog/src/system_schema/information_schema/tables.rs`), which renders space-separated `key=value` pairs and includes `extra_options`.

The rest of the semantic layer reference was checked and needs no change: `TABLE_SEMANTICS` (11 columns, option keys, `entity_declarations` fields), `greptime_private.semantic_entities`, and `greptime_private.semantic_relationships` (18-column contract) all match the source.

Not included on purpose: the `greptime.semantic.*` vocabulary is not added to the `CREATE TABLE` options table in `reference/sql/create.md`. The RFC keeps those sub-namespaces evolving until the layer reaches v1.0, and that table reads as a stable option contract. The full vocabulary already lives in `user-guide/semantic-layer/table-semantics.md`.

## Scope

- Documentation versions: Nightly
- Languages: English and Chinese

## Verification

- `pnpm build` and `DOC_LANG=zh pnpm build`: both succeed
- Every statement checked against GreptimeDB `main` source and the `table_semantics` sqlness case; no links, headings, or navigation touched

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] I updated navigation when the document structure changed.
