### PR TITLE
docs: cover v1.0 static authentication and clarify warnings

### DIFF
--- a/docs/user-guide/deployments-administration/authentication/static.md
+++ b/docs/user-guide/deployments-administration/authentication/static.md
@@ -32,7 +32,7 @@ Users configured this way have read-write access by default. File parsing follow
 
 Malformed entries and read errors produce warnings in the server log.
 
-For MySQL and PostgreSQL connections, `*` is reserved for bearer-token authentication. These two providers do not support bearer tokens, so `*` cannot be used as a password-authenticated SQL username.
+For MySQL and PostgreSQL connections, `*` is reserved for bearer-token authentication. `static_user_provider` and `watch_file_user_provider` do not support bearer tokens, so `*` cannot be used as a password-authenticated SQL username.
 
 ### Permission Modes
 
@@ -64,7 +64,7 @@ editor:rw=editor_pwd
 
 In this configuration:
 
-- `admin` has full read-write access (default)
+- `admin` has read-write access (default)
 - `alice` has read-only access
 - `bob` has write-only access
 - `viewer` has read-only access
@@ -118,6 +118,8 @@ Passwords are prefix-parsed. A legacy plaintext password that literally starts w
 SCRAM-SHA-256 lets PostgreSQL clients authenticate without sending the password in cleartext.
 
 GreptimeDB selects SCRAM-SHA-256 only when every configured user has a plaintext password (with or without `plain:`) or a `pg_scram_sha256:` verifier. These two formats can be mixed.
+
+With SCRAM-SHA-256, the server also sends an authentication challenge for an unknown username. After the client submits its proof, the server returns the same authentication failure result as for an incorrect password.
 
 :::warning
 A single `pbkdf2_sha256:` or `mysql_native_password:` entry makes PostgreSQL authentication fall back to cleartext for all users of that provider. A user with a `mysql_native_password:` verifier cannot authenticate through that fallback either, because the verifier cannot validate a cleartext password.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/authentication/static.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/authentication/static.md
@@ -32,7 +32,7 @@ bob=bbb
 
 格式错误的记录和读取错误会在服务端日志中产生告警。
 
-对于 MySQL 和 PostgreSQL 连接，用户名 `*` 保留用于 Bearer Token 认证。这两个 provider 不支持 Bearer Token，因此不能使用 `*` 作为通过密码认证的 SQL 用户名。
+对于 MySQL 和 PostgreSQL 连接，用户名 `*` 保留用于 Bearer Token 认证。`static_user_provider` 和 `watch_file_user_provider` 不支持 Bearer Token，因此不能使用 `*` 作为通过密码认证的 SQL 用户名。
 
 ### 权限模式
 
@@ -64,7 +64,7 @@ editor:rw=editor_pwd
 
 在此配置中：
 
-- `admin` 拥有完整的读写权限（默认）
+- `admin` 拥有读写权限（默认）
 - `alice` 拥有只读权限
 - `bob` 拥有只写权限
 - `viewer` 拥有只读权限
@@ -118,6 +118,8 @@ alice:readonly=pbkdf2_sha256:4096:73616c74:c5e478d59288c841aa530db6845c4c8d96289
 PostgreSQL 客户端使用 SCRAM-SHA-256 认证时，不发送明文密码。
 
 只有所有已配置用户都使用明文密码（带或不带 `plain:` 前缀）或 `pg_scram_sha256:` verifier 时，GreptimeDB 才会选择 SCRAM-SHA-256。这两种格式可以混用。
+
+使用 SCRAM-SHA-256 时，服务端也会向未知用户发送认证挑战。客户端提交 proof 后，服务端返回与密码错误相同的认证失败结果。
 
 :::warning
 只要存在一条 `pbkdf2_sha256:` 或 `mysql_native_password:` 记录，该 provider 的所有用户都会使用 PostgreSQL 明文认证。使用 `mysql_native_password:` verifier 的用户也无法通过回退后的明文认证，因为该 verifier 不能校验明文密码。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/deployments-administration/authentication/static.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.0/user-guide/deployments-administration/authentication/static.md
@@ -5,7 +5,7 @@ description: 介绍了 GreptimeDB 的静态用户配置，允许通过配置文�
 
 # Static User Provider
 
