### PR TITLE
docs: fix export-import-v2 local filesystem and S3 guidance for v1.2

### DIFF
--- a/docs/user-guide/deployments-administration/disaster-recovery/export-import-v2.md
+++ b/docs/user-guide/deployments-administration/disaster-recovery/export-import-v2.md
@@ -25,15 +25,15 @@ Before using Export/Import V2, make sure that:
 - You have a `greptime` binary that includes the `cli data export-v2` and `cli data import-v2` commands.
 - The snapshot storage location is readable and writable by both the CLI client and the GreptimeDB server.
 
-For remote object storage, explicitly enable one supported backend and provide the backend options. Export/Import V2 supports S3-compatible storage, Alibaba Cloud OSS, Google Cloud Storage, and Azure Blob Storage. For example, use `--s3` with `--s3-bucket` and `--s3-region` for S3-compatible storage.
+For remote object storage, explicitly enable one supported backend and provide the backend options. Export/Import V2 supports S3-compatible storage, Alibaba Cloud OSS, Google Cloud Storage, and Azure Blob Storage. For example, use `--s3` with `--s3-region` for S3-compatible storage.
 
 For `file://` snapshots, the path must be accessible from the GreptimeDB server as well as the CLI client. This usually means running the CLI on the same host as a standalone server, or mounting the same filesystem path into the GreptimeDB server. The parent directory of the snapshot must exist before you create the snapshot. For remote, Kubernetes, or distributed deployments, use object storage such as S3 or MinIO instead of a local `file://` path.
 
-The GreptimeDB server writes snapshot data files with `COPY DATABASE ... TO`, so a `file://` snapshot path must also be inside the server's copy root, which is `storage.copy_root` and defaults to `<storage.data_home>/copy`. The server rejects a path outside the copy root. See [Migrate Local SQL File Access](/user-guide/deployments-administration/migrate-local-sql-file-access.md) for details.
+The GreptimeDB server writes snapshot data files with `COPY DATABASE ... TO`, so a `file://` snapshot path must also be inside the server's copy root, which is `storage.copy_root` and defaults to `<storage.data_home>/copy`. The server rejects a path outside the copy root. Object storage snapshots are not subject to the copy root, because the server writes them directly to the object store. See [Migrate Local SQL File Access](/user-guide/deployments-administration/migrate-local-sql-file-access.md) for details.
 
 :::note
 
-The snapshot URI, such as `s3://my-bucket/snapshots/prod`, identifies the snapshot location. The object store options, such as `--s3-bucket my-bucket`, configure how the CLI connects to the backend. Keep them consistent across create, verify, import, list, and delete commands.
+The snapshot URI, such as `s3://my-bucket/snapshots/prod`, identifies the snapshot location, including the bucket. The object store options, such as `--s3-region` and `--s3-endpoint`, configure how the CLI connects to the backend. `--s3-bucket` and `--s3-root` do not change where the snapshot is read or written; the URI is authoritative. Pass the same connection options to create, verify, import, list, and delete commands.
 
 :::
 
@@ -130,7 +130,7 @@ greptime cli data import-v2 \
   --s3-endpoint http://127.0.0.1:9000
 ```
 
-For AWS S3, use the same `--s3` options but omit `--s3-endpoint` unless you use a custom endpoint. If your environment uses instance profiles or another credential provider, explicit access keys may not be required. The S3 backend still requires `--s3`, `--s3-bucket`, and `--s3-region`.
+For AWS S3, use the same `--s3` options but omit `--s3-endpoint` unless you use a custom endpoint. If your environment uses instance profiles or another credential provider, explicit access keys may not be required. The S3 backend still requires `--s3` and `--s3-region`.
 
 ## Export selected schemas
 
@@ -369,7 +369,7 @@ Common S3 options are:
 
 | Option | Description |
 | --- | --- |
-| `--s3-bucket` | S3 bucket name. Required for S3. |
+| `--s3-bucket` | S3 bucket name. Does not affect the snapshot location; the bucket in the snapshot URI is used. |
 | `--s3-region` | S3 region. Required for S3. |
 | `--s3-access-key-id` | Access key ID. Optional when the environment provides credentials. |
 | `--s3-secret-access-key` | Secret access key. Optional when the environment provides credentials. |
@@ -407,8 +407,8 @@ The failed run leaves a partial snapshot on disk, and `export-v2 verify` reports
 
 Check that:
 
-- The bucket in the snapshot URI matches `--s3-bucket`.
-- `--s3-endpoint` is set for MinIO or other S3-compatible services.
+- The bucket and path in the snapshot URI are correct. `--s3-bucket` does not change the snapshot location.
+- `--s3-endpoint` is set for MinIO or other S3-compatible services. Without it, the CLI sends requests to the public AWS S3 endpoint for `--s3-region`, which usually shows up as a long hang or a `301` response rather than a clear configuration error.
 - The credentials can read and write the snapshot location.
 - You pass the same storage options to create, verify, import, list, and delete commands.
 

--- a/docs/user-guide/deployments-administration/disaster-recovery/export-import-v2.md
+++ b/docs/user-guide/deployments-administration/disaster-recovery/export-import-v2.md
@@ -27,7 +27,9 @@ Before using Export/Import V2, make sure that:
 
 For remote object storage, explicitly enable one supported backend and provide the backend options. Export/Import V2 supports S3-compatible storage, Alibaba Cloud OSS, Google Cloud Storage, and Azure Blob Storage. For example, use `--s3` with `--s3-bucket` and `--s3-region` for S3-compatible storage.
 
-For `file://` snapshots, the path must be accessible from the GreptimeDB server as well as the CLI client. This usually means running the CLI on the same host as a standalone server, or mounting the same filesystem path into the GreptimeDB server. For remote, Kubernetes, or distributed deployments, use object storage such as S3 or MinIO instead of a local `file://` path.
+For `file://` snapshots, the path must be accessible from the GreptimeDB server as well as the CLI client. This usually means running the CLI on the same host as a standalone server, or mounting the same filesystem path into the GreptimeDB server. The parent directory of the snapshot must exist before you create the snapshot. For remote, Kubernetes, or distributed deployments, use object storage such as S3 or MinIO instead of a local `file://` path.
+
+The GreptimeDB server writes snapshot data files with `COPY DATABASE ... TO`, so a `file://` snapshot path must also be inside the server's copy root, which is `storage.copy_root` and defaults to `<storage.data_home>/copy`. The server rejects a path outside the copy root. See [Migrate Local SQL File Access](/user-guide/deployments-administration/migrate-local-sql-file-access.md) for details.
 
 :::note
 
