### PR TITLE
fix: redirect stable aliases during client navigation

### DIFF
--- a/src/theme/Root/__tests__/index.test.ts
+++ b/src/theme/Root/__tests__/index.test.ts
@@ -1,0 +1,71 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { location, versions, redirect } = vi.hoisted(() => ({
+  location: { pathname: '/', search: '', hash: '' },
+  versions: [
+    { name: 'current', isLast: false, docs: [{ path: '/nightly/' }] },
+    { name: '1.2', isLast: true, docs: [{ path: '/' }, { path: '/user-guide/overview' }] },
+    { name: '1.1', isLast: false, docs: [{ path: '/1.1/' }] },
+  ],
+  redirect: vi.fn<(props: unknown) => null>(() => null),
+}));
+
+vi.mock('@docusaurus/router', () => ({
+  useLocation: () => location,
+  Redirect: redirect,
+}));
+vi.mock('@docusaurus/useGlobalData', () => ({
+  usePluginData: () => ({ versions }),
+}));
+
+import Root from '../index';
+
+const render = () => renderToStaticMarkup(
+  React.createElement(Root, { children: 'Original route' }),
+);
+
+beforeEach(() => {
+  Object.assign(location, { pathname: '/', search: '', hash: '' });
+  versions[1].name = '1.2';
+  redirect.mockClear();
+});
+
+describe('stable alias navigation', () => {
+  it.each(['/1.2/user-guide/overview', '/1.2/user-guide/overview/'])(
+    'redirects %s before rendering the original route and preserves query/hash',
+    pathname => {
+      Object.assign(location, { pathname, search: '?source=search', hash: '#overview' });
+      expect(render()).toBe('');
+      expect(redirect.mock.calls[0][0]).toEqual({
+        to: { pathname: '/user-guide/overview/', search: '?source=search', hash: '#overview' },
+      });
+    },
+  );
+
+  it.each(['/1.2', '/1.2/'])('redirects the version root %s', pathname => {
+    location.pathname = pathname;
+    render();
+    expect(redirect.mock.calls[0][0]).toEqual({ to: { pathname: '/', search: '', hash: '' } });
+  });
+
+  it.each([
+    '/user-guide/overview/', '/1.1/', '/nightly/', '/1.20/',
+    '/1.2/missing/', '/1.2/nightly/', '/1.2/1.1/', '/1.2/search/',
+  ])('leaves %s to the normal router', pathname => {
+    location.pathname = pathname;
+    expect(render()).toBe('Original route');
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  it('follows stable promotion without keeping the previous alias', () => {
+    versions[1].name = '1.3';
+    location.pathname = '/1.3/user-guide/overview/';
+    expect(render()).toBe('');
+    redirect.mockClear();
+    location.pathname = '/1.2/user-guide/overview/';
+    expect(render()).toBe('Original route');
+    expect(redirect).not.toHaveBeenCalled();
+  });
+});

--- a/src/theme/Root/index.tsx
+++ b/src/theme/Root/index.tsx
@@ -1,0 +1,26 @@
+import React, { type ReactNode } from 'react';
+import { Redirect, useLocation } from '@docusaurus/router';
+import { usePluginData } from '@docusaurus/useGlobalData';
+
+export default function Root({ children }: { children: ReactNode }): ReactNode {
+  const { pathname, search, hash } = useLocation();
+  const { versions } = usePluginData('docusaurus-plugin-content-docs') as {
+    versions: { name: string; isLast: boolean; docs: { path: string }[] }[];
+  };
+  const stable = versions.find(version => version.isLast);
+  if (!stable) return children;
+  const prefix = `/${stable.name}`;
+
+  if (pathname === prefix || pathname.startsWith(`${prefix}/`)) {
+    const targetPath = pathname.slice(prefix.length).replace(/\/$/, '') || '/';
+    const target = stable.docs.find(doc =>
+      (doc.path.replace(/\/$/, '') || '/') === targetPath,
+    );
+    if (target) {
+      // Static redirect files are bypassed by same-site React Router navigation.
+      return <Redirect to={{ pathname: `${targetPath.replace(/\/$/, '')}/`, search, hash }} />;
+    }
+  }
+
+  return children;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,4 +4,5 @@ export default defineConfig({
   test: {
     include: ['src/**/__tests__/**/*.test.ts'],
   },
+  oxc: { jsx: { runtime: 'automatic' } },
 });


### PR DESCRIPTION
## What changed

Fix a 404 when opening stable-version URLs such as `/1.2/user-guide/overview/` from site search. Redirect valid aliases before rendering the route, preserving query strings and anchors. Existing static redirects remain in place.

Follow-up to #2847.

## Scope

- Documentation versions: current stable alias; no documentation content changes
- Languages: English and Chinese

## Verification

- `pnpm test`: 57 passed; `git diff --check` and changed-file spelling checks passed.
- `DOC_LANG=en pnpm check:links` and `DOC_LANG=zh pnpm check:links`: passed.
- Browser checks in both languages: search click/Enter, query/hash, back navigation, direct access, and invalid paths.
- `pnpm typecheck` remains blocked by existing dependency type-resolution errors.

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors.
- [x] I updated navigation when the document structure changed.