-GreptimeDB 提供了简单的内置身份验证机制，允许你配置一个固定的帐户以方便使用，或者配置一个帐户文件以支持多个用户帐户。通过传入文件，GreptimeDB 会加载其中的所有用户。
+GreptimeDB 通过 `static_user_provider` 提供用户名和密码认证，在启动时从文件或命令行参数加载凭证。`watch_file_user_provider` 使用相同的文件格式，并在文件变更时重新加载凭证。
 
 ## 单机模式
 
@@ -21,20 +21,34 @@ alice=aaa
 bob=bbb
 ```
 
-以这种方式配置的用户默认拥有完整的读写权限。
+以这种方式配置的用户默认拥有读写权限。文件解析规则如下：
+
+- 每行的首尾空白会被移除，空行和以 `#` 开头的行会被忽略。
+- 每条凭证必须恰好包含一个 `=`，密码不能包含 `=`。
+- 用户名和密码中位于 `=` 两侧的空白不会被移除，不要在分隔符两侧添加空格。
+- 同一用户名出现多次时，最后一条有效记录生效。
+- 格式错误的记录会被跳过。文件必须存在且至少包含一条有效凭证，否则 provider 初始化失败。
+- 读取错误（包括无效 UTF-8）会终止后续解析，错误发生前读到的有效凭证仍可能被加载。
 
 ### 权限模式
 
-你可以选择性地指定权限模式来控制用户的访问级别。格式为：
+可通过可选的权限模式控制读写访问，格式为：
 
 ```
 username:permission_mode=password
 ```
 
-可用的权限模式：
-- `rw` 或 `readwrite` - 完整的读写权限（未指定时的默认值）
-- `ro` 或 `readonly` - 只读权限
-- `wo` 或 `writeonly` - 只写权限
+权限模式不区分大小写：
+
+- `rw`、`readwrite` 或 `read_write` - 读写权限（未指定时的默认值）
+- `ro`、`readonly` 或 `read_only` - 只读权限
+- `wo`、`writeonly` 或 `write_only` - 只写权限
+
+:::warning
+v1.0 中，无法识别的权限模式会退回读写权限。例如，`alice:readonyl=pwd` 会赋予 `alice` 读写权限。加载配置前应检查权限模式的拼写。
+:::
+
+这些权限模式不限定到单个数据库或表。
 
 混合权限模式的配置示例：
 
@@ -47,7 +61,8 @@ editor:rw=editor_pwd
 ```
 
 在此配置中：
-- `admin` 拥有完整的读写权限（默认）
+
+- `admin` 拥有读写权限（默认）
 - `alice` 拥有只读权限
 - `bob` 拥有只写权限
 - `viewer` 拥有只读权限
@@ -55,36 +70,37 @@ editor:rw=editor_pwd
 
 ### 启动服务器
 
-在启动服务端时，需添加 `--user-provider` 参数，并将其设置为 `static_user_provider:file:<path_to_file>`（请将 `<path_to_file>` 替换为你的用户配置文件路径）：
+启动时，将 `--user-provider` 设置为 `static_user_provider:file:<path_to_file>`，并将 `<path_to_file>` 替换为用户配置文件路径：
 
 ```shell
-./greptime standalone start --user-provider=static_user_provider:file:<path_to_file>
+./greptime standalone start --user-provider='static_user_provider:file:<path_to_file>'
 ```
 
-用户及其权限将被载入 GreptimeDB 的内存。使用这些用户账户连接至 GreptimeDB 时，系统会严格执行相应的访问权限控制。
+provider 在启动时将有效用户及其权限模式加载到内存中。文件修改后需重启服务器才能生效。
 
-:::tip 注意
-`static_user_provider:file` 模式下，文件的内容只会在启动时被加载到数据库中，在数据库运行时修改或追加的内容不会生效。
-:::
+也可以通过 `static_user_provider:cmd` 在命令行中配置凭证，使用逗号分隔多条记录：
+
+```shell
+./greptime standalone start --user-provider='static_user_provider:cmd:admin=admin_pwd,alice:ro=alice_pwd'
+```
+
+记录使用与文件相同的凭证语法。命令行中的明文密码不能包含 `,` 或 `=`，无效记录会导致 provider 初始化失败。命令行凭证可能出现在 shell 历史和进程列表中，部署时应使用凭证文件。
 
 ### 动态文件重载
 
-如果你需要在不重启服务器的情况下更新用户凭证，可以使用 `watch_file_user_provider` 替代 `static_user_provider:file`。该 provider 会监控凭证文件的变化并自动重新加载：
+`watch_file_user_provider` 监控凭证文件，无需重启服务器即可重新加载用户和权限模式：
 
 ```shell