@@ -38,6 +40,21 @@ The snapshot URI, such as `s3://my-bucket/snapshots/prod`, identifies the snapsh
 ## Quick start with local filesystem
 
 Use a local filesystem snapshot only when the path is shared by the CLI client and the GreptimeDB server. For example, this works for a local standalone server when the CLI runs on the same host.
+
+The examples in this guide store snapshots under `/tmp/greptime-snapshots`. Set this directory as the server's copy root in the GreptimeDB configuration file and restart the server:
+
+```toml
+[storage]
+copy_root = "/tmp/greptime-snapshots"
+```
+
+Alternatively, keep the default copy root and use a snapshot path under `<storage.data_home>/copy`, such as `file:///path/to/data_home/copy/demo`.
+
+Create the parent directory so that both the server and the CLI can access it:
+
+```bash
+mkdir -p /tmp/greptime-snapshots
+```
 
 Create a snapshot:
 
@@ -117,6 +134,8 @@ For AWS S3, use the same `--s3` options but omit `--s3-endpoint` unless you use 
 
 ## Export selected schemas
 
+By default, `export-v2 create` exports every schema except `information_schema`. This includes the `greptime_private` schema, and importing such a snapshot restores `greptime_private` as well. To exclude it, list the schemas you want explicitly with `--schemas`.
+
 Export only selected schemas with `--schemas`. You can pass a comma-separated list:
 
 ```bash
@@ -165,6 +184,19 @@ greptime cli data import-v2 \
   --addr 127.0.0.1:4000 \
   --from file:///tmp/greptime-snapshots/schema-only
 ```
+
+## Choose the data file format
+
+Use `--format` to choose the data file format. Supported values are `parquet`, `csv`, and `json`. The default is `parquet`.
+
+```bash
+greptime cli data export-v2 create \
+  --addr 127.0.0.1:4000 \
+  --to file:///tmp/greptime-snapshots/demo-csv \
+  --format csv
+```
+
+The format is recorded in the snapshot manifest. `import-v2` reads the format from the manifest and applies it automatically, so you do not need to specify the format again when importing.
 
 ## Export by time range and chunk window
 
@@ -354,6 +386,18 @@ Check that GreptimeDB is running and that `--addr` points to the HTTP endpoint:
 ```bash
 curl http://127.0.0.1:4000/health
 ```
+
+### `file://` path is outside the configured copy root
+
+If `export-v2 create` fails with an error such as the following, the snapshot path is outside the server's copy root:
+
+```text
+Local filesystem path '/tmp/greptime-snapshots/demo/data/greptime_private/1/' is outside the configured copy root or is unsafe
+```
+
+Set `storage.copy_root` to a directory that contains the snapshot path, or use a snapshot path under `<storage.data_home>/copy`. See [Migrate Local SQL File Access](/user-guide/deployments-administration/migrate-local-sql-file-access.md) for details.
+
+The failed run leaves a partial snapshot on disk, and `export-v2 verify` reports the failed chunk. After fixing the configuration, run the same `export-v2 create` command again to resume, or pass `--force` to recreate the snapshot.
 
 ### `--chunk-time-window` fails validation
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/disaster-recovery/export-import-v2.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/disaster-recovery/export-import-v2.md
@@ -27,7 +27,9 @@ V2 快照包含 schema 元数据、manifest 和数据文件。数据文件会被
 
 对于远程对象存储，仅有快照 URI 还不够。你还需要显式启用一个受支持的存储后端，并传入该后端的连接选项。Export/Import V2 支持 S3-compatible 存储、阿里云 OSS、Google Cloud Storage 和 Azure Blob Storage。例如，对于 S3-compatible 存储，需要同时使用 `--s3`、`--s3-bucket` 和 `--s3-region`。
 
-对于 `file://` 快照，路径必须同时能被 GreptimeDB server 和 CLI client 访问。通常这意味着 CLI 与 standalone server 运行在同一台主机上，或者将同一个文件系统路径挂载到 GreptimeDB server 中。对于远程、Kubernetes 或分布式部署，请使用 S3 或 MinIO 等对象存储，而不是本地 `file://` 路径。
+对于 `file://` 快照，路径必须同时能被 GreptimeDB server 和 CLI client 访问。通常这意味着 CLI 与 standalone server 运行在同一台主机上，或者将同一个文件系统路径挂载到 GreptimeDB server 中。创建快照之前，快照的父目录必须已经存在。对于远程、Kubernetes 或分布式部署，请使用 S3 或 MinIO 等对象存储，而不是本地 `file://` 路径。
+
+GreptimeDB server 通过 `COPY DATABASE ... TO` 写入快照数据文件，因此 `file://` 快照路径还必须位于 server 的 copy root 内，即 `storage.copy_root`，默认为 `<storage.data_home>/copy`。位于 copy root 之外的路径会被 server 拒绝。详情请参阅[迁移本地 SQL 文件访问](/user-guide/deployments-administration/migrate-local-sql-file-access.md)。
 
 :::note
 
