### PR TITLE
docs: backport json2 pipeline type to 1.2

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/pipeline/pipeline-config.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/reference/pipeline/pipeline-config.md
@@ -1082,8 +1082,47 @@ GreptimeDB 目前内置了以下几种转换类型：
 - `time`: 时间类型。将被转换为 GreptimeDB `timestamp(9)` 类型。
 - `epoch`: 时间戳类型。将被转换为 GreptimeDB `timestamp(n)` 类型。n 为时间戳精度，n 的值视 epoch 精度而定。当精度为 `s` 时，n 为 0；当精度为 `ms` 时，n 为 3；当精度为 `us` 时，n 为 6；当精度为 `ns` 时，n 为 9。
 - `json`: JSON 类型。字段值必须是 JSON 对象或数组（例如由 [`json_parse`](#json_parse) 处理器生成），将被存储为表中的 JSON 列。标量值（例如字符串、数字）无法转换为 `json` 类型。
+- `json2`: [JSON2](/user-guide/logs/json2.md) 类型。字段可以不存在或为 `null`；存在且非 `null` 时，字段值必须是非空 JSON 对象（例如由 [`json_parse`](#json_parse) 处理器生成）。以数组为 root 的 JSON 和标量值无法转换为 `json2`。
 
 如果字段在转换过程中获得了非法值，Pipeline 将会抛出异常。例如将一个字符串 `abc` 转换为整数时，由于该字符串不是一个合法的整数，Pipeline 将会抛出异常。
+
+#### JSON2 type hint
+
+:::note
+JSON2 目前处于 Beta 阶段，部分功能仍在持续完善中。
+:::
+
+关于 JSON2 的行为、查询语法和当前限制，请参考 [JSON2 类型文档](/user-guide/logs/json2.md)。
+
+当 pipeline 创建目标列时，简写形式会创建一个不包含 type hint 的 JSON2 列：
+
+```yaml
+transform:
+  - field: payload
+    type: json2
+```
+
+如需为新建的 JSON2 列声明 type hint，请使用对象形式：
+
+```yaml
+transform:
+  - field: payload
+    type:
+      json2:
+        - path: user.id
+          type: int64
+        - path: 'attrs."http.status_code"'
+          type: string
+```
+
+每个 type hint 支持以下字段：
+
+- `path`（必填）：使用点号语法表示 JSON 子路径。如果 JSON key 本身包含点号，请使用双引号包裹对应的路径段。
+- `type`（必填）：支持 `string`、`int64`、`uint64`、`float64` 或 `boolean`。
+- `nullable`（可选）：该路径是否可以缺失或为 `null`，默认为 `true`。
+- `default`（可选）：路径缺失时使用的默认值，必须是声明类型对应的标量值。
+
+如果目标 JSON2 列已存在，GreptimeDB 会使用该列中保存的配置编码字段值，而不是 pipeline 中的内联 type hint。通过 [`table_suffix`](#table-suffix) 将数据路由到不同表时也是如此。如果字段值不符合实际使用的 type hint，transform 会按照 [`on_failure`](#on_failure-字段) 配置进行处理。
 
 ### `index` 字段
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/logs/json2.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/logs/json2.md
@@ -63,6 +63,9 @@ VALUES
     );
 ```
 
+自定义 pipeline 也可以在 transform 配置中使用 `type: json2` 写入 JSON2 列。
+支持的 type hint 选项请参考 [pipeline 配置](/reference/pipeline/pipeline-config.md#type-字段)。
+
 ### 查询 JSON 字段
 
 可以直接通过点号路径读取 JSON2 中的字段：

--- a/versioned_docs/version-1.2/reference/pipeline/pipeline-config.md
+++ b/versioned_docs/version-1.2/reference/pipeline/pipeline-config.md
@@ -1064,8 +1064,47 @@ GreptimeDB currently provides the following built-in transformation types:
 - `time`: Time type, which will be converted to GreptimeDB `timestamp(9)` type.
 - `epoch`: Timestamp type, which will be converted to GreptimeDB `timestamp(n)` type. The value of `n` depends on the precision of the epoch. When the precision is `s`, `n` is 0; when the precision is `ms`, `n` is 3; when the precision is `us`, `n` is 6; when the precision is `ns`, `n` is 9.
 - `json`: JSON type. The field value must be a JSON object or array, such as one produced by the [`json_parse`](#json_parse) processor, and it is stored as a JSON column in the table. Scalar values (for example, strings, numbers) cannot be converted to the `json` type.
+- `json2`: [JSON2](/user-guide/logs/json2.md) type. The field may be missing or `null`. A non-null value must be a non-empty JSON object, such as one produced by the [`json_parse`](#json_parse) processor. Root arrays and scalar values cannot be converted to `json2`.
 
 If a field obtains an illegal value during the transformation process, the Pipeline will throw an exception. For example, when converting a string `abc` to an integer, an exception will be thrown because the string is not a valid integer.
+
+#### JSON2 type hints
+
+:::note
+JSON2 is currently in Beta, and some capabilities are still being improved.
+:::
+
+For JSON2 behavior, query syntax, and current limitations, see the [JSON2 type documentation](/user-guide/logs/json2.md).
+
+When a pipeline creates the destination column, the short form creates a JSON2 column without type hints:
+
+```yaml
+transform:
+  - field: payload
+    type: json2
+```
+
+To declare type hints for the new JSON2 column, use the object form:
+
+```yaml
+transform:
+  - field: payload
+    type:
+      json2:
+        - path: user.id
+          type: int64
+        - path: 'attrs."http.status_code"'
+          type: string
+```
+
+Each type hint supports the following fields:
+
+- `path` (required): The JSON subpath in dot notation. Wrap a path segment in double quotes when the JSON key itself contains a dot.
+- `type` (required): One of `string`, `int64`, `uint64`, `float64`, or `boolean`.
+- `nullable` (optional): Whether the path can be missing or `null`. Defaults to `true`.
+- `default` (optional): A scalar value of the declared type to use when the path is missing.
+
+If the destination JSON2 column already exists, GreptimeDB encodes the value using the settings stored in that column instead of the inline hints. This also applies when [`table_suffix`](#table-suffix) routes records to different tables. Values that violate the applicable type hints follow the transform's [`on_failure`](#the-on_failure-field) setting.
 
 ### The `index` field
 

--- a/versioned_docs/version-1.2/user-guide/logs/json2.md
+++ b/versioned_docs/version-1.2/user-guide/logs/json2.md
@@ -70,6 +70,11 @@ VALUES
     );
 ```
 
+Custom pipelines can also write JSON2 columns by using `type: json2` in the
+transform configuration. See the
+[pipeline configuration reference](/reference/pipeline/pipeline-config.md#the-type-field)
+for the supported type-hint options.
+
 ### Query JSON fields
 
 You can read fields from JSON2 directly with dot paths:


### PR DESCRIPTION
## What changed

Backport commit `b8a41d9` to version 1.2 docs.

## Scope

- Documentation versions: 1.2
- Languages: English, Chinese

## Verification

<!-- List commands run and any manual checks. -->

## Checklist

- [ ] I verified the content against the applicable GreptimeDB version.
- [ ] I updated the relevant documentation versions and languages, or explained why not.
- [ ] I checked changed links and anchors.
- [ ] I updated navigation when the document structure changed.