-./greptime standalone start --user-provider=watch_file_user_provider:<path_to_file>
+./greptime standalone start --user-provider='watch_file_user_provider:<path_to_file>'
 ```
 
-`watch_file_user_provider`的特点：
-- 使用与 `static_user_provider:file` 相同的文件格式
-- 自动检测文件修改并重新加载凭证
-- 允许在不重启服务器的情况下添加、删除或修改用户
-- 如果文件临时不可用或无效，会保持上次有效的配置
+启动时，文件必须存在且至少包含一条有效凭证。重载时：
 
-这在需要动态管理用户访问的生产环境中特别有用。
+- 如果文件无法打开或没有有效凭证，provider 保留上一次配置。
+- 否则，加载到的凭证会替换上一次配置。格式错误的记录会被跳过，不会导致整个文件被拒绝。未出现在加载结果中的用户会被移除，包括记录变为无效的用户。
+
+重载不会断开已有的 MySQL 或 PostgreSQL 会话，也不会更新这些会话中已保存的用户信息。修改后的凭证和权限模式适用于后续认证。
 
 ## Kubernetes 集群
 
-你可以在 `values.yaml` 文件中配置鉴权用户。
-更多详情，请参考 [Helm Chart 配置](/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md#鉴权配置)。
-
+在 `values.yaml` 中配置鉴权用户，参见 [Helm Chart 配置](/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md#鉴权配置)。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/deployments-administration/authentication/static.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.1/user-guide/deployments-administration/authentication/static.md
@@ -44,7 +44,9 @@ username:permission_mode=password
 - `ro`、`readonly` 或 `read_only` - 只读权限
 - `wo`、`writeonly` 或 `write_only` - 只写权限
 
-v1.1 中，无法识别的权限模式会退回读写权限。加载配置前应检查权限模式的拼写。
+:::warning
+v1.1 中，无法识别的权限模式会退回读写权限。例如，`alice:readonyl=pwd` 会赋予 `alice` 读写权限。加载配置前应检查权限模式的拼写。
+:::
 
 这些权限模式不限定到单个数据库或表。
 
@@ -60,7 +62,7 @@ editor:rw=editor_pwd
 
 在此配置中：
 
-- `admin` 拥有完整的读写权限（默认）
+- `admin` 拥有读写权限（默认）
 - `alice` 拥有只读权限
 - `bob` 拥有只写权限
 - `viewer` 拥有只读权限

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/authentication/static.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/authentication/static.md
@@ -60,7 +60,7 @@ editor:rw=editor_pwd
 
 在此配置中：
 
-- `admin` 拥有完整的读写权限（默认）
+- `admin` 拥有读写权限（默认）
 - `alice` 拥有只读权限
 - `bob` 拥有只写权限
 - `viewer` 拥有只读权限
@@ -114,6 +114,8 @@ alice:readonly=pbkdf2_sha256:4096:73616c74:c5e478d59288c841aa530db6845c4c8d96289
 PostgreSQL 客户端使用 SCRAM-SHA-256 认证时，不发送明文密码。
 
 只有所有已配置用户都使用明文密码（带或不带 `plain:` 前缀）或 `pg_scram_sha256:` verifier 时，GreptimeDB 才会选择 SCRAM-SHA-256。这两种格式可以混用。
+
+使用 SCRAM-SHA-256 时，服务端也会向未知用户发送认证挑战。客户端提交 proof 后，服务端返回与密码错误相同的认证失败结果。
 
 :::warning
 只要存在一条 `pbkdf2_sha256:` 或 `mysql_native_password:` 记录，该 provider 的所有用户都会使用 PostgreSQL 明文认证。使用 `mysql_native_password:` verifier 的用户也无法通过回退后的明文认证，因为该 verifier 不能校验明文密码。

--- a/versioned_docs/version-1.0/user-guide/deployments-administration/authentication/static.md
+++ b/versioned_docs/version-1.0/user-guide/deployments-administration/authentication/static.md
@@ -5,7 +5,7 @@ description: Instructions for setting up static user authentication in GreptimeD
 
 # Static User Provider
 
-GreptimeDB offers a simple built-in mechanism for authentication, allowing users to configure either a fixed account for convenient usage or an account file for multiple user accounts. By passing in a file, GreptimeDB loads all users listed within it.
+GreptimeDB supports username/password authentication with `static_user_provider`, which loads credentials from a file or a command-line argument at startup. `watch_file_user_provider` uses the same file format and reloads credentials when the file changes.
 
 ## Standalone Mode
 
@@ -21,20 +21,34 @@ alice=aaa
 bob=bbb
 ```
 