@@ -38,6 +40,21 @@ V2 快照包含 schema 元数据、manifest 和数据文件。数据文件会被
 ## 使用本地文件系统快速开始
 
 只有在 CLI client 和 GreptimeDB server 共享同一路径时，才应使用本地文件系统快照。例如，对于本地 standalone server，如果 CLI 在同一台主机上运行，这种方式可以工作。
+
+本指南中的示例把快照存放在 `/tmp/greptime-snapshots` 下。请在 GreptimeDB 配置文件中把该目录设置为 server 的 copy root，然后重启 server：
+
+```toml
+[storage]
+copy_root = "/tmp/greptime-snapshots"
+```
+
+也可以保留默认的 copy root，改用 `<storage.data_home>/copy` 下的快照路径，例如 `file:///path/to/data_home/copy/demo`。
+
+创建父目录，并确保 server 和 CLI 都能访问它：
+
+```bash
+mkdir -p /tmp/greptime-snapshots
+```
 
 创建快照：
 
@@ -117,6 +134,8 @@ greptime cli data import-v2 \
 
 ## 导出指定 schemas
 
+默认情况下，`export-v2 create` 会导出除 `information_schema` 之外的所有 schema，其中包括 `greptime_private` schema，导入这样的快照时也会一并恢复 `greptime_private`。如果要排除它，请使用 `--schemas` 显式列出需要导出的 schemas。
+
 使用 `--schemas` 只导出指定 schemas。可以传入逗号分隔的列表：
 
 ```bash
@@ -165,6 +184,19 @@ greptime cli data import-v2 \
   --addr 127.0.0.1:4000 \
   --from file:///tmp/greptime-snapshots/schema-only
 ```
+
+## 选择数据文件格式
+
+使用 `--format` 选择数据文件格式。支持的值为 `parquet`、`csv` 和 `json`，默认值为 `parquet`。
+
+```bash
+greptime cli data export-v2 create \
+  --addr 127.0.0.1:4000 \
+  --to file:///tmp/greptime-snapshots/demo-csv \
+  --format csv
+```
+
+格式会记录在快照的 manifest 中。`import-v2` 会从 manifest 中读取格式并自动应用，因此导入时不需要再次指定格式。
 
 ## 按时间范围和 chunk window 导出
 
@@ -354,6 +386,18 @@ Export/Import V2 支持本地文件系统快照和远程对象存储快照。
 ```bash
 curl http://127.0.0.1:4000/health
 ```
+
+### `file://` 路径位于 copy root 之外
+
+如果 `export-v2 create` 返回类似下面的错误，说明快照路径位于 server 的 copy root 之外：
+
+```text
+Local filesystem path '/tmp/greptime-snapshots/demo/data/greptime_private/1/' is outside the configured copy root or is unsafe
+```
+
+请把 `storage.copy_root` 设置为包含该快照路径的目录，或者改用 `<storage.data_home>/copy` 下的快照路径。详情请参阅[迁移本地 SQL 文件访问](/user-guide/deployments-administration/migrate-local-sql-file-access.md)。
+
+失败的运行会在磁盘上留下一个不完整的快照，`export-v2 verify` 会报告失败的 chunk。修正配置后，再次运行同一条 `export-v2 create` 命令即可继续；如果想重新创建快照，请传入 `--force`。
 
 ### `--chunk-time-window` 校验失败
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/disaster-recovery/export-import-v2.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/disaster-recovery/export-import-v2.md
@@ -25,15 +25,15 @@ V2 快照包含 schema 元数据、manifest 和数据文件。数据文件会被
 - 你的 `greptime` binary 包含 `cli data export-v2` 和 `cli data import-v2` 命令。
 - CLI client 和 GreptimeDB server 都能读写快照存储位置。
 
-对于远程对象存储，仅有快照 URI 还不够。你还需要显式启用一个受支持的存储后端，并传入该后端的连接选项。Export/Import V2 支持 S3-compatible 存储、阿里云 OSS、Google Cloud Storage 和 Azure Blob Storage。例如，对于 S3-compatible 存储，需要同时使用 `--s3`、`--s3-bucket` 和 `--s3-region`。
+对于远程对象存储，仅有快照 URI 还不够。你还需要显式启用一个受支持的存储后端，并传入该后端的连接选项。Export/Import V2 支持 S3-compatible 存储、阿里云 OSS、Google Cloud Storage 和 Azure Blob Storage。例如，对于 S3-compatible 存储，需要同时使用 `--s3` 和 `--s3-region`。
 
 对于 `file://` 快照，路径必须同时能被 GreptimeDB server 和 CLI client 访问。通常这意味着 CLI 与 standalone server 运行在同一台主机上，或者将同一个文件系统路径挂载到 GreptimeDB server 中。创建快照之前，快照的父目录必须已经存在。对于远程、Kubernetes 或分布式部署，请使用 S3 或 MinIO 等对象存储，而不是本地 `file://` 路径。
 
-GreptimeDB server 通过 `COPY DATABASE ... TO` 写入快照数据文件，因此 `file://` 快照路径还必须位于 server 的 copy root 内，即 `storage.copy_root`，默认为 `<storage.data_home>/copy`。位于 copy root 之外的路径会被 server 拒绝。详情请参阅[迁移本地 SQL 文件访问](/user-guide/deployments-administration/migrate-local-sql-file-access.md)。
+GreptimeDB server 通过 `COPY DATABASE ... TO` 写入快照数据文件，因此 `file://` 快照路径还必须位于 server 的 copy root 内，即 `storage.copy_root`，默认为 `<storage.data_home>/copy`。位于 copy root 之外的路径会被 server 拒绝。对象存储快照不受 copy root 限制，因为 server 会直接把数据写入对象存储。详情请参阅[迁移本地 SQL 文件访问](/user-guide/deployments-administration/migrate-local-sql-file-access.md)。
 
 :::note
 