-Users configured this way have full read-write access by default.
+Users configured this way have read-write access by default. File parsing follows these rules:
+
+- Blank lines and lines starting with `#` are ignored after trimming leading and trailing whitespace from each line.
+- Each credential must contain exactly one `=`. Passwords cannot contain `=`.
+- Whitespace around `=` is not removed from the username or password. Do not add spaces around the separator.
+- If a username appears more than once, the last valid entry takes effect.
+- Malformed entries are skipped. The file must exist and contain at least one valid credential; otherwise, provider initialization fails.
+- A read error, including invalid UTF-8, stops parsing. Valid credentials read before the error can still be loaded.
 
 ### Permission Modes
 
-You can optionally specify permission modes to control user access levels. The format is:
+An optional permission mode controls read and write access. The format is:
 
 ```
 username:permission_mode=password
 ```
 
-Available permission modes:
-- `rw` or `readwrite` - Full read and write access (default when not specified)
-- `ro` or `readonly` - Read-only access
-- `wo` or `writeonly` - Write-only access
+Permission modes are case-insensitive:
+
+- `rw`, `readwrite`, or `read_write` - Read and write access (default when omitted)
+- `ro`, `readonly`, or `read_only` - Read-only access
+- `wo`, `writeonly`, or `write_only` - Write-only access
+
+:::warning
+An unrecognized permission mode falls back to read-write access in v1.0. For example, `alice:readonyl=pwd` grants Alice read-write access. Check the spelling of permission modes before loading the configuration.
+:::
+
+These modes are not scoped to individual databases or tables.
 
 Example configuration with mixed permission modes:
 
@@ -47,7 +61,8 @@ editor:rw=editor_pwd
 ```
 
 In this configuration:
-- `admin` has full read-write access (default)
+
+- `admin` has read-write access (default)
 - `alice` has read-only access
 - `bob` has write-only access
 - `viewer` has read-only access
@@ -55,36 +70,37 @@ In this configuration:
 
 ### Starting the Server
 
-Start the server with the `--user-provider` parameter and set it to `static_user_provider:file:<path_to_file>` (replace `<path_to_file>` with the path to your user configuration file):
+Set `--user-provider` to `static_user_provider:file:<path_to_file>`, replacing `<path_to_file>` with the user configuration file path:
 
 ```shell
-./greptime standalone start --user-provider=static_user_provider:file:<path_to_file>
+./greptime standalone start --user-provider='static_user_provider:file:<path_to_file>'
 ```
 
-The users and their permissions will be loaded into GreptimeDB's memory. You can create connections to GreptimeDB using these user accounts with their respective access levels enforced.
+The provider loads valid users and their permission modes into memory at startup. File changes take effect only after a restart.
 
-:::tip Note
-When using `static_user_provider:file`, the file’s contents are loaded at startup. Changes or additions to the file have no effect while the database is running.
-:::
+Credentials can also be passed inline with `static_user_provider:cmd`. Separate entries with commas:
+
+```shell
+./greptime standalone start --user-provider='static_user_provider:cmd:admin=admin_pwd,alice:ro=alice_pwd'
+```
+
+The entries use the same credential syntax as the file. Inline plaintext passwords cannot contain `,` or `=`. Invalid entries fail provider initialization. Command-line credentials can appear in shell history and process listings; use a credential file for deployment.
 
 ### Dynamic File Reloading
 
-If you need to update user credentials without restarting the server, you can use the `watch_file_user_provider` instead of `static_user_provider:file`. This provider monitors the credential file for changes and automatically reloads it:
+`watch_file_user_provider` monitors a credential file and reloads users and permission modes without restarting the server:
 
 ```shell
-./greptime standalone start --user-provider=watch_file_user_provider:<path_to_file>
+./greptime standalone start --user-provider='watch_file_user_provider:<path_to_file>'
 ```
 
-The watch file provider:
-- Uses the same file format as the static file provider
-- Automatically detects file modifications and reloads credentials
-- Allows adding, removing, or modifying users without server restart
-- If the file is temporarily unavailable or invalid, it keeps the last valid configuration
+The file must exist and contain at least one valid credential at startup. On reload:
 
-This is particularly useful in production environments where you need to manage user access dynamically.
+- If the file cannot be opened or contains no valid credentials, the provider retains the previous configuration.
+- Otherwise, the loaded credentials replace the previous configuration. Malformed entries are skipped; they do not reject the entire file. Users omitted from the loaded result are removed, including users whose entries became invalid.
+
+Reloading does not disconnect existing MySQL or PostgreSQL sessions or update the user information already attached to them. Changed credentials and permission modes apply to subsequent authentication.
 
 ## Kubernetes Cluster
 
-You can configure the authentication users in the `values.yaml` file.
-For more details, please refer to the [Helm Chart Configuration](/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md#authentication-configuration).
-
+Configure users in `values.yaml`. See the [Helm Chart Configuration](/user-guide/deployments-administration/deploy-on-kubernetes/common-helm-chart-configurations.md#authentication-configuration).

--- a/versioned_docs/version-1.1/user-guide/deployments-administration/authentication/static.md
+++ b/versioned_docs/version-1.1/user-guide/deployments-administration/authentication/static.md
@@ -44,7 +44,9 @@ Permission modes are case-insensitive:
 - `ro`, `readonly`, or `read_only` - Read-only access
 - `wo`, `writeonly`, or `write_only` - Write-only access
 
-An unrecognized permission mode falls back to read-write access in v1.1. Check the spelling of permission modes before loading the configuration.
+:::warning
+An unrecognized permission mode falls back to read-write access in v1.1. For example, `alice:readonyl=pwd` grants Alice read-write access. Check the spelling of permission modes before loading the configuration.
+:::
 
 These modes are not scoped to individual databases or tables.
 
@@ -60,7 +62,7 @@ editor:rw=editor_pwd
 
 In this configuration:
 
-- `admin` has full read-write access (default)
+- `admin` has read-write access (default)
 - `alice` has read-only access
 - `bob` has write-only access
 - `viewer` has read-only access

--- a/versioned_docs/version-1.2/user-guide/deployments-administration/authentication/static.md
+++ b/versioned_docs/version-1.2/user-guide/deployments-administration/authentication/static.md
@@ -60,7 +60,7 @@ editor:rw=editor_pwd
 
 In this configuration:
 
-- `admin` has full read-write access (default)
+- `admin` has read-write access (default)
 - `alice` has read-only access
 - `bob` has write-only access
 - `viewer` has read-only access
@@ -114,6 +114,8 @@ Passwords are prefix-parsed. A legacy plaintext password that literally starts w
 SCRAM-SHA-256 lets PostgreSQL clients authenticate without sending the password in cleartext.
 
 GreptimeDB selects SCRAM-SHA-256 only when every configured user has a plaintext password (with or without `plain:`) or a `pg_scram_sha256:` verifier. These two formats can be mixed.
+
+With SCRAM-SHA-256, the server also sends an authentication challenge for an unknown username. After the client submits its proof, the server returns the same authentication failure result as for an incorrect password.
 
 :::warning
 A single `pbkdf2_sha256:` or `mysql_native_password:` entry makes PostgreSQL authentication fall back to cleartext for all users of that provider. A user with a `mysql_native_password:` verifier cannot authenticate through that fallback either, because the verifier cannot validate a cleartext password.


### PR DESCRIPTION
## What changed

Follow up on #2856: cover v1.0 credential parsing and file reload behavior, warn about invalid permission modes in v1.0/v1.1, clarify provider names and unknown-user SCRAM authentication, and use consistent permission wording.

## Scope

- Documentation versions: Nightly, 1.2, 1.1, 1.0
- Languages: English, Chinese

## Verification

- Checked v1.0 behavior against v1.0.2 source and SCRAM behavior against main and v1.2.0 source.
- Both locale builds and strict link checks, shell syntax checks, spelling checks, and `git diff --check` passed.

## Checklist

- [x] I verified the content against the applicable GreptimeDB version.
- [x] I updated the relevant documentation versions and languages, or explained why not.
- [x] I checked changed links and anchors. Existing targets and headings are unchanged.
- [x] I updated navigation when the document structure changed. No navigation changes needed.