-快照 URI（例如 `s3://my-bucket/snapshots/prod`）标识快照位置。对象存储选项（例如 `--s3-bucket my-bucket`）配置 CLI 如何连接到对应后端。请在 create、verify、import、list 和 delete 命令中保持这些选项一致。
+快照 URI（例如 `s3://my-bucket/snapshots/prod`）标识快照位置，其中包括 bucket。对象存储选项（例如 `--s3-region` 和 `--s3-endpoint`）配置 CLI 如何连接到对应后端。`--s3-bucket` 和 `--s3-root` 不会改变快照的读写位置，以 URI 为准。请在 create、verify、import、list 和 delete 命令中传入相同的连接选项。
 
 :::
 
@@ -130,7 +130,7 @@ greptime cli data import-v2 \
   --s3-endpoint http://127.0.0.1:9000
 ```
 
-对于 AWS S3，请使用相同的 `--s3` 选项；除非使用自定义 endpoint，否则不要传 `--s3-endpoint`。如果你的环境使用 instance profile 或其他凭据提供机制，可能不需要显式传入 access key。S3 backend 仍然需要 `--s3`、`--s3-bucket` 和 `--s3-region`。
+对于 AWS S3，请使用相同的 `--s3` 选项；除非使用自定义 endpoint，否则不要传 `--s3-endpoint`。如果你的环境使用 instance profile 或其他凭据提供机制，可能不需要显式传入 access key。S3 backend 仍然需要 `--s3` 和 `--s3-region`。
 
 ## 导出指定 schemas
 
@@ -369,7 +369,7 @@ Export/Import V2 支持本地文件系统快照和远程对象存储快照。
 
 | Option | Description |
 | --- | --- |
-| `--s3-bucket` | S3 bucket 名称。使用 S3 时必填。 |
+| `--s3-bucket` | S3 bucket 名称。不影响快照位置，实际使用的是快照 URI 中的 bucket。 |
 | `--s3-region` | S3 region。使用 S3 时必填。 |
 | `--s3-access-key-id` | Access key ID。当环境提供凭据时可选。 |
 | `--s3-secret-access-key` | Secret access key。当环境提供凭据时可选。 |
@@ -407,8 +407,8 @@ Local filesystem path '/tmp/greptime-snapshots/demo/data/greptime_private/1/' is
 
 请检查：
 
-- 快照 URI 中的 bucket 是否与 `--s3-bucket` 一致。
-- 对于 MinIO 或其他 S3-compatible 服务，是否设置了 `--s3-endpoint`。
+- 快照 URI 中的 bucket 和路径是否正确。`--s3-bucket` 不会改变快照位置。
+- 对于 MinIO 或其他 S3-compatible 服务，是否设置了 `--s3-endpoint`。如果没有设置，CLI 会把请求发往 `--s3-region` 对应的公有 AWS S3 endpoint，通常表现为长时间无响应或返回 `301`，而不是明确的配置错误。
 - 凭据是否可以读写快照位置。
 - create、verify、import、list 和 delete 命令是否传入了相同的存储选项。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/disaster-recovery/export-import-v2.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/disaster-recovery/export-import-v2.md
@@ -27,7 +27,9 @@ V2 快照包含 schema 元数据、manifest 和数据文件。数据文件会被
 
 对于远程对象存储，仅有快照 URI 还不够。你还需要显式启用一个受支持的存储后端，并传入该后端的连接选项。Export/Import V2 支持 S3-compatible 存储、阿里云 OSS、Google Cloud Storage 和 Azure Blob Storage。例如，对于 S3-compatible 存储，需要同时使用 `--s3`、`--s3-bucket` 和 `--s3-region`。
 
-对于 `file://` 快照，路径必须同时能被 GreptimeDB server 和 CLI client 访问。通常这意味着 CLI 与 standalone server 运行在同一台主机上，或者将同一个文件系统路径挂载到 GreptimeDB server 中。对于远程、Kubernetes 或分布式部署，请使用 S3 或 MinIO 等对象存储，而不是本地 `file://` 路径。
+对于 `file://` 快照，路径必须同时能被 GreptimeDB server 和 CLI client 访问。通常这意味着 CLI 与 standalone server 运行在同一台主机上，或者将同一个文件系统路径挂载到 GreptimeDB server 中。创建快照之前，快照的父目录必须已经存在。对于远程、Kubernetes 或分布式部署，请使用 S3 或 MinIO 等对象存储，而不是本地 `file://` 路径。
+
+GreptimeDB server 通过 `COPY DATABASE ... TO` 写入快照数据文件，因此 `file://` 快照路径还必须位于 server 的 copy root 内，即 `storage.copy_root`，默认为 `<storage.data_home>/copy`。位于 copy root 之外的路径会被 server 拒绝。详情请参阅[迁移本地 SQL 文件访问](/user-guide/deployments-administration/migrate-local-sql-file-access.md)。
 
 :::note
 
@@ -38,6 +40,21 @@ V2 快照包含 schema 元数据、manifest 和数据文件。数据文件会被
 ## 使用本地文件系统快速开始
 
 只有在 CLI client 和 GreptimeDB server 共享同一路径时，才应使用本地文件系统快照。例如，对于本地 standalone server，如果 CLI 在同一台主机上运行，这种方式可以工作。
+
+本指南中的示例把快照存放在 `/tmp/greptime-snapshots` 下。请在 GreptimeDB 配置文件中把该目录设置为 server 的 copy root，然后重启 server：
+
+```toml
+[storage]
+copy_root = "/tmp/greptime-snapshots"
+```
+
+也可以保留默认的 copy root，改用 `<storage.data_home>/copy` 下的快照路径，例如 `file:///path/to/data_home/copy/demo`。
+
+创建父目录，并确保 server 和 CLI 都能访问它：
+
+```bash
+mkdir -p /tmp/greptime-snapshots
+```
 
 创建快照：
 
@@ -117,6 +134,8 @@ greptime cli data import-v2 \
 
 ## 导出指定 schemas
 
+默认情况下，`export-v2 create` 会导出除 `information_schema` 之外的所有 schema，其中包括 `greptime_private` schema，导入这样的快照时也会一并恢复 `greptime_private`。如果要排除它，请使用 `--schemas` 显式列出需要导出的 schemas。
+
 使用 `--schemas` 只导出指定 schemas。可以传入逗号分隔的列表：
 
 ```bash
@@ -165,6 +184,19 @@ greptime cli data import-v2 \
   --addr 127.0.0.1:4000 \
   --from file:///tmp/greptime-snapshots/schema-only
 ```
+
+## 选择数据文件格式
+
+使用 `--format` 选择数据文件格式。支持的值为 `parquet`、`csv` 和 `json`，默认值为 `parquet`。
+
+```bash
+greptime cli data export-v2 create \
+  --addr 127.0.0.1:4000 \
+  --to file:///tmp/greptime-snapshots/demo-csv \
+  --format csv
+```
+
+格式会记录在快照的 manifest 中。`import-v2` 会从 manifest 中读取格式并自动应用，因此导入时不需要再次指定格式。
 
 ## 按时间范围和 chunk window 导出
 
@@ -354,6 +386,18 @@ Export/Import V2 支持本地文件系统快照和远程对象存储快照。
 ```bash
 curl http://127.0.0.1:4000/health
 ```
+
+### `file://` 路径位于 copy root 之外
+
+如果 `export-v2 create` 返回类似下面的错误，说明快照路径位于 server 的 copy root 之外：
+
+```text
+Local filesystem path '/tmp/greptime-snapshots/demo/data/greptime_private/1/' is outside the configured copy root or is unsafe
+```
+
+请把 `storage.copy_root` 设置为包含该快照路径的目录，或者改用 `<storage.data_home>/copy` 下的快照路径。详情请参阅[迁移本地 SQL 文件访问](/user-guide/deployments-administration/migrate-local-sql-file-access.md)。
+
+失败的运行会在磁盘上留下一个不完整的快照，`export-v2 verify` 会报告失败的 chunk。修正配置后，再次运行同一条 `export-v2 create` 命令即可继续；如果想重新创建快照，请传入 `--force`。
 
 ### `--chunk-time-window` 校验失败
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/disaster-recovery/export-import-v2.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/disaster-recovery/export-import-v2.md
@@ -25,15 +25,15 @@ V2 快照包含 schema 元数据、manifest 和数据文件。数据文件会被
 - 你的 `greptime` binary 包含 `cli data export-v2` 和 `cli data import-v2` 命令。
 - CLI client 和 GreptimeDB server 都能读写快照存储位置。
 
-对于远程对象存储，仅有快照 URI 还不够。你还需要显式启用一个受支持的存储后端，并传入该后端的连接选项。Export/Import V2 支持 S3-compatible 存储、阿里云 OSS、Google Cloud Storage 和 Azure Blob Storage。例如，对于 S3-compatible 存储，需要同时使用 `--s3`、`--s3-bucket` 和 `--s3-region`。
+对于远程对象存储，仅有快照 URI 还不够。你还需要显式启用一个受支持的存储后端，并传入该后端的连接选项。Export/Import V2 支持 S3-compatible 存储、阿里云 OSS、Google Cloud Storage 和 Azure Blob Storage。例如，对于 S3-compatible 存储，需要同时使用 `--s3` 和 `--s3-region`。
 
 对于 `file://` 快照，路径必须同时能被 GreptimeDB server 和 CLI client 访问。通常这意味着 CLI 与 standalone server 运行在同一台主机上，或者将同一个文件系统路径挂载到 GreptimeDB server 中。创建快照之前，快照的父目录必须已经存在。对于远程、Kubernetes 或分布式部署，请使用 S3 或 MinIO 等对象存储，而不是本地 `file://` 路径。
 
-GreptimeDB server 通过 `COPY DATABASE ... TO` 写入快照数据文件，因此 `file://` 快照路径还必须位于 server 的 copy root 内，即 `storage.copy_root`，默认为 `<storage.data_home>/copy`。位于 copy root 之外的路径会被 server 拒绝。详情请参阅[迁移本地 SQL 文件访问](/user-guide/deployments-administration/migrate-local-sql-file-access.md)。
+GreptimeDB server 通过 `COPY DATABASE ... TO` 写入快照数据文件，因此 `file://` 快照路径还必须位于 server 的 copy root 内，即 `storage.copy_root`，默认为 `<storage.data_home>/copy`。位于 copy root 之外的路径会被 server 拒绝。对象存储快照不受 copy root 限制，因为 server 会直接把数据写入对象存储。详情请参阅[迁移本地 SQL 文件访问](/user-guide/deployments-administration/migrate-local-sql-file-access.md)。
 
 :::note
 
-快照 URI（例如 `s3://my-bucket/snapshots/prod`）标识快照位置。对象存储选项（例如 `--s3-bucket my-bucket`）配置 CLI 如何连接到对应后端。请在 create、verify、import、list 和 delete 命令中保持这些选项一致。
+快照 URI（例如 `s3://my-bucket/snapshots/prod`）标识快照位置，其中包括 bucket。对象存储选项（例如 `--s3-region` 和 `--s3-endpoint`）配置 CLI 如何连接到对应后端。`--s3-bucket` 和 `--s3-root` 不会改变快照的读写位置，以 URI 为准。请在 create、verify、import、list 和 delete 命令中传入相同的连接选项。
 
 :::
 
@@ -130,7 +130,7 @@ greptime cli data import-v2 \
   --s3-endpoint http://127.0.0.1:9000
 ```
 
-对于 AWS S3，请使用相同的 `--s3` 选项；除非使用自定义 endpoint，否则不要传 `--s3-endpoint`。如果你的环境使用 instance profile 或其他凭据提供机制，可能不需要显式传入 access key。S3 backend 仍然需要 `--s3`、`--s3-bucket` 和 `--s3-region`。
+对于 AWS S3，请使用相同的 `--s3` 选项；除非使用自定义 endpoint，否则不要传 `--s3-endpoint`。如果你的环境使用 instance profile 或其他凭据提供机制，可能不需要显式传入 access key。S3 backend 仍然需要 `--s3` 和 `--s3-region`。
 
 ## 导出指定 schemas
 
@@ -369,7 +369,7 @@ Export/Import V2 支持本地文件系统快照和远程对象存储快照。
 
 | Option | Description |
 | --- | --- |
-| `--s3-bucket` | S3 bucket 名称。使用 S3 时必填。 |
+| `--s3-bucket` | S3 bucket 名称。不影响快照位置，实际使用的是快照 URI 中的 bucket。 |
 | `--s3-region` | S3 region。使用 S3 时必填。 |
 | `--s3-access-key-id` | Access key ID。当环境提供凭据时可选。 |
 | `--s3-secret-access-key` | Secret access key。当环境提供凭据时可选。 |
@@ -407,8 +407,8 @@ Local filesystem path '/tmp/greptime-snapshots/demo/data/greptime_private/1/' is
 
 请检查：
 
-- 快照 URI 中的 bucket 是否与 `--s3-bucket` 一致。
-- 对于 MinIO 或其他 S3-compatible 服务，是否设置了 `--s3-endpoint`。
+- 快照 URI 中的 bucket 和路径是否正确。`--s3-bucket` 不会改变快照位置。
+- 对于 MinIO 或其他 S3-compatible 服务，是否设置了 `--s3-endpoint`。如果没有设置，CLI 会把请求发往 `--s3-region` 对应的公有 AWS S3 endpoint，通常表现为长时间无响应或返回 `301`，而不是明确的配置错误。
 - 凭据是否可以读写快照位置。
 - create、verify、import、list 和 delete 命令是否传入了相同的存储选项。
 

--- a/versioned_docs/version-1.2/user-guide/deployments-administration/disaster-recovery/export-import-v2.md
+++ b/versioned_docs/version-1.2/user-guide/deployments-administration/disaster-recovery/export-import-v2.md
@@ -25,15 +25,15 @@ Before using Export/Import V2, make sure that:
 - You have a `greptime` binary that includes the `cli data export-v2` and `cli data import-v2` commands.
 - The snapshot storage location is readable and writable by both the CLI client and the GreptimeDB server.
 
-For remote object storage, explicitly enable one supported backend and provide the backend options. Export/Import V2 supports S3-compatible storage, Alibaba Cloud OSS, Google Cloud Storage, and Azure Blob Storage. For example, use `--s3` with `--s3-bucket` and `--s3-region` for S3-compatible storage.
+For remote object storage, explicitly enable one supported backend and provide the backend options. Export/Import V2 supports S3-compatible storage, Alibaba Cloud OSS, Google Cloud Storage, and Azure Blob Storage. For example, use `--s3` with `--s3-region` for S3-compatible storage.
 
 For `file://` snapshots, the path must be accessible from the GreptimeDB server as well as the CLI client. This usually means running the CLI on the same host as a standalone server, or mounting the same filesystem path into the GreptimeDB server. The parent directory of the snapshot must exist before you create the snapshot. For remote, Kubernetes, or distributed deployments, use object storage such as S3 or MinIO instead of a local `file://` path.
 
-The GreptimeDB server writes snapshot data files with `COPY DATABASE ... TO`, so a `file://` snapshot path must also be inside the server's copy root, which is `storage.copy_root` and defaults to `<storage.data_home>/copy`. The server rejects a path outside the copy root. See [Migrate Local SQL File Access](/user-guide/deployments-administration/migrate-local-sql-file-access.md) for details.
+The GreptimeDB server writes snapshot data files with `COPY DATABASE ... TO`, so a `file://` snapshot path must also be inside the server's copy root, which is `storage.copy_root` and defaults to `<storage.data_home>/copy`. The server rejects a path outside the copy root. Object storage snapshots are not subject to the copy root, because the server writes them directly to the object store. See [Migrate Local SQL File Access](/user-guide/deployments-administration/migrate-local-sql-file-access.md) for details.
 
 :::note
 
-The snapshot URI, such as `s3://my-bucket/snapshots/prod`, identifies the snapshot location. The object store options, such as `--s3-bucket my-bucket`, configure how the CLI connects to the backend. Keep them consistent across create, verify, import, list, and delete commands.
+The snapshot URI, such as `s3://my-bucket/snapshots/prod`, identifies the snapshot location, including the bucket. The object store options, such as `--s3-region` and `--s3-endpoint`, configure how the CLI connects to the backend. `--s3-bucket` and `--s3-root` do not change where the snapshot is read or written; the URI is authoritative. Pass the same connection options to create, verify, import, list, and delete commands.
 
 :::
 
@@ -130,7 +130,7 @@ greptime cli data import-v2 \
   --s3-endpoint http://127.0.0.1:9000
 ```
 
-For AWS S3, use the same `--s3` options but omit `--s3-endpoint` unless you use a custom endpoint. If your environment uses instance profiles or another credential provider, explicit access keys may not be required. The S3 backend still requires `--s3`, `--s3-bucket`, and `--s3-region`.
+For AWS S3, use the same `--s3` options but omit `--s3-endpoint` unless you use a custom endpoint. If your environment uses instance profiles or another credential provider, explicit access keys may not be required. The S3 backend still requires `--s3` and `--s3-region`.
 
 ## Export selected schemas
 
@@ -369,7 +369,7 @@ Common S3 options are:
 
 | Option | Description |
 | --- | --- |
-| `--s3-bucket` | S3 bucket name. Required for S3. |
+| `--s3-bucket` | S3 bucket name. Does not affect the snapshot location; the bucket in the snapshot URI is used. |
 | `--s3-region` | S3 region. Required for S3. |
 | `--s3-access-key-id` | Access key ID. Optional when the environment provides credentials. |
 | `--s3-secret-access-key` | Secret access key. Optional when the environment provides credentials. |
@@ -407,8 +407,8 @@ The failed run leaves a partial snapshot on disk, and `export-v2 verify` reports
 
 Check that:
 
-- The bucket in the snapshot URI matches `--s3-bucket`.
-- `--s3-endpoint` is set for MinIO or other S3-compatible services.
+- The bucket and path in the snapshot URI are correct. `--s3-bucket` does not change the snapshot location.
+- `--s3-endpoint` is set for MinIO or other S3-compatible services. Without it, the CLI sends requests to the public AWS S3 endpoint for `--s3-region`, which usually shows up as a long hang or a `301` response rather than a clear configuration error.
 - The credentials can read and write the snapshot location.
 - You pass the same storage options to create, verify, import, list, and delete commands.
 

--- a/versioned_docs/version-1.2/user-guide/deployments-administration/disaster-recovery/export-import-v2.md
+++ b/versioned_docs/version-1.2/user-guide/deployments-administration/disaster-recovery/export-import-v2.md
@@ -27,7 +27,9 @@ Before using Export/Import V2, make sure that:
 
 For remote object storage, explicitly enable one supported backend and provide the backend options. Export/Import V2 supports S3-compatible storage, Alibaba Cloud OSS, Google Cloud Storage, and Azure Blob Storage. For example, use `--s3` with `--s3-bucket` and `--s3-region` for S3-compatible storage.
 
-For `file://` snapshots, the path must be accessible from the GreptimeDB server as well as the CLI client. This usually means running the CLI on the same host as a standalone server, or mounting the same filesystem path into the GreptimeDB server. For remote, Kubernetes, or distributed deployments, use object storage such as S3 or MinIO instead of a local `file://` path.
+For `file://` snapshots, the path must be accessible from the GreptimeDB server as well as the CLI client. This usually means running the CLI on the same host as a standalone server, or mounting the same filesystem path into the GreptimeDB server. The parent directory of the snapshot must exist before you create the snapshot. For remote, Kubernetes, or distributed deployments, use object storage such as S3 or MinIO instead of a local `file://` path.
+
+The GreptimeDB server writes snapshot data files with `COPY DATABASE ... TO`, so a `file://` snapshot path must also be inside the server's copy root, which is `storage.copy_root` and defaults to `<storage.data_home>/copy`. The server rejects a path outside the copy root. See [Migrate Local SQL File Access](/user-guide/deployments-administration/migrate-local-sql-file-access.md) for details.
 
 :::note
 
@@ -38,6 +40,21 @@ The snapshot URI, such as `s3://my-bucket/snapshots/prod`, identifies the snapsh
 ## Quick start with local filesystem
 
 Use a local filesystem snapshot only when the path is shared by the CLI client and the GreptimeDB server. For example, this works for a local standalone server when the CLI runs on the same host.
+
+The examples in this guide store snapshots under `/tmp/greptime-snapshots`. Set this directory as the server's copy root in the GreptimeDB configuration file and restart the server:
+
+```toml
+[storage]
+copy_root = "/tmp/greptime-snapshots"
+```
+
+Alternatively, keep the default copy root and use a snapshot path under `<storage.data_home>/copy`, such as `file:///path/to/data_home/copy/demo`.
+
+Create the parent directory so that both the server and the CLI can access it:
+
+```bash
+mkdir -p /tmp/greptime-snapshots
+```
 
 Create a snapshot:
 
@@ -117,6 +134,8 @@ For AWS S3, use the same `--s3` options but omit `--s3-endpoint` unless you use 
 
 ## Export selected schemas
 
+By default, `export-v2 create` exports every schema except `information_schema`. This includes the `greptime_private` schema, and importing such a snapshot restores `greptime_private` as well. To exclude it, list the schemas you want explicitly with `--schemas`.
+
 Export only selected schemas with `--schemas`. You can pass a comma-separated list:
 
 ```bash
@@ -165,6 +184,19 @@ greptime cli data import-v2 \
   --addr 127.0.0.1:4000 \
   --from file:///tmp/greptime-snapshots/schema-only
 ```
+
+## Choose the data file format
+
+Use `--format` to choose the data file format. Supported values are `parquet`, `csv`, and `json`. The default is `parquet`.
+
+```bash
+greptime cli data export-v2 create \
+  --addr 127.0.0.1:4000 \
+  --to file:///tmp/greptime-snapshots/demo-csv \
+  --format csv
+```
+
+The format is recorded in the snapshot manifest. `import-v2` reads the format from the manifest and applies it automatically, so you do not need to specify the format again when importing.
 
 ## Export by time range and chunk window
 
@@ -354,6 +386,18 @@ Check that GreptimeDB is running and that `--addr` points to the HTTP endpoint:
 ```bash
 curl http://127.0.0.1:4000/health
 ```
+
+### `file://` path is outside the configured copy root
+
+If `export-v2 create` fails with an error such as the following, the snapshot path is outside the server's copy root:
+
+```text
+Local filesystem path '/tmp/greptime-snapshots/demo/data/greptime_private/1/' is outside the configured copy root or is unsafe
+```
+
+Set `storage.copy_root` to a directory that contains the snapshot path, or use a snapshot path under `<storage.data_home>/copy`. See [Migrate Local SQL File Access](/user-guide/deployments-administration/migrate-local-sql-file-access.md) for details.
+
+The failed run leaves a partial snapshot on disk, and `export-v2 verify` reports the failed chunk. After fixing the configuration, run the same `export-v2 create` command again to resume, or pass `--force` to recreate the snapshot.
 
 ### `--chunk-time-window` fails validation
 


### PR DESCRIPTION
## What

Corrections to the Export/Import V2 page, based on an end-to-end run of the page against `greptime/greptimedb:v1.2.0` (commit `29b743ab`): standalone with a local filesystem snapshot, and a MinIO container for the object storage path. The rest of the page matched observed behavior and is left untouched.

Applies to `docs/` and `versioned_docs/version-1.2/`, plus the matching Chinese pages. The English pair and the Chinese pair are each kept identical.

## Local filesystem

### 1. Quick start fails on a default v1.2 configuration (copy root sandbox)

The first command in "Quick start with local filesystem" fails as written:

```bash
greptime cli data export-v2 create \
  --addr 127.0.0.1:4000 \
  --to file:///tmp/greptime-snapshots/demo
```

Server-side error (HTTP 400 on `/v1/sql`):

```text
Local filesystem path '/tmp/greptime-snapshots/demo/data/greptime_private/1/' is outside the configured copy root or is unsafe: absolute path is outside the configured copy root; use a path relative to the copy root or use S3, OSS, GCS, or AzBlob
```

`export-v2` writes data files through `COPY DATABASE ... TO`, and since v1.2 local paths in `COPY` are sandboxed to `storage.copy_root` (default `<storage.data_home>/copy`). Both fixes were verified: setting `[storage] copy_root = "/tmp/greptime-snapshots"` makes the documented command succeed unchanged, and using a path under the default copy root works too. Object storage targets are not subject to the sandbox (the server writes `s3://` directly), which the page now states next to its existing "use object storage for remote/distributed deployments" advice.

The page now:

- States the copy root constraint in Prerequisites and links to [Migrate Local SQL File Access](https://docs.greptime.com/user-guide/deployments-administration/migrate-local-sql-file-access).
- Adds the `storage.copy_root` snippet (and a `mkdir -p`) to the quick start so every `file:///tmp/greptime-snapshots/...` example on the page runs as written, with the default-copy-root path as the alternative.
- Adds a Troubleshooting entry with the error above. The failed run leaves a partial snapshot on disk that `export-v2 verify` reports as a failed chunk, so the entry also says how to resume or recreate it.

### 2. `--format` was undocumented

`export-v2 create --format <parquet|csv|json>` (default `parquet`) was not mentioned anywhere. CSV was verified end to end: the export produces `.csv` data files, and `import-v2` picks the format up from the manifest and issues `COPY ... WITH (FORMAT='csv')` on its own. Added a short section saying so, including that the format does not need to be repeated at import time.

### 3. Default schema set includes `greptime_private`

With no `--schemas`, v1.2.0 exports `["greptime_private", "metrics", "public"]`, excluding only `information_schema`, and `greptime_private` is restored on import. The page now states this and points to `--schemas` for excluding it.

### 4. Parent directory must exist

For `file://` snapshots the parent directory has to exist beforehand. Added one sentence in Prerequisites and the `mkdir -p` step in the quick start.

## Object storage (S3 / MinIO)

The documented S3/MinIO commands work as written: create, verify, list, import, and delete all succeed with the same option set, and a cross-instance restore matches row counts. Two statements around them do not hold.

### 5. `--s3-bucket` and `--s3-root` do not affect the snapshot location

The page told readers to keep `--s3-bucket` consistent with the URI and, under `NoSuchBucket`, to check that the URI bucket matches `--s3-bucket`. On v1.2.0 the bucket in the URI is the only thing that matters:

| Experiment | Command | Result |
| --- | --- | --- |
| Mismatched bucket, read | URI `s3://greptime/...` + `--s3-bucket wrongbucket`, `verify` | `Snapshot is valid.` |
| Mismatched bucket, write | same options, `create` | Succeeds; data lands in `greptime`, `wrongbucket` is never created or accessed |
| No `--s3-bucket` at all | `--s3` + `--s3-region` + credentials + `--s3-endpoint` | `Snapshot is valid.` |
| Reverse | URI `s3://nosuchbucket/...` + `--s3-bucket greptime` | `Snapshot not found at 's3://nosuchbucket/...'` |
| `--s3-root /myprefix` | URI `s3://greptime/snapshots/rootTest` | Snapshot still at `snapshots/rootTest/`; `myprefix` never appears |

The only options actually enforced are `--s3` (`s3:// requires --s3 and related options`) and `--s3-region` (`S3 region must be set when --s3 is enabled`), which the page already had right.

Changed: the note no longer asks readers to keep `--s3-bucket` consistent and says the URI is authoritative; `--s3-bucket` is no longer listed as required (Prerequisites, the AWS paragraph, the options table); the `NoSuchBucket` troubleshooting item points at the URI instead. The examples keep `--s3-bucket` as they were, since they work.

### 6. A missing `--s3-endpoint` hangs instead of failing

Against MinIO without `--s3-endpoint`, the CLI does not fail fast; it sends requests to `https://s3.us-west-2.amazonaws.com/...`, gets `301`, and keeps retrying (still running after 20 s, killed by hand). The troubleshooting item already said to check the endpoint; it now describes this symptom so readers recognize it.

## Checks

- `DOC_LANG=en pnpm check:links` and `DOC_LANG=zh pnpm check:links` pass, including the new cross-links in the versioned copies.
- `git diff --check` clean; no lockfile or generated files touched.
