### PR TITLE
docs: redraw the disaster recovery diagrams as SVG

### DIFF
--- a/docs/user-guide/deployments-administration/disaster-recovery/dr-solution-based-on-cross-region-deployment-in-single-cluster.md
+++ b/docs/user-guide/deployments-administration/disaster-recovery/dr-solution-based-on-cross-region-deployment-in-single-cluster.md
@@ -41,7 +41,7 @@ those numbers when comparing the solutions.
 
 ### Metadata across 2 regions, data in the same region
 
-![DR-across-2dc-1region](/DR-across-2dc-1region.png)
+![DR-across-2dc-1region](/DR-across-2dc-1region.svg)
 
 In this solution, the data is in one region (2 DCs), while the metadata across 2 regions.
 
@@ -62,7 +62,7 @@ If you want a regional-level disaster recovery solution, you can take it a step 
 
 ### Data across 2 regions
 
-![DR-across-3dc-2region](/DR-across-3dc-2region.png)
+![DR-across-3dc-2region](/DR-across-3dc-2region.svg)
 
 In this solution, the data across 2 regions.
 
@@ -80,7 +80,7 @@ If you can't tolerate performance degradation from a single DC failure, consider
 
 ### Metadata across 3 regions, data across 2 regions
 
-![DR-across-5dc-2region](/DR-across-5dc-2region.png)
+![DR-across-5dc-2region](/DR-across-5dc-2region.svg)
 
 In this solution, the data across 2 regions, while the metadata across 3 regions.
 
@@ -103,7 +103,7 @@ You can take it a step further by providing read and write services on both 3 re
 
 ### Data across 3 regions
 
-![DR-across-5dc-3region](/DR-across-5dc-3region.png)
+![DR-across-5dc-3region](/DR-across-5dc-3region.svg)
 
 In this solution, the data across 3 regions.
 

--- a/docs/user-guide/deployments-administration/disaster-recovery/overview.md
+++ b/docs/user-guide/deployments-administration/disaster-recovery/overview.md
@@ -20,12 +20,12 @@ This document contains:
 
 The following figure illustrates these two concepts:
 
-![RTO-RPO-explain](/RTO-RPO-explain.png)
+![RTO-RPO-explain](/RTO-RPO-explain.svg)
 
 * **Write-Ahead Logging (WAL)**: persistently records every data modification to ensure data integrity and consistency.
 
 GreptimeDB storage engine is a typical [LSM Tree](https://en.wikipedia.org/wiki/Log-structured_merge-tree) :
-![LSM-tree-explain](/LSM-tree-explain.png)
+![LSM-tree-explain](/LSM-tree-explain.svg)
 
 The data written is going firstly persisted into WAL, then applied into Memtable in memory. Under specific conditions (e.g., exceeding the memory threshold), the Memtable will be flushed and persisted as an SSTable. So the DR of WAL and SSTable is key to the DR of GreptimeDB.
 
@@ -36,7 +36,7 @@ The data written is going firstly persisted into WAL, then applied into Memtable
 ### GreptimeDB
 
 Before digging into the specific DR solution, let's explain the architecture of GreptimeDB components in the perspective of DR:
-![Component-architecture](/Component-architecture.png)
+![Component-architecture](/Component-architecture.svg)
 
 GreptimeDB is designed with a cloud-native architecture based on storage-compute separation:
 * **Frontend**:  the ingestion and query service layer, which forwards requests to Datanode and processes, and merges responses from Datanode.
@@ -50,7 +50,7 @@ At the same time, the WAL component is pluggable, e.g. using Kafka as the WAL se
 
 ### Backup and restore
 
-![BR-explain](/BR-explain.png)
+![BR-explain](/BR-explain.svg)
 
 The Backup & Restore (BR) tool can perform a full snapshot backup of databases or tables at a specific time and supports incremental backup.
 When a cluster encounters a disaster, you can restore the cluster from backup data. Generally speaking, BR is the last resort for disaster recovery.
@@ -66,7 +66,7 @@ If the Standalone is running on the local disk for WAL and data, then:
 A good start is to deploy GreptimeDB Standalone into an IaaS platform that has a backup and recovery solution. For example, Amazon EC2 with EBS volumes provides a comprehensive [Backup and Recovery solution](https://docs.aws.amazon.com/prescriptive-guidance/latest/backup-recovery/backup-recovery-ec2-ebs.html).
 
 But if running the Standalone with remote WAL and object storage, there is a better DR solution:
-![DR-Standalone](/DR-Standalone.png)
+![DR-Standalone](/DR-Standalone.svg)
 
 Write the WAL to the Kafka cluster and store the data in object storage, so that the ingested data no longer depends on the node's local disk.
 
@@ -105,7 +105,7 @@ Confirm the resulting RPO and RTO with a failure drill. If the region as a whole
 
 ### DR solution based on Active-Active Failover
 
-![Active-active failover](/active-active-failover.png)
+![Active-active failover](/active-active-failover.svg)
 
 In some edge or small-to-medium scale scenarios, or if you lack the resources to deploy remote WAL or object storage, Active-Active Failover offers a better solution compared to Standalone DR. Two actively serving standalone nodes replicate data changes asynchronously. If a peer or the inter-site network fails, the healthy node continues serving, retains pending changes on its local storage, and sends them after the peer recovers.
 
@@ -123,7 +123,7 @@ For more information about this solution, see [DR solution based on Active-Activ
 
 ### DR solution  based on cross-region deployment in a single cluster
 
-![Cross-region-single-cluster](/Cross-region-single-cluster.png)
+![Cross-region-single-cluster](/Cross-region-single-cluster.svg)
 
 For medium-to-large scale scenarios requiring zero RPO, this solution is highly recommended. In this deployment architecture, the entire cluster spans across three regions, with each region capable of handling both read and write requests. Data replication is achieved using remote WAL and object storage, both of which must have cross-region DR enabled.
 If Region 1 becomes completely unavailable due to a disaster, the table regions within it will be opened and recovered in the other regions.
@@ -139,7 +139,7 @@ Confirm the resulting RPO and RTO with an end-to-end failure drill. For more inf
 
 ### DR solution based on BR
 
-![/BR-DR](/BR-DR.png)
+![/BR-DR](/BR-DR.svg)
 
 In this architecture, GreptimeDB Cluster 1 is deployed in region 1. The BR process continuously and regularly backs up the data from Cluster 1 to region 2. If region 1 experiences a disaster rendering Cluster 1 unrecoverable, you can use the backup data to restore a new cluster (Cluster 2) in region 2 to resume services.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/disaster-recovery/dr-solution-based-on-cross-region-deployment-in-single-cluster.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/disaster-recovery/dr-solution-based-on-cross-region-deployment-in-single-cluster.md
@@ -40,7 +40,7 @@ Table partition count: 3
 
 ### 元数据跨两个区域，数据在同一区域
 
-![DR-across-2dc-1region](/DR-across-2dc-1region.png)
+![DR-across-2dc-1region](/DR-across-2dc-1region.svg)
 
 在此解决方案中，数据位于一个区域（2 个 DC），而元数据跨越两个区域。
 
@@ -60,7 +60,7 @@ DC1 和 DC2 一起用于处理读写服务，而位于第二区域的 DC3 是用
 
 ### 数据跨两个区域
 
-![DR-across-3dc-2region](/DR-across-3dc-2region.png)
+![DR-across-3dc-2region](/DR-across-3dc-2region.svg)
 
 在此解决方案中，数据跨越两个区域。
 
@@ -78,7 +78,7 @@ DC1 和 DC2 一起用于处理读写服务，而位于第二区域的 DC3 是用
 
 ### 元数据跨三个区域，数据跨两个区域
 
-![DR-across-5dc-2region](/DR-across-5dc-2region.png)
+![DR-across-5dc-2region](/DR-across-5dc-2region.svg)
 
 在此解决方案中，数据跨越两个区域，而元数据跨越三个区域。
 
@@ -101,7 +101,7 @@ Region1 和 Region2 一起用于处理读写服务，而 Region3 是一个副本
 
 ## 数据跨三个区域
 
-![DR-across-5dc-3region](/DR-across-5dc-3region.png)
+![DR-across-5dc-3region](/DR-across-5dc-3region.svg)
 
 在此解决方案中，数据跨越三个区域。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/disaster-recovery/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-guide/deployments-administration/disaster-recovery/overview.md
@@ -20,13 +20,13 @@ description: 介绍 GreptimeDB 的灾难恢复（DR）解决方案，包括基�
 
 下图说明了这两个概念：
 
-![RTO-RPO-explain](/RTO-RPO-explain.png)
+![RTO-RPO-explain](/RTO-RPO-explain.svg)
 
 * **预写式日志（WAL）**：持久记录每个数据修改，以确保数据的完整性和一致性。
 
 GreptimeDB 存储引擎是一个典型的 [LSM 树](https://en.wikipedia.org/wiki/Log-structured_merge-tree)：
 
-![LSM-tree-explain](/LSM-tree-explain.png)
+![LSM-tree-explain](/LSM-tree-explain.svg)
 
 写入的数据首先持久化到 WAL，然后应用到内存中的 Memtable。
 在特定条件下（例如超过内存阈值时），
@@ -41,7 +41,7 @@ Memtable 将被刷新并持久化为 SSTable。
 
 在深入了解具体的解决方案之前，让我们从灾难恢复的角度看一下 GreptimeDB 组件的架构：
 
-![Component-architecture](/Component-architecture.png)
+![Component-architecture](/Component-architecture.svg)
 
 GreptimeDB 基于存储计算分离的云原生架构设计：
 
@@ -56,7 +56,7 @@ GreptimeDB 将数据存储在对象存储（如 [AWS S3](https://docs.aws.amazon
 
 ### 备份与恢复
 
-![BR-explain](/BR-explain.png)
+![BR-explain](/BR-explain.svg)
 
 备份与恢复（BR）工具可以在特定时间对数据库或表进行完整快照备份，并支持增量备份。
 当集群遇到灾难时，你可以使用备份数据恢复集群。
@@ -75,7 +75,7 @@ GreptimeDB 将数据存储在对象存储（如 [AWS S3](https://docs.aws.amazon
 
 但是如果使用远程 WAL 和对象存储运行 Standalone，有一个更好的 DR 解决方案：
 
-![DR-Standalone](/DR-Standalone.png)
+![DR-Standalone](/DR-Standalone.svg)
 
 把 WAL 写入 Kafka、数据存入对象存储之后，已写入的数据不再依赖节点本地磁盘；灾难发生时可以借助远程 WAL 和对象存储恢复实例。
 
@@ -114,7 +114,7 @@ RPO=0 和分钟级 RTO 是该拓扑的设计目标，成立需要三个前提：
 
 ### 基于双活互备的 DR 解决方案
 
-![Active-active failover](/active-active-failover.png)
+![Active-active failover](/active-active-failover.svg)
 
 在某些边缘或中小型场景中，或者如果你没有资源部署 Remote WAL 或对象存储，双活互备相对于 Standalone 的灾难恢复提供了更好的解决方案。
 两个独立节点都能提供服务，并异步复制数据变更。
@@ -132,7 +132,7 @@ RPO=0 和分钟级 RTO 是该拓扑的设计目标，成立需要三个前提：
 
 ### 基于单集群跨区域部署的 DR 解决方案
 
-![Cross-region-single-cluster](/Cross-region-single-cluster.png)
+![Cross-region-single-cluster](/Cross-region-single-cluster.svg)
 
 对于需要零 RPO 的中大型场景，强烈推荐此解决方案。
 在此部署架构中，整个集群跨越三个 Region，每个 Region 都能处理读写请求。
@@ -151,7 +151,7 @@ Region 3 作为副本遵循 Metasrv 的多种协议。
 
 ### 基于备份恢复的 DR 解决方案
 
-![/BR-DR](/BR-DR.png)
+![/BR-DR](/BR-DR.svg)
 
 在此架构中，GreptimeDB Cluster 1 部署在 Region 1。
 BR 进程持续定期将数据从 Cluster 1 备份到 Region 2。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/disaster-recovery/dr-solution-based-on-cross-region-deployment-in-single-cluster.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/disaster-recovery/dr-solution-based-on-cross-region-deployment-in-single-cluster.md
@@ -40,7 +40,7 @@ Table partition count: 3
 
 ### 元数据跨两个区域，数据在同一区域
 
-![DR-across-2dc-1region](/DR-across-2dc-1region.png)
+![DR-across-2dc-1region](/DR-across-2dc-1region.svg)
 
 在此解决方案中，数据位于一个区域（2 个 DC），而元数据跨越两个区域。
 
@@ -60,7 +60,7 @@ DC1 和 DC2 一起用于处理读写服务，而位于第二区域的 DC3 是用
 
 ### 数据跨两个区域
 
-![DR-across-3dc-2region](/DR-across-3dc-2region.png)
+![DR-across-3dc-2region](/DR-across-3dc-2region.svg)
 
 在此解决方案中，数据跨越两个区域。
 
@@ -78,7 +78,7 @@ DC1 和 DC2 一起用于处理读写服务，而位于第二区域的 DC3 是用
 
 ### 元数据跨三个区域，数据跨两个区域
 
-![DR-across-5dc-2region](/DR-across-5dc-2region.png)
+![DR-across-5dc-2region](/DR-across-5dc-2region.svg)
 
 在此解决方案中，数据跨越两个区域，而元数据跨越三个区域。
 
@@ -101,7 +101,7 @@ Region1 和 Region2 一起用于处理读写服务，而 Region3 是一个副本
 
 ## 数据跨三个区域
 
-![DR-across-5dc-3region](/DR-across-5dc-3region.png)
+![DR-across-5dc-3region](/DR-across-5dc-3region.svg)
 
 在此解决方案中，数据跨越三个区域。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/disaster-recovery/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.2/user-guide/deployments-administration/disaster-recovery/overview.md
@@ -20,13 +20,13 @@ description: 介绍 GreptimeDB 的灾难恢复（DR）解决方案，包括基�
 
 下图说明了这两个概念：
 
-![RTO-RPO-explain](/RTO-RPO-explain.png)
+![RTO-RPO-explain](/RTO-RPO-explain.svg)
 
 * **预写式日志（WAL）**：持久记录每个数据修改，以确保数据的完整性和一致性。
 
 GreptimeDB 存储引擎是一个典型的 [LSM 树](https://en.wikipedia.org/wiki/Log-structured_merge-tree)：
 
-![LSM-tree-explain](/LSM-tree-explain.png)
+![LSM-tree-explain](/LSM-tree-explain.svg)
 
 写入的数据首先持久化到 WAL，然后应用到内存中的 Memtable。
 在特定条件下（例如超过内存阈值时），
@@ -41,7 +41,7 @@ Memtable 将被刷新并持久化为 SSTable。
 
 在深入了解具体的解决方案之前，让我们从灾难恢复的角度看一下 GreptimeDB 组件的架构：
 
-![Component-architecture](/Component-architecture.png)
+![Component-architecture](/Component-architecture.svg)
 
 GreptimeDB 基于存储计算分离的云原生架构设计：
 
@@ -56,7 +56,7 @@ GreptimeDB 将数据存储在对象存储（如 [AWS S3](https://docs.aws.amazon
 
 ### 备份与恢复
 
-![BR-explain](/BR-explain.png)
+![BR-explain](/BR-explain.svg)
 
 备份与恢复（BR）工具可以在特定时间对数据库或表进行完整快照备份，并支持增量备份。
 当集群遇到灾难时，你可以使用备份数据恢复集群。
@@ -75,7 +75,7 @@ GreptimeDB 将数据存储在对象存储（如 [AWS S3](https://docs.aws.amazon
 
 但是如果使用远程 WAL 和对象存储运行 Standalone，有一个更好的 DR 解决方案：
 
-![DR-Standalone](/DR-Standalone.png)
+![DR-Standalone](/DR-Standalone.svg)
 
 把 WAL 写入 Kafka、数据存入对象存储之后，已写入的数据不再依赖节点本地磁盘；灾难发生时可以借助远程 WAL 和对象存储恢复实例。
 
@@ -85,7 +85,7 @@ RPO=0 和分钟级 RTO 是该拓扑的设计目标，成立需要三个前提：
 
 ### 基于双活互备的 DR 解决方案
 
-![Active-active failover](/active-active-failover.png)
+![Active-active failover](/active-active-failover.svg)
 
 在某些边缘或中小型场景中，或者如果你没有资源部署 Remote WAL 或对象存储，双活互备相对于 Standalone 的灾难恢复提供了更好的解决方案。
 两个独立节点都能提供服务，并异步复制数据变更。
@@ -103,7 +103,7 @@ RPO=0 和分钟级 RTO 是该拓扑的设计目标，成立需要三个前提：
 
 ### 基于单集群跨区域部署的 DR 解决方案
 
-![Cross-region-single-cluster](/Cross-region-single-cluster.png)
+![Cross-region-single-cluster](/Cross-region-single-cluster.svg)
 
 对于需要零 RPO 的中大型场景，强烈推荐此解决方案。
 在此部署架构中，整个集群跨越三个 Region，每个 Region 都能处理读写请求。
@@ -122,7 +122,7 @@ Region 3 作为副本遵循 Metasrv 的多种协议。
 
 ### 基于备份恢复的 DR 解决方案
 
-![/BR-DR](/BR-DR.png)
+![/BR-DR](/BR-DR.svg)
 
 在此架构中，GreptimeDB Cluster 1 部署在 Region 1。
 BR 进程持续定期将数据从 Cluster 1 备份到 Region 2。

--- a/static/BR-DR.svg
+++ b/static/BR-DR.svg
@@ -94,7 +94,7 @@
   <rect class="node" x="1178" y="232" width="194" height="44" rx="9"/>
   <text class="t" x="1275" y="261" text-anchor="middle">Datanode</text>
   <rect x="1196" y="294" width="158" height="44" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
-  <text class="m" x="1275" y="321" text-anchor="middle" fill="#2f8fb5">Region 1-2</text>
+  <text class="m" x="1275" y="321" text-anchor="middle" fill="#2f8fb5">Region 1-1</text>
   <rect x="1196" y="356" width="158" height="44" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
   <text class="m" x="1275" y="383" text-anchor="middle" fill="#2f8fb5">Region 1-2</text>
   <rect x="1196" y="418" width="158" height="44" rx="7" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>

--- a/static/BR-DR.svg
+++ b/static/BR-DR.svg
@@ -1,0 +1,104 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1460" height="600" viewBox="0 0 1460 600" role="img" aria-labelledby="title description">
+  <title id="title">Disaster recovery based on backup and restore across two regions</title>
+  <desc id="description">Cluster 1 in region 1 backs up to storage in region 2; a new cluster 2 is restored there if region 1 is lost.</desc>
+  <defs>
+    <marker id="a" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="g" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="gs" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="as" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="am" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#b5760a"/>
+    </marker>
+    <style>
+      .t { font: 600 19px Arial, sans-serif; fill: #170128; }
+      .l { font: 16px Arial, sans-serif; fill: #39314a; }
+      .s { font: 14px Arial, sans-serif; fill: #5b5470; }
+      .m { font: 15px "DejaVu Sans Mono", Menlo, monospace; fill: #39314a; }
+      .mt { font: 600 17px "DejaVu Sans Mono", Menlo, monospace; fill: #170128; }
+      .ms { font: 12px "DejaVu Sans Mono", Menlo, monospace; fill: #ffffff; }
+      .zone { fill: #ffffff; stroke: #b9b3d6; stroke-width: 2; stroke-dasharray: 8 6; }
+      .node { fill: #f3f2ff; stroke: #6f6fff; stroke-width: 2; }
+      .infra { fill: #eefaff; stroke: #2491ad; stroke-width: 2; }
+      .wal { fill: #fdf4e3; stroke: #b5760a; stroke-width: 2; }
+      .fail { fill: #fff4f4; stroke: #d64545; stroke-width: 2; }
+      .flow { fill: none; stroke: #6f6fff; stroke-width: 2.5; marker-end: url(#a); }
+      .bus { fill: none; stroke: #6f6fff; stroke-width: 2.5; }
+      .rep { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+              marker-end: url(#g); }
+      .rep2 { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+               marker-start: url(#gs); marker-end: url(#g); }
+      .lbl { font: 600 15px Arial, sans-serif; fill: #39314a; }
+    </style>
+  </defs>
+
+  <rect width="1460" height="600" fill="#ffffff"/>
+
+  <rect class="zone" x="30" y="26" width="150" height="40" rx="8"/>
+  <text class="l" x="105" y="53" text-anchor="middle">Cluster 1</text>
+  <rect class="node" x="140" y="87" width="250" height="56" rx="10" opacity="0.45"/>
+  <rect class="node" x="130" y="96" width="250" height="56" rx="10"/>
+  <text class="t" x="255.0" y="130.0" text-anchor="middle">Frontend nodes</text>
+  <path class="flow" d="M265 161 L145 214"/>
+  <rect class="zone" x="30" y="216" width="230" height="296" rx="12"/>
+  <rect class="node" x="48" y="232" width="194" height="44" rx="9"/>
+  <text class="t" x="145" y="261" text-anchor="middle">Datanode 1</text>
+  <rect x="66" y="294" width="158" height="44" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
+  <text class="m" x="145" y="321" text-anchor="middle" fill="#2f8fb5">Region 1-1</text>
+  <rect x="66" y="356" width="158" height="44" rx="7" fill="#fbf3e0" stroke="#b5860a" stroke-width="1.5"/>
+  <text class="m" x="145" y="383" text-anchor="middle" fill="#b5860a">Region 2-1</text>
+  <rect x="66" y="418" width="158" height="44" rx="7" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
+  <text class="m" x="145" y="445" text-anchor="middle" fill="#c2544a">Region 3-1</text>
+  <path class="flow" d="M265 161 L415 214"/>
+  <rect class="zone" x="300" y="216" width="230" height="296" rx="12"/>
+  <rect class="node" x="318" y="232" width="194" height="44" rx="9"/>
+  <text class="t" x="415" y="261" text-anchor="middle">Datanode 2</text>
+  <rect x="336" y="294" width="158" height="44" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
+  <text class="m" x="415" y="321" text-anchor="middle" fill="#2f8fb5">Region 1-2</text>
+  <rect x="336" y="356" width="158" height="44" rx="7" fill="#fbf3e0" stroke="#b5860a" stroke-width="1.5"/>
+  <text class="m" x="415" y="383" text-anchor="middle" fill="#b5860a">Region 2-2</text>
+  <rect x="336" y="418" width="158" height="44" rx="7" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
+  <text class="m" x="415" y="445" text-anchor="middle" fill="#c2544a">Region 3-2</text>
+  <line x1="570" y1="20" x2="570" y2="580" stroke="#b9b3d6" stroke-width="2" stroke-dasharray="8 6"/>
+  <rect class="zone" x="700" y="96" width="210" height="416" rx="12"/>
+  <text class="t" x="805" y="134" text-anchor="middle">Backup</text>
+  <text class="t" x="805" y="158" text-anchor="middle">storage</text>
+  <rect class="infra" x="730" y="186" width="150" height="46" rx="9"/>
+  <text class="l" x="805" y="215" text-anchor="middle" fill="#2491ad">Backup 1</text>
+  <rect class="infra" x="730" y="248" width="150" height="46" rx="9"/>
+  <text class="l" x="805" y="277" text-anchor="middle" fill="#2491ad">Backup 2</text>
+  <rect class="infra" x="730" y="310" width="150" height="46" rx="9"/>
+  <text class="l" x="805" y="339" text-anchor="middle" fill="#2491ad">Backup 3</text>
+  <rect class="infra" x="730" y="372" width="150" height="46" rx="9"/>
+  <text class="l" x="805" y="401" text-anchor="middle" fill="#2491ad">Backup 4</text>
+  <rect class="infra" x="730" y="434" width="150" height="46" rx="9"/>
+  <text class="l" x="805" y="463" text-anchor="middle" fill="#2491ad">Backup 5</text>
+  <polygon points="600,333 666,333 666,327 692,340 666,353 666,347 600,347" fill="#b5760a" opacity="0.9"/>
+  <text class="s" x="646" y="306" text-anchor="middle">Backup</text>
+  <polygon points="920,333 986,333 986,327 1012,340 986,353 986,347 920,347" fill="#b5760a" opacity="0.9"/>
+  <text class="s" x="966" y="306" text-anchor="middle">Restore</text>
+  <rect class="zone" x="1290" y="26" width="150" height="40" rx="8"/>
+  <text class="l" x="1365" y="53" text-anchor="middle">Cluster 2</text>
+  <rect class="node" x="1150" y="87" width="250" height="56" rx="10" opacity="0.45"/>
+  <rect class="node" x="1140" y="96" width="250" height="56" rx="10"/>
+  <text class="t" x="1265.0" y="130.0" text-anchor="middle">Frontend nodes</text>
+  <path class="flow" d="M1275 161 L1275 214"/>
+  <rect class="zone" x="1160" y="216" width="230" height="296" rx="12"/>
+  <rect class="node" x="1178" y="232" width="194" height="44" rx="9"/>
+  <text class="t" x="1275" y="261" text-anchor="middle">Datanode</text>
+  <rect x="1196" y="294" width="158" height="44" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
+  <text class="m" x="1275" y="321" text-anchor="middle" fill="#2f8fb5">Region 1-2</text>
+  <rect x="1196" y="356" width="158" height="44" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
+  <text class="m" x="1275" y="383" text-anchor="middle" fill="#2f8fb5">Region 1-2</text>
+  <rect x="1196" y="418" width="158" height="44" rx="7" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
+  <text class="m" x="1275" y="445" text-anchor="middle" fill="#c2544a">Region 3-1</text>
+  <text class="s" x="30" y="560" text-anchor="start">Region 1</text>
+  <text class="s" x="590" y="560" text-anchor="start">Region 2</text>
+</svg>

--- a/static/BR-explain.svg
+++ b/static/BR-explain.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="700" viewBox="0 0 1200 700" role="img" aria-labelledby="title description">
+  <title id="title">Backup and restore between a GreptimeDB cluster and its backup storage</title>
+  <desc id="description">The backup cluster uploads SST files to storage; the restore cluster downloads them back when the original cluster is lost.</desc>
+  <defs>
+    <marker id="a" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="g" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="gs" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="as" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="am" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#b5760a"/>
+    </marker>
+    <style>
+      .t { font: 600 19px Arial, sans-serif; fill: #170128; }
+      .l { font: 16px Arial, sans-serif; fill: #39314a; }
+      .s { font: 14px Arial, sans-serif; fill: #5b5470; }
+      .m { font: 15px "DejaVu Sans Mono", Menlo, monospace; fill: #39314a; }
+      .mt { font: 600 17px "DejaVu Sans Mono", Menlo, monospace; fill: #170128; }
+      .ms { font: 12px "DejaVu Sans Mono", Menlo, monospace; fill: #ffffff; }
+      .zone { fill: #ffffff; stroke: #b9b3d6; stroke-width: 2; stroke-dasharray: 8 6; }
+      .node { fill: #f3f2ff; stroke: #6f6fff; stroke-width: 2; }
+      .infra { fill: #eefaff; stroke: #2491ad; stroke-width: 2; }
+      .wal { fill: #fdf4e3; stroke: #b5760a; stroke-width: 2; }
+      .fail { fill: #fff4f4; stroke: #d64545; stroke-width: 2; }
+      .flow { fill: none; stroke: #6f6fff; stroke-width: 2.5; marker-end: url(#a); }
+      .bus { fill: none; stroke: #6f6fff; stroke-width: 2.5; }
+      .rep { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+              marker-end: url(#g); }
+      .rep2 { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+               marker-start: url(#gs); marker-end: url(#g); }
+      .lbl { font: 600 15px Arial, sans-serif; fill: #39314a; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="700" fill="#ffffff"/>
+
+  <rect class="zone" x="30" y="40" width="650" height="300" rx="12"/>
+  <text class="t" x="56" y="76" text-anchor="start">Backup Cluster</text>
+  <rect class="node" x="190" y="130" width="330" height="110" rx="11"/>
+  <text class="t" x="355" y="192" text-anchor="middle">GreptimeDB</text>
+  <polygon points="520.0,102.0 524.8,118.4 539.8,110.2 531.6,125.2 548.0,130.0 531.6,134.8 539.8,149.8 524.8,141.6 520.0,158.0 515.2,141.6 500.2,149.8 508.4,134.8 492.0,130.0 508.4,125.2 500.2,110.2 515.2,118.4" fill="#d64545"/>
+  <rect class="zone" x="30" y="360" width="650" height="300" rx="12"/>
+  <text class="t" x="56" y="396" text-anchor="start">Restore Cluster</text>
+  <rect class="node" x="190" y="450" width="330" height="110" rx="11"/>
+  <text class="t" x="355" y="512" text-anchor="middle">GreptimeDB</text>
+  <rect class="zone" x="880" y="40" width="290" height="620" rx="12"/>
+  <text class="t" x="1025" y="78" text-anchor="middle">Storage</text>
+  <rect class="infra" x="940" y="110" width="170" height="54" rx="9"/>
+  <text class="l" x="1025" y="144" text-anchor="middle" fill="#2491ad">SST File</text>
+  <rect class="infra" x="940" y="196" width="170" height="54" rx="9"/>
+  <text class="l" x="1025" y="230" text-anchor="middle" fill="#2491ad">SST File</text>
+  <rect class="infra" x="940" y="282" width="170" height="54" rx="9"/>
+  <text class="l" x="1025" y="316" text-anchor="middle" fill="#2491ad">SST File</text>
+  <rect class="infra" x="940" y="368" width="170" height="54" rx="9"/>
+  <text class="l" x="1025" y="402" text-anchor="middle" fill="#2491ad">SST File</text>
+  <rect class="infra" x="940" y="454" width="170" height="54" rx="9"/>
+  <text class="l" x="1025" y="488" text-anchor="middle" fill="#2491ad">SST File</text>
+  <rect class="infra" x="940" y="540" width="170" height="54" rx="9"/>
+  <text class="l" x="1025" y="574" text-anchor="middle" fill="#2491ad">SST File</text>
+  <polygon points="700,187 832,187 832,178 866,195 832,212 832,203 700,203" fill="#b5760a" opacity="0.9"/>
+  <text class="s" x="783" y="140" text-anchor="middle">backup &amp;</text>
+  <text class="s" x="783" y="160" text-anchor="middle">upload</text>
+  <polygon points="866,497 734,497 734,488 700,505 734,522 734,513 866,513" fill="#b5760a" opacity="0.9"/>
+  <text class="s" x="783" y="450" text-anchor="middle">download &amp;</text>
+  <text class="s" x="783" y="470" text-anchor="middle">restore</text>
+</svg>

--- a/static/BR-explain.svg
+++ b/static/BR-explain.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="700" viewBox="0 0 1200 700" role="img" aria-labelledby="title description">
   <title id="title">Backup and restore between a GreptimeDB cluster and its backup storage</title>
-  <desc id="description">The backup cluster uploads SST files to storage; the restore cluster downloads them back when the original cluster is lost.</desc>
+  <desc id="description">The backup cluster uploads backup files to storage; the restore cluster downloads them back when the original cluster is lost.</desc>
   <defs>
     <marker id="a" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
       <path d="M0,0 L0,6 L9,3 z" fill="#6f6fff"/>
@@ -53,17 +53,17 @@
   <rect class="zone" x="880" y="40" width="290" height="620" rx="12"/>
   <text class="t" x="1025" y="78" text-anchor="middle">Storage</text>
   <rect class="infra" x="940" y="110" width="170" height="54" rx="9"/>
-  <text class="l" x="1025" y="144" text-anchor="middle" fill="#2491ad">SST File</text>
+  <text class="l" x="1025" y="144" text-anchor="middle" fill="#2491ad">Backup file</text>
   <rect class="infra" x="940" y="196" width="170" height="54" rx="9"/>
-  <text class="l" x="1025" y="230" text-anchor="middle" fill="#2491ad">SST File</text>
+  <text class="l" x="1025" y="230" text-anchor="middle" fill="#2491ad">Backup file</text>
   <rect class="infra" x="940" y="282" width="170" height="54" rx="9"/>
-  <text class="l" x="1025" y="316" text-anchor="middle" fill="#2491ad">SST File</text>
+  <text class="l" x="1025" y="316" text-anchor="middle" fill="#2491ad">Backup file</text>
   <rect class="infra" x="940" y="368" width="170" height="54" rx="9"/>
-  <text class="l" x="1025" y="402" text-anchor="middle" fill="#2491ad">SST File</text>
+  <text class="l" x="1025" y="402" text-anchor="middle" fill="#2491ad">Backup file</text>
   <rect class="infra" x="940" y="454" width="170" height="54" rx="9"/>
-  <text class="l" x="1025" y="488" text-anchor="middle" fill="#2491ad">SST File</text>
+  <text class="l" x="1025" y="488" text-anchor="middle" fill="#2491ad">Backup file</text>
   <rect class="infra" x="940" y="540" width="170" height="54" rx="9"/>
-  <text class="l" x="1025" y="574" text-anchor="middle" fill="#2491ad">SST File</text>
+  <text class="l" x="1025" y="574" text-anchor="middle" fill="#2491ad">Backup file</text>
   <polygon points="700,187 832,187 832,178 866,195 832,212 832,203 700,203" fill="#b5760a" opacity="0.9"/>
   <text class="s" x="783" y="140" text-anchor="middle">backup &amp;</text>
   <text class="s" x="783" y="160" text-anchor="middle">upload</text>

--- a/static/Component-architecture.svg
+++ b/static/Component-architecture.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="660" viewBox="0 0 920 660" role="img" aria-labelledby="title description">
+  <title id="title">GreptimeDB component architecture from a disaster recovery point of view</title>
+  <desc id="description">Frontend routes to three Datanodes, each holding table regions. The Datanodes share the WAL and the object storage.</desc>
+  <defs>
+    <marker id="a" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="g" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="gs" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="as" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="am" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#b5760a"/>
+    </marker>
+    <style>
+      .t { font: 600 19px Arial, sans-serif; fill: #170128; }
+      .l { font: 16px Arial, sans-serif; fill: #39314a; }
+      .s { font: 14px Arial, sans-serif; fill: #5b5470; }
+      .m { font: 15px "DejaVu Sans Mono", Menlo, monospace; fill: #39314a; }
+      .mt { font: 600 17px "DejaVu Sans Mono", Menlo, monospace; fill: #170128; }
+      .ms { font: 12px "DejaVu Sans Mono", Menlo, monospace; fill: #ffffff; }
+      .zone { fill: #ffffff; stroke: #b9b3d6; stroke-width: 2; stroke-dasharray: 8 6; }
+      .node { fill: #f3f2ff; stroke: #6f6fff; stroke-width: 2; }
+      .infra { fill: #eefaff; stroke: #2491ad; stroke-width: 2; }
+      .wal { fill: #fdf4e3; stroke: #b5760a; stroke-width: 2; }
+      .fail { fill: #fff4f4; stroke: #d64545; stroke-width: 2; }
+      .flow { fill: none; stroke: #6f6fff; stroke-width: 2.5; marker-end: url(#a); }
+      .bus { fill: none; stroke: #6f6fff; stroke-width: 2.5; }
+      .rep { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+              marker-end: url(#g); }
+      .rep2 { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+               marker-start: url(#gs); marker-end: url(#g); }
+      .lbl { font: 600 15px Arial, sans-serif; fill: #39314a; }
+    </style>
+  </defs>
+
+  <rect width="920" height="660" fill="#ffffff"/>
+
+  <rect class="node" x="340" y="21" width="250" height="62" rx="10" opacity="0.45"/>
+  <rect class="node" x="330" y="30" width="250" height="62" rx="10"/>
+  <text class="t" x="455.0" y="67.0" text-anchor="middle">Frontend</text>
+  <path class="flow" d="M455 101 L140 178"/>
+  <path class="flow" d="M455 101 L452 178"/>
+  <path class="flow" d="M455 101 L764 178"/>
+  <rect class="zone" x="40" y="180" width="216" height="300" rx="12"/>
+  <rect class="node" x="56" y="196" width="184" height="44" rx="9"/>
+  <text class="t" x="148" y="225" text-anchor="middle">Datanode 1</text>
+  <rect x="72" y="258" width="152" height="44" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
+  <text class="m" x="148" y="285" text-anchor="middle" fill="#2f8fb5">Region 1-1</text>
+  <rect x="72" y="320" width="152" height="44" rx="7" fill="#fbf3e0" stroke="#b5860a" stroke-width="1.5"/>
+  <text class="m" x="148" y="347" text-anchor="middle" fill="#b5860a">Region 2-1</text>
+  <rect x="72" y="382" width="152" height="44" rx="7" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
+  <text class="m" x="148" y="409" text-anchor="middle" fill="#c2544a">Region 3-1</text>
+  <rect class="zone" x="352" y="180" width="216" height="300" rx="12"/>
+  <rect class="node" x="368" y="196" width="184" height="44" rx="9"/>
+  <text class="t" x="460" y="225" text-anchor="middle">Datanode 2</text>
+  <rect x="384" y="258" width="152" height="44" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
+  <text class="m" x="460" y="285" text-anchor="middle" fill="#2f8fb5">Region 1-2</text>
+  <rect x="384" y="320" width="152" height="44" rx="7" fill="#fbf3e0" stroke="#b5860a" stroke-width="1.5"/>
+  <text class="m" x="460" y="347" text-anchor="middle" fill="#b5860a">Region 2-2</text>
+  <rect x="384" y="382" width="152" height="44" rx="7" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
+  <text class="m" x="460" y="409" text-anchor="middle" fill="#c2544a">Region 3-2</text>
+  <rect class="zone" x="664" y="180" width="216" height="300" rx="12"/>
+  <rect class="node" x="680" y="196" width="184" height="44" rx="9"/>
+  <text class="t" x="772" y="225" text-anchor="middle">Datanode 3</text>
+  <rect x="696" y="258" width="152" height="44" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
+  <text class="m" x="772" y="285" text-anchor="middle" fill="#2f8fb5">Region 1-3</text>
+  <rect x="696" y="320" width="152" height="44" rx="7" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
+  <text class="m" x="772" y="347" text-anchor="middle" fill="#c2544a">Region 3-3</text>
+  <rect x="696" y="382" width="152" height="44" rx="7" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
+  <text class="m" x="772" y="409" text-anchor="middle" fill="#c2544a">Region 3-4</text>
+  <rect class="wal" x="40" y="540" width="528" height="74" rx="11"/>
+  <text class="t" x="304" y="586" text-anchor="middle" fill="#b5760a">WAL</text>
+  <rect class="infra" x="616" y="540" width="264" height="74" rx="11"/>
+  <text class="t" x="748" y="586" text-anchor="middle" fill="#2491ad">Object Storage</text>
+  <line x1="148" y1="482" x2="148" y2="538" stroke="#6f6fff" stroke-width="2.5" marker-start="url(#as)" marker-end="url(#a)" opacity="0.9"/>
+  <line x1="772" y1="482" x2="772" y2="538" stroke="#6f6fff" stroke-width="2.5" marker-start="url(#as)" marker-end="url(#a)" opacity="0.9"/>
+</svg>

--- a/static/Component-architecture.svg
+++ b/static/Component-architecture.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="920" height="660" viewBox="0 0 920 660" role="img" aria-labelledby="title description">
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="700" viewBox="0 0 920 700" role="img" aria-labelledby="title description">
   <title id="title">GreptimeDB component architecture from a disaster recovery point of view</title>
-  <desc id="description">Frontend routes to three Datanodes, each holding table regions. The Datanodes share the WAL and the object storage.</desc>
+  <desc id="description">Frontend routes to three Datanodes, each holding table regions. The Datanodes share the WAL and the object storage below them.</desc>
   <defs>
     <marker id="a" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
       <path d="M0,0 L0,6 L9,3 z" fill="#6f6fff"/>
@@ -39,7 +39,7 @@
     </style>
   </defs>
 
-  <rect width="920" height="660" fill="#ffffff"/>
+  <rect width="920" height="700" fill="#ffffff"/>
 
   <rect class="node" x="340" y="21" width="250" height="62" rx="10" opacity="0.45"/>
   <rect class="node" x="330" y="30" width="250" height="62" rx="10"/>
@@ -74,10 +74,11 @@
   <text class="m" x="772" y="347" text-anchor="middle" fill="#c2544a">Region 3-3</text>
   <rect x="696" y="382" width="152" height="44" rx="7" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
   <text class="m" x="772" y="409" text-anchor="middle" fill="#c2544a">Region 3-4</text>
-  <rect class="wal" x="40" y="540" width="528" height="74" rx="11"/>
-  <text class="t" x="304" y="586" text-anchor="middle" fill="#b5760a">WAL</text>
-  <rect class="infra" x="616" y="540" width="264" height="74" rx="11"/>
-  <text class="t" x="748" y="586" text-anchor="middle" fill="#2491ad">Object Storage</text>
-  <line x1="148" y1="482" x2="148" y2="538" stroke="#6f6fff" stroke-width="2.5" marker-start="url(#as)" marker-end="url(#a)" opacity="0.9"/>
-  <line x1="772" y1="482" x2="772" y2="538" stroke="#6f6fff" stroke-width="2.5" marker-start="url(#as)" marker-end="url(#a)" opacity="0.9"/>
+  <line x1="148" y1="482" x2="148" y2="524" stroke="#6f6fff" stroke-width="2.5" marker-start="url(#as)" marker-end="url(#a)" opacity="0.9"/>
+  <line x1="460" y1="482" x2="460" y2="524" stroke="#6f6fff" stroke-width="2.5" marker-start="url(#as)" marker-end="url(#a)" opacity="0.9"/>
+  <line x1="772" y1="482" x2="772" y2="524" stroke="#6f6fff" stroke-width="2.5" marker-start="url(#as)" marker-end="url(#a)" opacity="0.9"/>
+  <rect class="wal" x="40" y="526" width="840" height="62" rx="11"/>
+  <text class="t" x="460" y="565" text-anchor="middle" fill="#b5760a">WAL</text>
+  <rect class="infra" x="40" y="600" width="840" height="62" rx="11"/>
+  <text class="t" x="460" y="639" text-anchor="middle" fill="#2491ad">Object Storage</text>
 </svg>

--- a/static/Component-architecture.svg
+++ b/static/Component-architecture.svg
@@ -47,7 +47,7 @@
   <path class="flow" d="M455 101 L140 178"/>
   <path class="flow" d="M455 101 L452 178"/>
   <path class="flow" d="M455 101 L764 178"/>
-  <rect class="zone" x="40" y="180" width="216" height="300" rx="12"/>
+  <rect class="zone" x="40" y="180" width="216" height="266" rx="12"/>
   <rect class="node" x="56" y="196" width="184" height="44" rx="9"/>
   <text class="t" x="148" y="225" text-anchor="middle">Datanode 1</text>
   <rect x="72" y="258" width="152" height="44" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
@@ -56,7 +56,7 @@
   <text class="m" x="148" y="347" text-anchor="middle" fill="#b5860a">Region 2-1</text>
   <rect x="72" y="382" width="152" height="44" rx="7" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
   <text class="m" x="148" y="409" text-anchor="middle" fill="#c2544a">Region 3-1</text>
-  <rect class="zone" x="352" y="180" width="216" height="300" rx="12"/>
+  <rect class="zone" x="352" y="180" width="216" height="266" rx="12"/>
   <rect class="node" x="368" y="196" width="184" height="44" rx="9"/>
   <text class="t" x="460" y="225" text-anchor="middle">Datanode 2</text>
   <rect x="384" y="258" width="152" height="44" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
@@ -65,7 +65,7 @@
   <text class="m" x="460" y="347" text-anchor="middle" fill="#b5860a">Region 2-2</text>
   <rect x="384" y="382" width="152" height="44" rx="7" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
   <text class="m" x="460" y="409" text-anchor="middle" fill="#c2544a">Region 3-2</text>
-  <rect class="zone" x="664" y="180" width="216" height="300" rx="12"/>
+  <rect class="zone" x="664" y="180" width="216" height="266" rx="12"/>
   <rect class="node" x="680" y="196" width="184" height="44" rx="9"/>
   <text class="t" x="772" y="225" text-anchor="middle">Datanode 3</text>
   <rect x="696" y="258" width="152" height="44" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
@@ -74,9 +74,9 @@
   <text class="m" x="772" y="347" text-anchor="middle" fill="#c2544a">Region 3-3</text>
   <rect x="696" y="382" width="152" height="44" rx="7" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
   <text class="m" x="772" y="409" text-anchor="middle" fill="#c2544a">Region 3-4</text>
-  <line x1="148" y1="482" x2="148" y2="524" stroke="#6f6fff" stroke-width="2.5" marker-start="url(#as)" marker-end="url(#a)" opacity="0.9"/>
-  <line x1="460" y1="482" x2="460" y2="524" stroke="#6f6fff" stroke-width="2.5" marker-start="url(#as)" marker-end="url(#a)" opacity="0.9"/>
-  <line x1="772" y1="482" x2="772" y2="524" stroke="#6f6fff" stroke-width="2.5" marker-start="url(#as)" marker-end="url(#a)" opacity="0.9"/>
+  <line x1="148" y1="448" x2="148" y2="524" stroke="#6f6fff" stroke-width="2.5" marker-start="url(#as)" marker-end="url(#a)" opacity="0.9"/>
+  <line x1="460" y1="448" x2="460" y2="524" stroke="#6f6fff" stroke-width="2.5" marker-start="url(#as)" marker-end="url(#a)" opacity="0.9"/>
+  <line x1="772" y1="448" x2="772" y2="524" stroke="#6f6fff" stroke-width="2.5" marker-start="url(#as)" marker-end="url(#a)" opacity="0.9"/>
   <rect class="wal" x="40" y="526" width="840" height="62" rx="11"/>
   <text class="t" x="460" y="565" text-anchor="middle" fill="#b5760a">WAL</text>
   <rect class="infra" x="40" y="600" width="840" height="62" rx="11"/>

--- a/static/Cross-region-single-cluster.svg
+++ b/static/Cross-region-single-cluster.svg
@@ -80,7 +80,7 @@
   <rect x="655.5" y="294" width="160" height="44" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
   <text class="m" x="736" y="321" text-anchor="middle" fill="#2f8fb5">Region 1-3</text>
   <rect x="655.5" y="356" width="160" height="44" rx="7" fill="#fbf3e0" stroke="#b5860a" stroke-width="1.5"/>
-  <text class="m" x="736" y="383" text-anchor="middle" fill="#b5860a">Region 2-4</text>
+  <text class="m" x="736" y="383" text-anchor="middle" fill="#b5860a">Region 2-3</text>
   <rect x="655.5" y="418" width="160" height="44" rx="7" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
   <text class="m" x="736" y="445" text-anchor="middle" fill="#c2544a">Region 3-3</text>
   <path class="flow" d="M860 161 L984 214"/>
@@ -107,7 +107,7 @@
   <rect x="1210.0" y="294" width="160" height="44" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
   <text class="m" x="1290" y="321" text-anchor="middle" fill="#2f8fb5">Region 1-5</text>
   <rect x="1210.0" y="356" width="160" height="44" rx="7" fill="#fbf3e0" stroke="#b5860a" stroke-width="1.5"/>
-  <text class="m" x="1290" y="383" text-anchor="middle" fill="#b5860a">Region 2-3</text>
+  <text class="m" x="1290" y="383" text-anchor="middle" fill="#b5860a">Region 2-4</text>
   <rect x="1210.0" y="418" width="160" height="44" rx="7" fill="#f2ecfb" stroke="#8a63c9" stroke-width="1.5"/>
   <text class="m" x="1290" y="445" text-anchor="middle" fill="#8a63c9">Region 4-2</text>
   <text class="s" x="1160" y="580" text-anchor="start">Region 3</text>

--- a/static/Cross-region-single-cluster.svg
+++ b/static/Cross-region-single-cluster.svg
@@ -80,7 +80,7 @@
   <rect x="655.5" y="294" width="160" height="44" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
   <text class="m" x="736" y="321" text-anchor="middle" fill="#2f8fb5">Region 1-3</text>
   <rect x="655.5" y="356" width="160" height="44" rx="7" fill="#fbf3e0" stroke="#b5860a" stroke-width="1.5"/>
-  <text class="m" x="736" y="383" text-anchor="middle" fill="#b5860a">Region 2-2</text>
+  <text class="m" x="736" y="383" text-anchor="middle" fill="#b5860a">Region 2-4</text>
   <rect x="655.5" y="418" width="160" height="44" rx="7" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
   <text class="m" x="736" y="445" text-anchor="middle" fill="#c2544a">Region 3-3</text>
   <path class="flow" d="M860 161 L984 214"/>

--- a/static/Cross-region-single-cluster.svg
+++ b/static/Cross-region-single-cluster.svg
@@ -1,0 +1,122 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1520" height="800" viewBox="0 0 1520 800" role="img" aria-labelledby="title description">
+  <title id="title">A single GreptimeDB cluster deployed across three regions</title>
+  <desc id="description">Each region runs Metasrv and Frontend nodes over its own Datanodes; all of them share a WAL and an object storage that replicate across regions.</desc>
+  <defs>
+    <marker id="a" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="g" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="gs" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="as" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="am" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#b5760a"/>
+    </marker>
+    <style>
+      .t { font: 600 19px Arial, sans-serif; fill: #170128; }
+      .l { font: 16px Arial, sans-serif; fill: #39314a; }
+      .s { font: 14px Arial, sans-serif; fill: #5b5470; }
+      .m { font: 15px "DejaVu Sans Mono", Menlo, monospace; fill: #39314a; }
+      .mt { font: 600 17px "DejaVu Sans Mono", Menlo, monospace; fill: #170128; }
+      .ms { font: 12px "DejaVu Sans Mono", Menlo, monospace; fill: #ffffff; }
+      .zone { fill: #ffffff; stroke: #b9b3d6; stroke-width: 2; stroke-dasharray: 8 6; }
+      .node { fill: #f3f2ff; stroke: #6f6fff; stroke-width: 2; }
+      .infra { fill: #eefaff; stroke: #2491ad; stroke-width: 2; }
+      .wal { fill: #fdf4e3; stroke: #b5760a; stroke-width: 2; }
+      .fail { fill: #fff4f4; stroke: #d64545; stroke-width: 2; }
+      .flow { fill: none; stroke: #6f6fff; stroke-width: 2.5; marker-end: url(#a); }
+      .bus { fill: none; stroke: #6f6fff; stroke-width: 2.5; }
+      .rep { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+              marker-end: url(#g); }
+      .rep2 { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+               marker-start: url(#gs); marker-end: url(#g); }
+      .lbl { font: 600 15px Arial, sans-serif; fill: #39314a; }
+    </style>
+  </defs>
+
+  <rect width="1520" height="800" fill="#ffffff"/>
+
+  <rect class="zone" x="225.0" y="26" width="150" height="40" rx="8"/>
+  <text class="l" x="300.0" y="53" text-anchor="middle">Metasrv</text>
+  <rect class="node" x="185.0" y="87" width="250" height="56" rx="10" opacity="0.45"/>
+  <rect class="node" x="175.0" y="96" width="250" height="56" rx="10"/>
+  <text class="t" x="300.0" y="130.0" text-anchor="middle">Frontend nodes</text>
+  <path class="flow" d="M300 161 L176 214"/>
+  <rect class="zone" x="58" y="216" width="235" height="296" rx="12"/>
+  <rect class="node" x="76" y="232" width="199" height="44" rx="9"/>
+  <text class="t" x="175.5" y="261" text-anchor="middle">Datanode 1</text>
+  <rect x="95.5" y="294" width="160" height="44" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
+  <text class="m" x="176" y="321" text-anchor="middle" fill="#2f8fb5">Region 1-1</text>
+  <rect x="95.5" y="356" width="160" height="44" rx="7" fill="#fbf3e0" stroke="#b5860a" stroke-width="1.5"/>
+  <text class="m" x="176" y="383" text-anchor="middle" fill="#b5860a">Region 2-1</text>
+  <rect x="95.5" y="418" width="160" height="44" rx="7" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
+  <text class="m" x="176" y="445" text-anchor="middle" fill="#c2544a">Region 3-1</text>
+  <path class="flow" d="M300 161 L424 214"/>
+  <rect class="zone" x="307" y="216" width="235" height="296" rx="12"/>
+  <rect class="node" x="325" y="232" width="199" height="44" rx="9"/>
+  <text class="t" x="424.5" y="261" text-anchor="middle">Datanode 2</text>
+  <rect x="344.5" y="294" width="160" height="44" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
+  <text class="m" x="424" y="321" text-anchor="middle" fill="#2f8fb5">Region 1-2</text>
+  <rect x="344.5" y="356" width="160" height="44" rx="7" fill="#fbf3e0" stroke="#b5860a" stroke-width="1.5"/>
+  <text class="m" x="424" y="383" text-anchor="middle" fill="#b5860a">Region 2-2</text>
+  <rect x="344.5" y="418" width="160" height="44" rx="7" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
+  <text class="m" x="424" y="445" text-anchor="middle" fill="#c2544a">Region 3-2</text>
+  <text class="s" x="40" y="580" text-anchor="start">Region 1</text>
+  <line x1="300.0" y1="516" x2="300.0" y2="596" stroke="#6f6fff" stroke-width="2.5" marker-start="url(#as)" marker-end="url(#a)" opacity="0.9"/>
+  <rect class="zone" x="785.0" y="26" width="150" height="40" rx="8"/>
+  <text class="l" x="860.0" y="53" text-anchor="middle">Metasrv</text>
+  <rect class="node" x="745.0" y="87" width="250" height="56" rx="10" opacity="0.45"/>
+  <rect class="node" x="735.0" y="96" width="250" height="56" rx="10"/>
+  <text class="t" x="860.0" y="130.0" text-anchor="middle">Frontend nodes</text>
+  <path class="flow" d="M860 161 L736 214"/>
+  <rect class="zone" x="618" y="216" width="235" height="296" rx="12"/>
+  <rect class="node" x="636" y="232" width="199" height="44" rx="9"/>
+  <text class="t" x="735.5" y="261" text-anchor="middle">Datanode 3</text>
+  <rect x="655.5" y="294" width="160" height="44" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
+  <text class="m" x="736" y="321" text-anchor="middle" fill="#2f8fb5">Region 1-3</text>
+  <rect x="655.5" y="356" width="160" height="44" rx="7" fill="#fbf3e0" stroke="#b5860a" stroke-width="1.5"/>
+  <text class="m" x="736" y="383" text-anchor="middle" fill="#b5860a">Region 2-2</text>
+  <rect x="655.5" y="418" width="160" height="44" rx="7" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
+  <text class="m" x="736" y="445" text-anchor="middle" fill="#c2544a">Region 3-3</text>
+  <path class="flow" d="M860 161 L984 214"/>
+  <rect class="zone" x="867" y="216" width="235" height="296" rx="12"/>
+  <rect class="node" x="885" y="232" width="199" height="44" rx="9"/>
+  <text class="t" x="984.5" y="261" text-anchor="middle">Datanode 4</text>
+  <rect x="904.5" y="294" width="160" height="44" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
+  <text class="m" x="984" y="321" text-anchor="middle" fill="#2f8fb5">Region 1-4</text>
+  <rect x="904.5" y="356" width="160" height="44" rx="7" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
+  <text class="m" x="984" y="383" text-anchor="middle" fill="#c2544a">Region 3-4</text>
+  <rect x="904.5" y="418" width="160" height="44" rx="7" fill="#f2ecfb" stroke="#8a63c9" stroke-width="1.5"/>
+  <text class="m" x="984" y="445" text-anchor="middle" fill="#8a63c9">Region 4-1</text>
+  <text class="s" x="600" y="580" text-anchor="start">Region 2</text>
+  <line x1="860.0" y1="516" x2="860.0" y2="596" stroke="#6f6fff" stroke-width="2.5" marker-start="url(#as)" marker-end="url(#a)" opacity="0.9"/>
+  <rect class="zone" x="1215.0" y="26" width="150" height="40" rx="8"/>
+  <text class="l" x="1290.0" y="53" text-anchor="middle">Metasrv</text>
+  <rect class="node" x="1175.0" y="87" width="250" height="56" rx="10" opacity="0.45"/>
+  <rect class="node" x="1165.0" y="96" width="250" height="56" rx="10"/>
+  <text class="t" x="1290.0" y="130.0" text-anchor="middle">Frontend nodes</text>
+  <path class="flow" d="M1290 161 L1290 214"/>
+  <rect class="zone" x="1172.5" y="216" width="235" height="296" rx="12"/>
+  <rect class="node" x="1190.5" y="232" width="199" height="44" rx="9"/>
+  <text class="t" x="1290.0" y="261" text-anchor="middle">Datanode 5</text>
+  <rect x="1210.0" y="294" width="160" height="44" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
+  <text class="m" x="1290" y="321" text-anchor="middle" fill="#2f8fb5">Region 1-5</text>
+  <rect x="1210.0" y="356" width="160" height="44" rx="7" fill="#fbf3e0" stroke="#b5860a" stroke-width="1.5"/>
+  <text class="m" x="1290" y="383" text-anchor="middle" fill="#b5860a">Region 2-3</text>
+  <rect x="1210.0" y="418" width="160" height="44" rx="7" fill="#f2ecfb" stroke="#8a63c9" stroke-width="1.5"/>
+  <text class="m" x="1290" y="445" text-anchor="middle" fill="#8a63c9">Region 4-2</text>
+  <text class="s" x="1160" y="580" text-anchor="start">Region 3</text>
+  <line x1="1290.0" y1="516" x2="1290.0" y2="596" stroke="#6f6fff" stroke-width="2.5" marker-start="url(#as)" marker-end="url(#a)" opacity="0.9"/>
+  <line x1="570" y1="20" x2="570" y2="600" stroke="#b9b3d6" stroke-width="2" stroke-dasharray="8 6"/>
+  <line x1="1130" y1="20" x2="1130" y2="600" stroke="#b9b3d6" stroke-width="2" stroke-dasharray="8 6"/>
+  <rect class="wal" x="40" y="600" width="1440" height="62" rx="10"/>
+  <text class="t" x="760" y="639" text-anchor="middle" fill="#b5760a">WAL</text>
+  <rect class="infra" x="40" y="680" width="1440" height="62" rx="10"/>
+  <text class="t" x="760" y="719" text-anchor="middle" fill="#2491ad">Object Storage</text>
+  <text class="s" x="1480" y="775" text-anchor="end">Cross-Region Replication</text>
+</svg>

--- a/static/DR-Standalone.svg
+++ b/static/DR-Standalone.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1180" height="680" viewBox="0 0 1180 680" role="img" aria-labelledby="title description">
+  <title id="title">Disaster recovery for GreptimeDB Standalone with remote WAL and object storage</title>
+  <desc id="description">The standalone instance writes to a remote WAL and flushes to object storage; a replacement instance replays the WAL and loads the data back.</desc>
+  <defs>
+    <marker id="a" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="g" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="gs" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="as" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="am" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#b5760a"/>
+    </marker>
+    <style>
+      .t { font: 600 19px Arial, sans-serif; fill: #170128; }
+      .l { font: 16px Arial, sans-serif; fill: #39314a; }
+      .s { font: 14px Arial, sans-serif; fill: #5b5470; }
+      .m { font: 15px "DejaVu Sans Mono", Menlo, monospace; fill: #39314a; }
+      .mt { font: 600 17px "DejaVu Sans Mono", Menlo, monospace; fill: #170128; }
+      .ms { font: 12px "DejaVu Sans Mono", Menlo, monospace; fill: #ffffff; }
+      .zone { fill: #ffffff; stroke: #b9b3d6; stroke-width: 2; stroke-dasharray: 8 6; }
+      .node { fill: #f3f2ff; stroke: #6f6fff; stroke-width: 2; }
+      .infra { fill: #eefaff; stroke: #2491ad; stroke-width: 2; }
+      .wal { fill: #fdf4e3; stroke: #b5760a; stroke-width: 2; }
+      .fail { fill: #fff4f4; stroke: #d64545; stroke-width: 2; }
+      .flow { fill: none; stroke: #6f6fff; stroke-width: 2.5; marker-end: url(#a); }
+      .bus { fill: none; stroke: #6f6fff; stroke-width: 2.5; }
+      .rep { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+              marker-end: url(#g); }
+      .rep2 { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+               marker-start: url(#gs); marker-end: url(#g); }
+      .lbl { font: 600 15px Arial, sans-serif; fill: #39314a; }
+    </style>
+  </defs>
+
+  <rect width="1180" height="680" fill="#ffffff"/>
+
+  <rect class="zone" x="40" y="40" width="680" height="290" rx="12"/>
+  <text class="t" x="66" y="76" text-anchor="start">Backup Standalone</text>
+  <rect class="node" x="200" y="130" width="330" height="110" rx="11"/>
+  <text class="t" x="365" y="192" text-anchor="middle">GreptimeDB</text>
+  <polygon points="530.0,102.0 534.8,118.4 549.8,110.2 541.6,125.2 558.0,130.0 541.6,134.8 549.8,149.8 534.8,141.6 530.0,158.0 525.2,141.6 510.2,149.8 518.4,134.8 502.0,130.0 518.4,125.2 510.2,110.2 525.2,118.4" fill="#d64545"/>
+  <rect class="zone" x="40" y="350" width="680" height="290" rx="12"/>
+  <text class="t" x="66" y="386" text-anchor="start">Restore Standalone</text>
+  <rect class="node" x="200" y="440" width="330" height="110" rx="11"/>
+  <text class="t" x="365" y="502" text-anchor="middle">GreptimeDB</text>
+  <rect class="wal" x="930" y="110" width="220" height="110" rx="11"/>
+  <text class="t" x="1040" y="172" text-anchor="middle" fill="#b5760a">WAL</text>
+  <rect class="infra" x="930" y="440" width="220" height="110" rx="11"/>
+  <text class="t" x="1040" y="494" text-anchor="middle" fill="#2491ad">Object</text>
+  <text class="t" x="1040" y="520" text-anchor="middle" fill="#2491ad">Storage</text>
+  <path class="flow" d="M532 172 L926 166"/>
+  <text class="s" x="740" y="150" text-anchor="middle">Write</text>
+  <path class="flow" d="M532 200 L926 462"/>
+  <text class="s" x="830" y="372" text-anchor="middle">Flush &amp;</text>
+  <text class="s" x="830" y="392" text-anchor="middle">Compact</text>
+  <path class="rep" d="M930 200 L536 486"/>
+  <text class="lbl" x="606" y="400" text-anchor="middle" fill="#2a9d5c">Replay</text>
+  <path class="rep" d="M926 505 L536 505"/>
+  <text class="lbl" x="740" y="486" text-anchor="middle" fill="#2a9d5c">Load</text>
+</svg>

--- a/static/DR-across-2dc-1region.svg
+++ b/static/DR-across-2dc-1region.svg
@@ -1,0 +1,117 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1520" height="700" viewBox="0 0 1520 700" role="img" aria-labelledby="title description">
+  <title id="title">Metadata across two regions, data in one region</title>
+  <desc id="description">DC 1 and DC 2 in region 1 each run one Datanode and serve all reads and writes. DC 3 in region 2 holds a Metasrv replica only, so the cluster keeps a majority if region 1 is lost.</desc>
+  <defs>
+    <marker id="a" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="g" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="gs" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="as" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="am" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#b5760a"/>
+    </marker>
+    <style>
+      .t { font: 600 19px Arial, sans-serif; fill: #170128; }
+      .l { font: 16px Arial, sans-serif; fill: #39314a; }
+      .s { font: 14px Arial, sans-serif; fill: #5b5470; }
+      .m { font: 15px "DejaVu Sans Mono", Menlo, monospace; fill: #39314a; }
+      .mt { font: 600 17px "DejaVu Sans Mono", Menlo, monospace; fill: #170128; }
+      .ms { font: 12px "DejaVu Sans Mono", Menlo, monospace; fill: #ffffff; }
+      .zone { fill: #ffffff; stroke: #b9b3d6; stroke-width: 2; stroke-dasharray: 8 6; }
+      .node { fill: #f3f2ff; stroke: #6f6fff; stroke-width: 2; }
+      .infra { fill: #eefaff; stroke: #2491ad; stroke-width: 2; }
+      .wal { fill: #fdf4e3; stroke: #b5760a; stroke-width: 2; }
+      .fail { fill: #fff4f4; stroke: #d64545; stroke-width: 2; }
+      .flow { fill: none; stroke: #6f6fff; stroke-width: 2.5; marker-end: url(#a); }
+      .bus { fill: none; stroke: #6f6fff; stroke-width: 2.5; }
+      .rep { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+              marker-end: url(#g); }
+      .rep2 { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+               marker-start: url(#gs); marker-end: url(#g); }
+      .lbl { font: 600 15px Arial, sans-serif; fill: #39314a; }
+
+      .zone-label { font: 600 15px Arial, sans-serif; fill: #6b638a; }
+      .meta-flow { fill: none; stroke: #6f6fff; stroke-width: 2.5; marker-end: url(#a); }
+      .failover { fill: none; stroke: #2a9d5c; stroke-width: 3; marker-end: url(#g); }
+      .failover-label { font: 600 15px Arial, sans-serif; fill: #2a9d5c; }
+    </style>
+  </defs>
+
+  <rect width="1520" height="700" fill="#ffffff"/>
+
+  <rect x="40" y="70" width="910" height="414" rx="16" fill="#fbfaff" stroke="#8a7fd0" stroke-width="2" stroke-dasharray="12 8"/>
+  <text class="t" x="62" y="56" text-anchor="start">Region 1</text>
+  <rect class="node" x="60" y="108" width="380" height="64" rx="11"/>
+  <text class="t" x="250.0" y="136" text-anchor="middle">Metasrv × 2</text>
+  <text class="s" x="250.0" y="158" text-anchor="middle">Leader election; state in the metadata backend</text>
+  <rect class="node" x="60" y="184" width="380" height="64" rx="11"/>
+  <text class="t" x="250.0" y="212" text-anchor="middle">Frontend × N</text>
+  <text class="s" x="250.0" y="234" text-anchor="middle">Stateless, behind a load balancer</text>
+  <path class="flow" d="M250 248 L250 286"/>
+  <rect class="zone" x="60" y="288" width="380" height="174" rx="12"/>
+  <text class="zone-label" x="78" y="316" text-anchor="start">AZ 1 · DC 1</text>
+  <rect class="fail" x="76" y="332" width="348" height="112" rx="11"/>
+  <text class="t" x="250.0" y="362" text-anchor="middle" fill="#a32a2a">Datanode 1 · unavailable</text>
+  <rect x="92" y="389" width="152" height="42" rx="8" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5" opacity="0.4"/>
+  <text class="l" x="168" y="416" text-anchor="middle" fill="#2f8fb5" opacity="0.4">Region 1</text>
+  <rect x="256" y="389" width="152" height="42" rx="8" fill="#fbf3e0" stroke="#b5860a" stroke-width="1.5" opacity="0.4"/>
+  <text class="l" x="332" y="416" text-anchor="middle" fill="#b5860a" opacity="0.4">Region 2</text>
+  <rect class="node" x="550" y="108" width="380" height="64" rx="11"/>
+  <text class="t" x="740.0" y="136" text-anchor="middle">Metasrv × 2</text>
+  <text class="s" x="740.0" y="158" text-anchor="middle">Leader election; state in the metadata backend</text>
+  <rect class="node" x="550" y="184" width="380" height="64" rx="11"/>
+  <text class="t" x="740.0" y="212" text-anchor="middle">Frontend × N</text>
+  <text class="s" x="740.0" y="234" text-anchor="middle">Stateless, behind a load balancer</text>
+  <path class="flow" d="M740 248 L740 286"/>
+  <rect class="zone" x="550" y="288" width="380" height="174" rx="12"/>
+  <text class="zone-label" x="568" y="316" text-anchor="start">AZ 2 · DC 2</text>
+  <rect class="node" x="566" y="332" width="348" height="112" rx="11"/>
+  <text class="t" x="740.0" y="362" text-anchor="middle">Datanode 2</text>
+  <rect x="580" y="389" width="100" height="42" rx="8" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
+  <text class="s" x="630" y="416" text-anchor="middle" fill="#c2544a">Region 3</text>
+  <rect x="690" y="389" width="100" height="42" rx="8" fill="#f2ecfb" stroke="#8a63c9" stroke-width="1.5"/>
+  <text class="s" x="740" y="416" text-anchor="middle" fill="#8a63c9">Region 4</text>
+  <rect x="800" y="389" width="100" height="42" rx="8" fill="#edf9f1" stroke="#2a9d5c" stroke-width="1.5" stroke-dasharray="6 5"/>
+  <text class="s" x="850" y="416" text-anchor="middle" fill="#2a9d5c">Region 1, 2</text>
+  <rect x="1060" y="70" width="420" height="414" rx="16" fill="#fbfaff" stroke="#8a7fd0" stroke-width="2" stroke-dasharray="12 8"/>
+  <text class="t" x="1082" y="56" text-anchor="start">Region 2</text>
+  <rect class="node" x="1080" y="108" width="380" height="64" rx="11"/>
+  <text class="t" x="1270.0" y="136" text-anchor="middle">Metasrv × 1</text>
+  <text class="s" x="1270.0" y="158" text-anchor="middle">Leader election; state in the metadata backend</text>
+  <rect class="zone" x="1080" y="184" width="380" height="64" rx="11"/>
+  <text class="s" x="1270.0" y="220" text-anchor="middle">No read or write traffic</text>
+  <rect class="zone" x="1080" y="288" width="380" height="174" rx="12"/>
+  <text class="zone-label" x="1098" y="316" text-anchor="start">AZ 3 · DC 3</text>
+  <text class="s" x="1270.0" y="384" text-anchor="middle">Metasrv replica only,</text>
+  <text class="s" x="1270.0" y="408" text-anchor="middle">so the region can hold a majority</text>
+  <path class="failover" d="M424 388 L564 388"/>
+  <text class="failover-label" x="495.0" y="354" text-anchor="middle">Region</text>
+  <text class="failover-label" x="495.0" y="374" text-anchor="middle">Failover</text>
+  <rect class="wal" x="40.0" y="524" width="464.0" height="92" rx="12"/>
+  <text class="t" x="272.0" y="562" text-anchor="middle" fill="#b5760a">Remote WAL</text>
+  <text class="s" x="272.0" y="586" text-anchor="middle">Kafka; replicated brokers</text>
+  <rect class="infra" x="528.0" y="524" width="464.0" height="92" rx="12"/>
+  <text class="t" x="760.0" y="562" text-anchor="middle" fill="#2491ad">Object storage</text>
+  <text class="s" x="760.0" y="586" text-anchor="middle">SSTables and index</text>
+  <rect class="infra" x="1016.0" y="524" width="464.0" height="92" rx="12"/>
+  <text class="t" x="1248.0" y="562" text-anchor="middle" fill="#2491ad">Metadata backend</text>
+  <text class="s" x="1248.0" y="586" text-anchor="middle">etcd, MySQL or PostgreSQL</text>
+  <path class="bus" d="M250 502 L760 502"/>
+  <path class="bus" d="M250 484 L250 502"/>
+  <path class="bus" d="M740 484 L740 502"/>
+  <path class="flow" d="M272 502 L272 522"/>
+  <path class="flow" d="M760 502 L760 522"/>
+  <path class="bus" d="M440 140 L452 140 L452 30 L1498 30"/>
+  <path class="bus" d="M930 140 L942 140 L942 30 L1498 30"/>
+  <path class="bus" d="M1460 140 L1498 140"/>
+  <path class="bus" d="M1498 30 L1498 570"/>
+  <path class="meta-flow" d="M1498 570 L1482 570"/>
+  <text class="l" x="760.0" y="664" text-anchor="middle">DC 1 and DC 2 serve every request; DC 3 only completes the Metasrv majority.</text>
+</svg>

--- a/static/DR-across-3dc-2region.svg
+++ b/static/DR-across-3dc-2region.svg
@@ -1,0 +1,124 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1520" height="700" viewBox="0 0 1520 700" role="img" aria-labelledby="title description">
+  <title id="title">Data across two regions</title>
+  <desc id="description">DC 1 and DC 2 in region 1 and DC 3 in region 2 each run one Datanode; all three serve reads and writes.</desc>
+  <defs>
+    <marker id="a" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="g" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="gs" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="as" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="am" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#b5760a"/>
+    </marker>
+    <style>
+      .t { font: 600 19px Arial, sans-serif; fill: #170128; }
+      .l { font: 16px Arial, sans-serif; fill: #39314a; }
+      .s { font: 14px Arial, sans-serif; fill: #5b5470; }
+      .m { font: 15px "DejaVu Sans Mono", Menlo, monospace; fill: #39314a; }
+      .mt { font: 600 17px "DejaVu Sans Mono", Menlo, monospace; fill: #170128; }
+      .ms { font: 12px "DejaVu Sans Mono", Menlo, monospace; fill: #ffffff; }
+      .zone { fill: #ffffff; stroke: #b9b3d6; stroke-width: 2; stroke-dasharray: 8 6; }
+      .node { fill: #f3f2ff; stroke: #6f6fff; stroke-width: 2; }
+      .infra { fill: #eefaff; stroke: #2491ad; stroke-width: 2; }
+      .wal { fill: #fdf4e3; stroke: #b5760a; stroke-width: 2; }
+      .fail { fill: #fff4f4; stroke: #d64545; stroke-width: 2; }
+      .flow { fill: none; stroke: #6f6fff; stroke-width: 2.5; marker-end: url(#a); }
+      .bus { fill: none; stroke: #6f6fff; stroke-width: 2.5; }
+      .rep { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+              marker-end: url(#g); }
+      .rep2 { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+               marker-start: url(#gs); marker-end: url(#g); }
+      .lbl { font: 600 15px Arial, sans-serif; fill: #39314a; }
+
+      .zone-label { font: 600 15px Arial, sans-serif; fill: #6b638a; }
+      .meta-flow { fill: none; stroke: #6f6fff; stroke-width: 2.5; marker-end: url(#a); }
+      .failover { fill: none; stroke: #2a9d5c; stroke-width: 3; marker-end: url(#g); }
+      .failover-label { font: 600 15px Arial, sans-serif; fill: #2a9d5c; }
+    </style>
+  </defs>
+
+  <rect width="1520" height="700" fill="#ffffff"/>
+
+  <rect x="40" y="70" width="910" height="414" rx="16" fill="#fbfaff" stroke="#8a7fd0" stroke-width="2" stroke-dasharray="12 8"/>
+  <text class="t" x="62" y="56" text-anchor="start">Region 1</text>
+  <rect class="node" x="60" y="108" width="380" height="64" rx="11"/>
+  <text class="t" x="250.0" y="136" text-anchor="middle">Metasrv × 2</text>
+  <text class="s" x="250.0" y="158" text-anchor="middle">Leader election; state in the metadata backend</text>
+  <rect class="node" x="60" y="184" width="380" height="64" rx="11"/>
+  <text class="t" x="250.0" y="212" text-anchor="middle">Frontend × N</text>
+  <text class="s" x="250.0" y="234" text-anchor="middle">Stateless, behind a load balancer</text>
+  <path class="flow" d="M250 248 L250 286"/>
+  <rect class="zone" x="60" y="288" width="380" height="174" rx="12"/>
+  <text class="zone-label" x="78" y="316" text-anchor="start">AZ 1 · DC 1</text>
+  <rect class="fail" x="76" y="332" width="348" height="112" rx="11"/>
+  <text class="t" x="250.0" y="362" text-anchor="middle" fill="#a32a2a">Datanode 1 · unavailable</text>
+  <rect x="92" y="389" width="152" height="42" rx="8" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5" opacity="0.4"/>
+  <text class="l" x="168" y="416" text-anchor="middle" fill="#2f8fb5" opacity="0.4">Region 1</text>
+  <rect x="256" y="389" width="152" height="42" rx="8" fill="#fbf3e0" stroke="#b5860a" stroke-width="1.5" opacity="0.4"/>
+  <text class="l" x="332" y="416" text-anchor="middle" fill="#b5860a" opacity="0.4">Region 2</text>
+  <rect class="node" x="550" y="108" width="380" height="64" rx="11"/>
+  <text class="t" x="740.0" y="136" text-anchor="middle">Metasrv × 2</text>
+  <text class="s" x="740.0" y="158" text-anchor="middle">Leader election; state in the metadata backend</text>
+  <rect class="node" x="550" y="184" width="380" height="64" rx="11"/>
+  <text class="t" x="740.0" y="212" text-anchor="middle">Frontend × N</text>
+  <text class="s" x="740.0" y="234" text-anchor="middle">Stateless, behind a load balancer</text>
+  <path class="flow" d="M740 248 L740 286"/>
+  <rect class="zone" x="550" y="288" width="380" height="174" rx="12"/>
+  <text class="zone-label" x="568" y="316" text-anchor="start">AZ 2 · DC 2</text>
+  <rect class="node" x="566" y="332" width="348" height="112" rx="11"/>
+  <text class="t" x="740.0" y="362" text-anchor="middle">Datanode 2</text>
+  <rect x="580" y="389" width="100" height="42" rx="8" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
+  <text class="s" x="630" y="416" text-anchor="middle" fill="#c2544a">Region 3</text>
+  <rect x="690" y="389" width="100" height="42" rx="8" fill="#f2ecfb" stroke="#8a63c9" stroke-width="1.5"/>
+  <text class="s" x="740" y="416" text-anchor="middle" fill="#8a63c9">Region 4</text>
+  <rect x="800" y="389" width="100" height="42" rx="8" fill="#edf9f1" stroke="#2a9d5c" stroke-width="1.5" stroke-dasharray="6 5"/>
+  <text class="s" x="850" y="416" text-anchor="middle" fill="#2a9d5c">Region 1, 2</text>
+  <rect x="1060" y="70" width="420" height="414" rx="16" fill="#fbfaff" stroke="#8a7fd0" stroke-width="2" stroke-dasharray="12 8"/>
+  <text class="t" x="1082" y="56" text-anchor="start">Region 2</text>
+  <rect class="node" x="1080" y="108" width="380" height="64" rx="11"/>
+  <text class="t" x="1270.0" y="136" text-anchor="middle">Metasrv × 1</text>
+  <text class="s" x="1270.0" y="158" text-anchor="middle">Leader election; state in the metadata backend</text>
+  <rect class="node" x="1080" y="184" width="380" height="64" rx="11"/>
+  <text class="t" x="1270.0" y="212" text-anchor="middle">Frontend × N</text>
+  <text class="s" x="1270.0" y="234" text-anchor="middle">Stateless, behind a load balancer</text>
+  <path class="flow" d="M1270 248 L1270 286"/>
+  <rect class="zone" x="1080" y="288" width="380" height="174" rx="12"/>
+  <text class="zone-label" x="1098" y="316" text-anchor="start">AZ 3 · DC 3</text>
+  <rect class="node" x="1096" y="332" width="348" height="112" rx="11"/>
+  <text class="t" x="1270.0" y="362" text-anchor="middle">Datanode 3</text>
+  <rect x="1112" y="389" width="152" height="42" rx="8" fill="#fbecf4" stroke="#c0508c" stroke-width="1.5"/>
+  <text class="l" x="1188" y="416" text-anchor="middle" fill="#c0508c">Region 5</text>
+  <rect x="1276" y="389" width="152" height="42" rx="8" fill="#ecf0fb" stroke="#4a63c9" stroke-width="1.5"/>
+  <text class="l" x="1352" y="416" text-anchor="middle" fill="#4a63c9">Region 6</text>
+  <path class="failover" d="M424 388 L564 388"/>
+  <text class="failover-label" x="495.0" y="354" text-anchor="middle">Region</text>
+  <text class="failover-label" x="495.0" y="374" text-anchor="middle">Failover</text>
+  <rect class="wal" x="40.0" y="524" width="464.0" height="92" rx="12"/>
+  <text class="t" x="272.0" y="562" text-anchor="middle" fill="#b5760a">Remote WAL</text>
+  <text class="s" x="272.0" y="586" text-anchor="middle">Kafka; replicated brokers</text>
+  <rect class="infra" x="528.0" y="524" width="464.0" height="92" rx="12"/>
+  <text class="t" x="760.0" y="562" text-anchor="middle" fill="#2491ad">Object storage</text>
+  <text class="s" x="760.0" y="586" text-anchor="middle">SSTables and index</text>
+  <rect class="infra" x="1016.0" y="524" width="464.0" height="92" rx="12"/>
+  <text class="t" x="1248.0" y="562" text-anchor="middle" fill="#2491ad">Metadata backend</text>
+  <text class="s" x="1248.0" y="586" text-anchor="middle">etcd, MySQL or PostgreSQL</text>
+  <path class="bus" d="M250 502 L1270 502"/>
+  <path class="bus" d="M250 484 L250 502"/>
+  <path class="bus" d="M740 484 L740 502"/>
+  <path class="bus" d="M1270 484 L1270 502"/>
+  <path class="flow" d="M272 502 L272 522"/>
+  <path class="flow" d="M760 502 L760 522"/>
+  <path class="bus" d="M440 140 L452 140 L452 30 L1498 30"/>
+  <path class="bus" d="M930 140 L942 140 L942 30 L1498 30"/>
+  <path class="bus" d="M1460 140 L1498 140"/>
+  <path class="bus" d="M1498 30 L1498 570"/>
+  <path class="meta-flow" d="M1498 570 L1482 570"/>
+  <text class="l" x="760.0" y="664" text-anchor="middle">Every DC serves requests, so the loss of one region leaves the other serving.</text>
+</svg>

--- a/static/DR-across-5dc-2region.svg
+++ b/static/DR-across-5dc-2region.svg
@@ -1,0 +1,139 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2352" height="700" viewBox="0 0 2352 700" role="img" aria-labelledby="title description">
+  <title id="title">Metadata across three regions, data across two regions</title>
+  <desc id="description">Five DCs, one Datanode each. Regions 1 and 2 serve reads and writes; region 3 holds a Metasrv replica only.</desc>
+  <defs>
+    <marker id="a" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="g" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="gs" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="as" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="am" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#b5760a"/>
+    </marker>
+    <style>
+      .t { font: 600 19px Arial, sans-serif; fill: #170128; }
+      .l { font: 16px Arial, sans-serif; fill: #39314a; }
+      .s { font: 14px Arial, sans-serif; fill: #5b5470; }
+      .m { font: 15px "DejaVu Sans Mono", Menlo, monospace; fill: #39314a; }
+      .mt { font: 600 17px "DejaVu Sans Mono", Menlo, monospace; fill: #170128; }
+      .ms { font: 12px "DejaVu Sans Mono", Menlo, monospace; fill: #ffffff; }
+      .zone { fill: #ffffff; stroke: #b9b3d6; stroke-width: 2; stroke-dasharray: 8 6; }
+      .node { fill: #f3f2ff; stroke: #6f6fff; stroke-width: 2; }
+      .infra { fill: #eefaff; stroke: #2491ad; stroke-width: 2; }
+      .wal { fill: #fdf4e3; stroke: #b5760a; stroke-width: 2; }
+      .fail { fill: #fff4f4; stroke: #d64545; stroke-width: 2; }
+      .flow { fill: none; stroke: #6f6fff; stroke-width: 2.5; marker-end: url(#a); }
+      .bus { fill: none; stroke: #6f6fff; stroke-width: 2.5; }
+      .rep { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+              marker-end: url(#g); }
+      .rep2 { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+               marker-start: url(#gs); marker-end: url(#g); }
+      .lbl { font: 600 15px Arial, sans-serif; fill: #39314a; }
+
+      .zone-label { font: 600 15px Arial, sans-serif; fill: #6b638a; }
+      .meta-flow { fill: none; stroke: #6f6fff; stroke-width: 2.5; marker-end: url(#a); }
+      .failover { fill: none; stroke: #2a9d5c; stroke-width: 3; marker-end: url(#g); }
+      .failover-label { font: 600 15px Arial, sans-serif; fill: #2a9d5c; }
+    </style>
+  </defs>
+
+  <rect width="2352" height="700" fill="#ffffff"/>
+
+  <rect x="40" y="70" width="816" height="414" rx="16" fill="#fbfaff" stroke="#8a7fd0" stroke-width="2" stroke-dasharray="12 8"/>
+  <text class="t" x="62" y="56" text-anchor="start">Region 1</text>
+  <rect class="node" x="60" y="108" width="776" height="64" rx="11"/>
+  <text class="t" x="448.0" y="136" text-anchor="middle">Metasrv × 2</text>
+  <text class="s" x="448.0" y="158" text-anchor="middle">Leader election; state in the metadata backend</text>
+  <rect class="node" x="60" y="184" width="776" height="64" rx="11"/>
+  <text class="t" x="448.0" y="212" text-anchor="middle">Frontend × N</text>
+  <text class="s" x="448.0" y="234" text-anchor="middle">Stateless, behind a load balancer</text>
+  <path class="bus" d="M250 248 L250 260 L646 260 L646 248"/>
+  <path class="flow" d="M250 260 L250 286"/>
+  <path class="flow" d="M646 260 L646 286"/>
+  <rect class="zone" x="60" y="288" width="380" height="174" rx="12"/>
+  <text class="zone-label" x="78" y="316" text-anchor="start">AZ 1 · DC 1</text>
+  <rect class="node" x="76" y="332" width="348" height="112" rx="11"/>
+  <text class="t" x="250.0" y="362" text-anchor="middle">Datanode 1</text>
+  <rect x="92" y="389" width="152" height="42" rx="8" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
+  <text class="l" x="168" y="416" text-anchor="middle" fill="#2f8fb5">Region 1</text>
+  <rect x="256" y="389" width="152" height="42" rx="8" fill="#fbf3e0" stroke="#b5860a" stroke-width="1.5"/>
+  <text class="l" x="332" y="416" text-anchor="middle" fill="#b5860a">Region 2</text>
+  <rect class="zone" x="456" y="288" width="380" height="174" rx="12"/>
+  <text class="zone-label" x="474" y="316" text-anchor="start">AZ 2 · DC 2</text>
+  <rect class="fail" x="472" y="332" width="348" height="112" rx="11"/>
+  <text class="t" x="646.0" y="362" text-anchor="middle" fill="#a32a2a">Datanode 2 · unavailable</text>
+  <rect x="488" y="389" width="152" height="42" rx="8" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5" opacity="0.4"/>
+  <text class="l" x="564" y="416" text-anchor="middle" fill="#c2544a" opacity="0.4">Region 3</text>
+  <rect x="652" y="389" width="152" height="42" rx="8" fill="#f2ecfb" stroke="#8a63c9" stroke-width="1.5" opacity="0.4"/>
+  <text class="l" x="728" y="416" text-anchor="middle" fill="#8a63c9" opacity="0.4">Region 4</text>
+  <rect x="966" y="70" width="816" height="414" rx="16" fill="#fbfaff" stroke="#8a7fd0" stroke-width="2" stroke-dasharray="12 8"/>
+  <text class="t" x="988" y="56" text-anchor="start">Region 2</text>
+  <rect class="node" x="986" y="108" width="776" height="64" rx="11"/>
+  <text class="t" x="1374.0" y="136" text-anchor="middle">Metasrv × 2</text>
+  <text class="s" x="1374.0" y="158" text-anchor="middle">Leader election; state in the metadata backend</text>
+  <rect class="node" x="986" y="184" width="776" height="64" rx="11"/>
+  <text class="t" x="1374.0" y="212" text-anchor="middle">Frontend × N</text>
+  <text class="s" x="1374.0" y="234" text-anchor="middle">Stateless, behind a load balancer</text>
+  <path class="bus" d="M1176 248 L1176 260 L1572 260 L1572 248"/>
+  <path class="flow" d="M1176 260 L1176 286"/>
+  <path class="flow" d="M1572 260 L1572 286"/>
+  <rect class="zone" x="986" y="288" width="380" height="174" rx="12"/>
+  <text class="zone-label" x="1004" y="316" text-anchor="start">AZ 3 · DC 3</text>
+  <rect class="node" x="1002" y="332" width="348" height="112" rx="11"/>
+  <text class="t" x="1176.0" y="362" text-anchor="middle">Datanode 3</text>
+  <rect x="1016" y="389" width="100" height="42" rx="8" fill="#fbecf4" stroke="#c0508c" stroke-width="1.5"/>
+  <text class="s" x="1066" y="416" text-anchor="middle" fill="#c0508c">Region 5</text>
+  <rect x="1126" y="389" width="100" height="42" rx="8" fill="#ecf0fb" stroke="#4a63c9" stroke-width="1.5"/>
+  <text class="s" x="1176" y="416" text-anchor="middle" fill="#4a63c9">Region 6</text>
+  <rect x="1236" y="389" width="100" height="42" rx="8" fill="#edf9f1" stroke="#2a9d5c" stroke-width="1.5" stroke-dasharray="6 5"/>
+  <text class="s" x="1286" y="416" text-anchor="middle" fill="#2a9d5c">Region 3, 4</text>
+  <rect class="zone" x="1382" y="288" width="380" height="174" rx="12"/>
+  <text class="zone-label" x="1400" y="316" text-anchor="start">AZ 4 · DC 4</text>
+  <rect class="node" x="1398" y="332" width="348" height="112" rx="11"/>
+  <text class="t" x="1572.0" y="362" text-anchor="middle">Datanode 4</text>
+  <rect x="1414" y="389" width="152" height="42" rx="8" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
+  <text class="l" x="1490" y="416" text-anchor="middle" fill="#2f8fb5">Region 7</text>
+  <rect x="1578" y="389" width="152" height="42" rx="8" fill="#fbf3e0" stroke="#b5860a" stroke-width="1.5"/>
+  <text class="l" x="1654" y="416" text-anchor="middle" fill="#b5860a">Region 8</text>
+  <rect x="1892" y="70" width="420" height="414" rx="16" fill="#fbfaff" stroke="#8a7fd0" stroke-width="2" stroke-dasharray="12 8"/>
+  <text class="t" x="1914" y="56" text-anchor="start">Region 3</text>
+  <rect class="node" x="1912" y="108" width="380" height="64" rx="11"/>
+  <text class="t" x="2102.0" y="136" text-anchor="middle">Metasrv × 1</text>
+  <text class="s" x="2102.0" y="158" text-anchor="middle">Leader election; state in the metadata backend</text>
+  <rect class="zone" x="1912" y="184" width="380" height="64" rx="11"/>
+  <text class="s" x="2102.0" y="220" text-anchor="middle">No read or write traffic</text>
+  <rect class="zone" x="1912" y="288" width="380" height="174" rx="12"/>
+  <text class="zone-label" x="1930" y="316" text-anchor="start">AZ 5 · DC 5</text>
+  <text class="s" x="2102.0" y="384" text-anchor="middle">Metasrv replica only,</text>
+  <text class="s" x="2102.0" y="408" text-anchor="middle">so the region can hold a majority</text>
+  <path class="failover" d="M820 388 L1000 388"/>
+  <text class="failover-label" x="911.0" y="354" text-anchor="middle">Region</text>
+  <text class="failover-label" x="911.0" y="374" text-anchor="middle">Failover</text>
+  <rect class="wal" x="40.0" y="524" width="741.3333333333334" height="92" rx="12"/>
+  <text class="t" x="410.6666666666667" y="562" text-anchor="middle" fill="#b5760a">Remote WAL</text>
+  <text class="s" x="410.6666666666667" y="586" text-anchor="middle">Kafka; replicated brokers</text>
+  <rect class="infra" x="805.3333333333334" y="524" width="741.3333333333334" height="92" rx="12"/>
+  <text class="t" x="1176.0" y="562" text-anchor="middle" fill="#2491ad">Object storage</text>
+  <text class="s" x="1176.0" y="586" text-anchor="middle">SSTables and index</text>
+  <rect class="infra" x="1570.6666666666667" y="524" width="741.3333333333334" height="92" rx="12"/>
+  <text class="t" x="1941.3333333333335" y="562" text-anchor="middle" fill="#2491ad">Metadata backend</text>
+  <text class="s" x="1941.3333333333335" y="586" text-anchor="middle">etcd, MySQL or PostgreSQL</text>
+  <path class="bus" d="M411 502 L1374 502"/>
+  <path class="bus" d="M448 484 L448 502"/>
+  <path class="bus" d="M1374 484 L1374 502"/>
+  <path class="flow" d="M411 502 L411 522"/>
+  <path class="flow" d="M1176 502 L1176 522"/>
+  <path class="bus" d="M836 140 L848 140 L848 30 L2330 30"/>
+  <path class="bus" d="M1762 140 L1774 140 L1774 30 L2330 30"/>
+  <path class="bus" d="M2292 140 L2330 140"/>
+  <path class="bus" d="M2330 30 L2330 570"/>
+  <path class="meta-flow" d="M2330 570 L2314 570"/>
+  <text class="l" x="1176.0" y="664" text-anchor="middle">Regions 1 and 2 serve every request; region 3 only completes the Metasrv majority.</text>
+</svg>

--- a/static/DR-across-5dc-3region.svg
+++ b/static/DR-across-5dc-3region.svg
@@ -1,0 +1,146 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2352" height="700" viewBox="0 0 2352 700" role="img" aria-labelledby="title description">
+  <title id="title">Data across three regions</title>
+  <desc id="description">Five DCs, one Datanode each, with all three regions serving reads and writes.</desc>
+  <defs>
+    <marker id="a" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="g" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="gs" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="as" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="am" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#b5760a"/>
+    </marker>
+    <style>
+      .t { font: 600 19px Arial, sans-serif; fill: #170128; }
+      .l { font: 16px Arial, sans-serif; fill: #39314a; }
+      .s { font: 14px Arial, sans-serif; fill: #5b5470; }
+      .m { font: 15px "DejaVu Sans Mono", Menlo, monospace; fill: #39314a; }
+      .mt { font: 600 17px "DejaVu Sans Mono", Menlo, monospace; fill: #170128; }
+      .ms { font: 12px "DejaVu Sans Mono", Menlo, monospace; fill: #ffffff; }
+      .zone { fill: #ffffff; stroke: #b9b3d6; stroke-width: 2; stroke-dasharray: 8 6; }
+      .node { fill: #f3f2ff; stroke: #6f6fff; stroke-width: 2; }
+      .infra { fill: #eefaff; stroke: #2491ad; stroke-width: 2; }
+      .wal { fill: #fdf4e3; stroke: #b5760a; stroke-width: 2; }
+      .fail { fill: #fff4f4; stroke: #d64545; stroke-width: 2; }
+      .flow { fill: none; stroke: #6f6fff; stroke-width: 2.5; marker-end: url(#a); }
+      .bus { fill: none; stroke: #6f6fff; stroke-width: 2.5; }
+      .rep { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+              marker-end: url(#g); }
+      .rep2 { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+               marker-start: url(#gs); marker-end: url(#g); }
+      .lbl { font: 600 15px Arial, sans-serif; fill: #39314a; }
+
+      .zone-label { font: 600 15px Arial, sans-serif; fill: #6b638a; }
+      .meta-flow { fill: none; stroke: #6f6fff; stroke-width: 2.5; marker-end: url(#a); }
+      .failover { fill: none; stroke: #2a9d5c; stroke-width: 3; marker-end: url(#g); }
+      .failover-label { font: 600 15px Arial, sans-serif; fill: #2a9d5c; }
+    </style>
+  </defs>
+
+  <rect width="2352" height="700" fill="#ffffff"/>
+
+  <rect x="40" y="70" width="816" height="414" rx="16" fill="#fbfaff" stroke="#8a7fd0" stroke-width="2" stroke-dasharray="12 8"/>
+  <text class="t" x="62" y="56" text-anchor="start">Region 1</text>
+  <rect class="node" x="60" y="108" width="776" height="64" rx="11"/>
+  <text class="t" x="448.0" y="136" text-anchor="middle">Metasrv × 2</text>
+  <text class="s" x="448.0" y="158" text-anchor="middle">Leader election; state in the metadata backend</text>
+  <rect class="node" x="60" y="184" width="776" height="64" rx="11"/>
+  <text class="t" x="448.0" y="212" text-anchor="middle">Frontend × N</text>
+  <text class="s" x="448.0" y="234" text-anchor="middle">Stateless, behind a load balancer</text>
+  <path class="bus" d="M250 248 L250 260 L646 260 L646 248"/>
+  <path class="flow" d="M250 260 L250 286"/>
+  <path class="flow" d="M646 260 L646 286"/>
+  <rect class="zone" x="60" y="288" width="380" height="174" rx="12"/>
+  <text class="zone-label" x="78" y="316" text-anchor="start">AZ 1 · DC 1</text>
+  <rect class="node" x="76" y="332" width="348" height="112" rx="11"/>
+  <text class="t" x="250.0" y="362" text-anchor="middle">Datanode 1</text>
+  <rect x="92" y="389" width="152" height="42" rx="8" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
+  <text class="l" x="168" y="416" text-anchor="middle" fill="#2f8fb5">Region 1</text>
+  <rect x="256" y="389" width="152" height="42" rx="8" fill="#fbf3e0" stroke="#b5860a" stroke-width="1.5"/>
+  <text class="l" x="332" y="416" text-anchor="middle" fill="#b5860a">Region 2</text>
+  <rect class="zone" x="456" y="288" width="380" height="174" rx="12"/>
+  <text class="zone-label" x="474" y="316" text-anchor="start">AZ 2 · DC 2</text>
+  <rect class="fail" x="472" y="332" width="348" height="112" rx="11"/>
+  <text class="t" x="646.0" y="362" text-anchor="middle" fill="#a32a2a">Datanode 2 · unavailable</text>
+  <rect x="488" y="389" width="152" height="42" rx="8" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5" opacity="0.4"/>
+  <text class="l" x="564" y="416" text-anchor="middle" fill="#c2544a" opacity="0.4">Region 3</text>
+  <rect x="652" y="389" width="152" height="42" rx="8" fill="#f2ecfb" stroke="#8a63c9" stroke-width="1.5" opacity="0.4"/>
+  <text class="l" x="728" y="416" text-anchor="middle" fill="#8a63c9" opacity="0.4">Region 4</text>
+  <rect x="966" y="70" width="816" height="414" rx="16" fill="#fbfaff" stroke="#8a7fd0" stroke-width="2" stroke-dasharray="12 8"/>
+  <text class="t" x="988" y="56" text-anchor="start">Region 2</text>
+  <rect class="node" x="986" y="108" width="776" height="64" rx="11"/>
+  <text class="t" x="1374.0" y="136" text-anchor="middle">Metasrv × 2</text>
+  <text class="s" x="1374.0" y="158" text-anchor="middle">Leader election; state in the metadata backend</text>
+  <rect class="node" x="986" y="184" width="776" height="64" rx="11"/>
+  <text class="t" x="1374.0" y="212" text-anchor="middle">Frontend × N</text>
+  <text class="s" x="1374.0" y="234" text-anchor="middle">Stateless, behind a load balancer</text>
+  <path class="bus" d="M1176 248 L1176 260 L1572 260 L1572 248"/>
+  <path class="flow" d="M1176 260 L1176 286"/>
+  <path class="flow" d="M1572 260 L1572 286"/>
+  <rect class="zone" x="986" y="288" width="380" height="174" rx="12"/>
+  <text class="zone-label" x="1004" y="316" text-anchor="start">AZ 3 · DC 3</text>
+  <rect class="node" x="1002" y="332" width="348" height="112" rx="11"/>
+  <text class="t" x="1176.0" y="362" text-anchor="middle">Datanode 3</text>
+  <rect x="1016" y="389" width="100" height="42" rx="8" fill="#fbecf4" stroke="#c0508c" stroke-width="1.5"/>
+  <text class="s" x="1066" y="416" text-anchor="middle" fill="#c0508c">Region 5</text>
+  <rect x="1126" y="389" width="100" height="42" rx="8" fill="#ecf0fb" stroke="#4a63c9" stroke-width="1.5"/>
+  <text class="s" x="1176" y="416" text-anchor="middle" fill="#4a63c9">Region 6</text>
+  <rect x="1236" y="389" width="100" height="42" rx="8" fill="#edf9f1" stroke="#2a9d5c" stroke-width="1.5" stroke-dasharray="6 5"/>
+  <text class="s" x="1286" y="416" text-anchor="middle" fill="#2a9d5c">Region 3, 4</text>
+  <rect class="zone" x="1382" y="288" width="380" height="174" rx="12"/>
+  <text class="zone-label" x="1400" y="316" text-anchor="start">AZ 4 · DC 4</text>
+  <rect class="node" x="1398" y="332" width="348" height="112" rx="11"/>
+  <text class="t" x="1572.0" y="362" text-anchor="middle">Datanode 4</text>
+  <rect x="1414" y="389" width="152" height="42" rx="8" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
+  <text class="l" x="1490" y="416" text-anchor="middle" fill="#2f8fb5">Region 7</text>
+  <rect x="1578" y="389" width="152" height="42" rx="8" fill="#fbf3e0" stroke="#b5860a" stroke-width="1.5"/>
+  <text class="l" x="1654" y="416" text-anchor="middle" fill="#b5860a">Region 8</text>
+  <rect x="1892" y="70" width="420" height="414" rx="16" fill="#fbfaff" stroke="#8a7fd0" stroke-width="2" stroke-dasharray="12 8"/>
+  <text class="t" x="1914" y="56" text-anchor="start">Region 3</text>
+  <rect class="node" x="1912" y="108" width="380" height="64" rx="11"/>
+  <text class="t" x="2102.0" y="136" text-anchor="middle">Metasrv × 1</text>
+  <text class="s" x="2102.0" y="158" text-anchor="middle">Leader election; state in the metadata backend</text>
+  <rect class="node" x="1912" y="184" width="380" height="64" rx="11"/>
+  <text class="t" x="2102.0" y="212" text-anchor="middle">Frontend × N</text>
+  <text class="s" x="2102.0" y="234" text-anchor="middle">Stateless, behind a load balancer</text>
+  <path class="flow" d="M2102 248 L2102 286"/>
+  <rect class="zone" x="1912" y="288" width="380" height="174" rx="12"/>
+  <text class="zone-label" x="1930" y="316" text-anchor="start">AZ 5 · DC 5</text>
+  <rect class="node" x="1928" y="332" width="348" height="112" rx="11"/>
+  <text class="t" x="2102.0" y="362" text-anchor="middle">Datanode 5</text>
+  <rect x="1944" y="389" width="152" height="42" rx="8" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
+  <text class="l" x="2020" y="416" text-anchor="middle" fill="#c2544a">Region 9</text>
+  <rect x="2108" y="389" width="152" height="42" rx="8" fill="#f2ecfb" stroke="#8a63c9" stroke-width="1.5"/>
+  <text class="l" x="2184" y="416" text-anchor="middle" fill="#8a63c9">Region 10</text>
+  <path class="failover" d="M820 388 L1000 388"/>
+  <text class="failover-label" x="911.0" y="354" text-anchor="middle">Region</text>
+  <text class="failover-label" x="911.0" y="374" text-anchor="middle">Failover</text>
+  <rect class="wal" x="40.0" y="524" width="741.3333333333334" height="92" rx="12"/>
+  <text class="t" x="410.6666666666667" y="562" text-anchor="middle" fill="#b5760a">Remote WAL</text>
+  <text class="s" x="410.6666666666667" y="586" text-anchor="middle">Kafka; replicated brokers</text>
+  <rect class="infra" x="805.3333333333334" y="524" width="741.3333333333334" height="92" rx="12"/>
+  <text class="t" x="1176.0" y="562" text-anchor="middle" fill="#2491ad">Object storage</text>
+  <text class="s" x="1176.0" y="586" text-anchor="middle">SSTables and index</text>
+  <rect class="infra" x="1570.6666666666667" y="524" width="741.3333333333334" height="92" rx="12"/>
+  <text class="t" x="1941.3333333333335" y="562" text-anchor="middle" fill="#2491ad">Metadata backend</text>
+  <text class="s" x="1941.3333333333335" y="586" text-anchor="middle">etcd, MySQL or PostgreSQL</text>
+  <path class="bus" d="M411 502 L2102 502"/>
+  <path class="bus" d="M448 484 L448 502"/>
+  <path class="bus" d="M1374 484 L1374 502"/>
+  <path class="bus" d="M2102 484 L2102 502"/>
+  <path class="flow" d="M411 502 L411 522"/>
+  <path class="flow" d="M1176 502 L1176 522"/>
+  <path class="bus" d="M836 140 L848 140 L848 30 L2330 30"/>
+  <path class="bus" d="M1762 140 L1774 140 L1774 30 L2330 30"/>
+  <path class="bus" d="M2292 140 L2330 140"/>
+  <path class="bus" d="M2330 30 L2330 570"/>
+  <path class="meta-flow" d="M2330 570 L2314 570"/>
+  <text class="l" x="1176.0" y="664" text-anchor="middle">Every region serves requests, so losing one leaves the other two serving.</text>
+</svg>

--- a/static/LSM-tree-explain.svg
+++ b/static/LSM-tree-explain.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1060" height="400" viewBox="0 0 1060 400" role="img" aria-labelledby="title description">
+  <title id="title">How a write moves through the GreptimeDB storage engine</title>
+  <desc id="description">A write is persisted to the WAL, applied to the memtables, and later flushed into SSTable files.</desc>
+  <defs>
+    <marker id="a" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="g" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="gs" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="as" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="am" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#b5760a"/>
+    </marker>
+    <style>
+      .t { font: 600 19px Arial, sans-serif; fill: #170128; }
+      .l { font: 16px Arial, sans-serif; fill: #39314a; }
+      .s { font: 14px Arial, sans-serif; fill: #5b5470; }
+      .m { font: 15px "DejaVu Sans Mono", Menlo, monospace; fill: #39314a; }
+      .mt { font: 600 17px "DejaVu Sans Mono", Menlo, monospace; fill: #170128; }
+      .ms { font: 12px "DejaVu Sans Mono", Menlo, monospace; fill: #ffffff; }
+      .zone { fill: #ffffff; stroke: #b9b3d6; stroke-width: 2; stroke-dasharray: 8 6; }
+      .node { fill: #f3f2ff; stroke: #6f6fff; stroke-width: 2; }
+      .infra { fill: #eefaff; stroke: #2491ad; stroke-width: 2; }
+      .wal { fill: #fdf4e3; stroke: #b5760a; stroke-width: 2; }
+      .fail { fill: #fff4f4; stroke: #d64545; stroke-width: 2; }
+      .flow { fill: none; stroke: #6f6fff; stroke-width: 2.5; marker-end: url(#a); }
+      .bus { fill: none; stroke: #6f6fff; stroke-width: 2.5; }
+      .rep { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+              marker-end: url(#g); }
+      .rep2 { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+               marker-start: url(#gs); marker-end: url(#g); }
+      .lbl { font: 600 15px Arial, sans-serif; fill: #39314a; }
+    </style>
+  </defs>
+
+  <rect width="1060" height="400" fill="#ffffff"/>
+
+  <path d="M70 95 L228 95 L250 126 L228 157 L70 157 Z" fill="#fdeeec" stroke="#c2544a" stroke-width="2"/>
+  <text class="t" x="149" y="133" text-anchor="middle" fill="#c2544a">Data</text>
+  <path class="flow" d="M262 126 L332 126"/>
+  <text class="s" x="297" y="110" text-anchor="middle">Persist</text>
+  <path d="M344 95 L497 95 L519 126 L497 157 L344 157 Z" fill="#fdf4e3" stroke="#b5760a" stroke-width="2"/>
+  <text class="t" x="420" y="133" text-anchor="middle" fill="#b5760a">WAL</text>
+  <path class="flow" d="M531 126 L601 126"/>
+  <text class="s" x="566" y="110" text-anchor="middle">Apply</text>
+  <path d="M613 95 L826 95 L848 126 L826 157 L613 157 Z" fill="#f3f2ff" stroke="#6f6fff" stroke-width="2"/>
+  <text class="t" x="720" y="133" text-anchor="middle" fill="#6f6fff">Memtables</text>
+  <path class="flow" d="M718 157 L718 268"/>
+  <text class="s" x="736" y="216" text-anchor="start">Flush</text>
+  <rect class="infra" x="466" y="280" width="165" height="66" rx="9"/>
+  <text class="t" x="548" y="320" text-anchor="middle" fill="#2491ad">SSTable</text>
+  <rect class="infra" x="646" y="280" width="165" height="66" rx="9"/>
+  <text class="t" x="728" y="320" text-anchor="middle" fill="#2491ad">SSTable</text>
+  <rect class="infra" x="826" y="280" width="165" height="66" rx="9"/>
+  <text class="t" x="908" y="320" text-anchor="middle" fill="#2491ad">SSTable</text>
+</svg>

--- a/static/RTO-RPO-explain.svg
+++ b/static/RTO-RPO-explain.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1160" height="400" viewBox="0 0 1160 400" role="img" aria-labelledby="title description">
+  <title id="title">Recovery point objective and recovery time objective on a timeline</title>
+  <desc id="description">A timeline with three marks: RPO, the disaster, and RTO. The span from RPO to the disaster is the data lost; the span from the disaster to RTO is the downtime.</desc>
+  <defs>
+    <marker id="a" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="g" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="gs" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="as" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="am" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#b5760a"/>
+    </marker>
+    <style>
+      .t { font: 600 19px Arial, sans-serif; fill: #170128; }
+      .l { font: 16px Arial, sans-serif; fill: #39314a; }
+      .s { font: 14px Arial, sans-serif; fill: #5b5470; }
+      .m { font: 15px "DejaVu Sans Mono", Menlo, monospace; fill: #39314a; }
+      .mt { font: 600 17px "DejaVu Sans Mono", Menlo, monospace; fill: #170128; }
+      .ms { font: 12px "DejaVu Sans Mono", Menlo, monospace; fill: #ffffff; }
+      .zone { fill: #ffffff; stroke: #b9b3d6; stroke-width: 2; stroke-dasharray: 8 6; }
+      .node { fill: #f3f2ff; stroke: #6f6fff; stroke-width: 2; }
+      .infra { fill: #eefaff; stroke: #2491ad; stroke-width: 2; }
+      .wal { fill: #fdf4e3; stroke: #b5760a; stroke-width: 2; }
+      .fail { fill: #fff4f4; stroke: #d64545; stroke-width: 2; }
+      .flow { fill: none; stroke: #6f6fff; stroke-width: 2.5; marker-end: url(#a); }
+      .bus { fill: none; stroke: #6f6fff; stroke-width: 2.5; }
+      .rep { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+              marker-end: url(#g); }
+      .rep2 { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+               marker-start: url(#gs); marker-end: url(#g); }
+      .lbl { font: 600 15px Arial, sans-serif; fill: #39314a; }
+    </style>
+  </defs>
+
+  <rect width="1160" height="400" fill="#ffffff"/>
+
+  <line x1="300" y1="110" x2="300" y2="340" stroke="#b9b3d6" stroke-width="2"/>
+  <text class="t" x="300" y="92" text-anchor="middle">RPO</text>
+  <line x1="600" y1="110" x2="600" y2="340" stroke="#b9b3d6" stroke-width="2"/>
+  <text class="t" x="600" y="92" text-anchor="middle">DISASTER</text>
+  <line x1="920" y1="110" x2="920" y2="340" stroke="#b9b3d6" stroke-width="2"/>
+  <text class="t" x="920" y="92" text-anchor="middle">RTO</text>
+  <line x1="70" y1="225" x2="1090" y2="225" stroke="#6f6fff" stroke-width="2.5" stroke-dasharray="9 7" marker-start="url(#as)" marker-end="url(#a)" opacity="0.85"/>
+  <text class="s" x="96" y="205" text-anchor="start">Time</text>
+  <text class="s" x="1064" y="205" text-anchor="end">Time</text>
+  <polygon points="600.0,195.0 605.2,212.5 621.2,203.8 612.5,219.8 630.0,225.0 612.5,230.2 621.2,246.2 605.2,237.5 600.0,255.0 594.8,237.5 578.8,246.2 587.5,230.2 570.0,225.0 587.5,219.8 578.8,203.8 594.8,212.5" fill="#d64545"/>
+  <line x1="300" y1="300" x2="600" y2="300" stroke="#d64545" stroke-width="4" stroke-dasharray="2 7" stroke-linecap="round"/>
+  <line x1="600" y1="300" x2="920" y2="300" stroke="#b5760a" stroke-width="4" stroke-dasharray="2 7" stroke-linecap="round"/>
+  <text class="lbl" x="450" y="283" text-anchor="middle">Lost Data</text>
+  <text class="lbl" x="760" y="283" text-anchor="middle">Down Time</text>
+</svg>

--- a/static/active-active-failover.svg
+++ b/static/active-active-failover.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1100" height="730" viewBox="0 0 1100 730" role="img" aria-labelledby="title description">
   <title id="title">Active-active failover between two GreptimeDB standalone nodes</title>
-  <desc id="description">A load balancer sends traffic to two standalone nodes in different regions; their tables replicate to each other.</desc>
+  <desc id="description">A load balancer sends traffic to two peer standalone nodes; their tables replicate to each other.</desc>
   <defs>
     <marker id="a" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
       <path d="M0,0 L0,6 L9,3 z" fill="#6f6fff"/>
@@ -47,7 +47,6 @@
   <polygon points="790,116 790,152 785,152 800,182 815,152 810,152 810,116" fill="#b5760a" opacity="0.9"/>
   <rect class="zone" x="40" y="190" width="1020" height="500" rx="14"/>
   <text class="t" x="66" y="226" text-anchor="start">Dual Active-Standby</text>
-  <line x1="550" y1="190" x2="550" y2="690" stroke="#b9b3d6" stroke-width="2" stroke-dasharray="8 6"/>
   <rect class="zone" x="120" y="330" width="340" height="300" rx="12"/>
   <text class="t" x="290" y="372" text-anchor="middle">Standalone 1</text>
   <rect x="205" y="400" width="170" height="48" rx="7" fill="#e8f5ee" stroke="#2a8f5c" stroke-width="1.5"/>
@@ -68,6 +67,4 @@
   <path class="rep2" d="M472 492 L698 492"/>
   <path class="rep2" d="M472 560 L698 560"/>
   <text class="lbl" x="585" y="396" text-anchor="middle">Replicate</text>
-  <text class="s" x="66" y="668" text-anchor="start">Region 1</text>
-  <text class="s" x="576" y="668" text-anchor="start">Region 2</text>
 </svg>

--- a/static/active-active-failover.svg
+++ b/static/active-active-failover.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="730" viewBox="0 0 1100 730" role="img" aria-labelledby="title description">
+  <title id="title">Active-active failover between two GreptimeDB standalone nodes</title>
+  <desc id="description">A load balancer sends traffic to two standalone nodes in different regions; their tables replicate to each other.</desc>
+  <defs>
+    <marker id="a" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="g" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="gs" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#2a9d5c"/>
+    </marker>
+    <marker id="as" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#6f6fff"/>
+    </marker>
+    <marker id="am" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#b5760a"/>
+    </marker>
+    <style>
+      .t { font: 600 19px Arial, sans-serif; fill: #170128; }
+      .l { font: 16px Arial, sans-serif; fill: #39314a; }
+      .s { font: 14px Arial, sans-serif; fill: #5b5470; }
+      .m { font: 15px "DejaVu Sans Mono", Menlo, monospace; fill: #39314a; }
+      .mt { font: 600 17px "DejaVu Sans Mono", Menlo, monospace; fill: #170128; }
+      .ms { font: 12px "DejaVu Sans Mono", Menlo, monospace; fill: #ffffff; }
+      .zone { fill: #ffffff; stroke: #b9b3d6; stroke-width: 2; stroke-dasharray: 8 6; }
+      .node { fill: #f3f2ff; stroke: #6f6fff; stroke-width: 2; }
+      .infra { fill: #eefaff; stroke: #2491ad; stroke-width: 2; }
+      .wal { fill: #fdf4e3; stroke: #b5760a; stroke-width: 2; }
+      .fail { fill: #fff4f4; stroke: #d64545; stroke-width: 2; }
+      .flow { fill: none; stroke: #6f6fff; stroke-width: 2.5; marker-end: url(#a); }
+      .bus { fill: none; stroke: #6f6fff; stroke-width: 2.5; }
+      .rep { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+              marker-end: url(#g); }
+      .rep2 { fill: none; stroke: #2a9d5c; stroke-width: 2.5; stroke-dasharray: 7 5;
+               marker-start: url(#gs); marker-end: url(#g); }
+      .lbl { font: 600 15px Arial, sans-serif; fill: #39314a; }
+    </style>
+  </defs>
+
+  <rect width="1100" height="730" fill="#ffffff"/>
+
+  <rect class="zone" x="300" y="30" width="500" height="78" rx="12"/>
+  <text class="t" x="550" y="78" text-anchor="middle">Load Balancer</text>
+  <polygon points="290,116 290,152 285,152 300,182 315,152 310,152 310,116" fill="#b5760a" opacity="0.9"/>
+  <polygon points="790,116 790,152 785,152 800,182 815,152 810,152 810,116" fill="#b5760a" opacity="0.9"/>
+  <rect class="zone" x="40" y="190" width="1020" height="500" rx="14"/>
+  <text class="t" x="66" y="226" text-anchor="start">Dual Active-Standby</text>
+  <line x1="550" y1="190" x2="550" y2="690" stroke="#b9b3d6" stroke-width="2" stroke-dasharray="8 6"/>
+  <rect class="zone" x="120" y="330" width="340" height="300" rx="12"/>
+  <text class="t" x="290" y="372" text-anchor="middle">Standalone 1</text>
+  <rect x="205" y="400" width="170" height="48" rx="7" fill="#e8f5ee" stroke="#2a8f5c" stroke-width="1.5"/>
+  <text class="l" x="290" y="429" text-anchor="middle" fill="#2a8f5c">Table 1</text>
+  <rect x="205" y="468" width="170" height="48" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
+  <text class="l" x="290" y="497" text-anchor="middle" fill="#2f8fb5">Table 2</text>
+  <rect x="205" y="536" width="170" height="48" rx="7" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
+  <text class="l" x="290" y="565" text-anchor="middle" fill="#c2544a">Table 3</text>
+  <rect class="zone" x="620" y="330" width="340" height="300" rx="12"/>
+  <text class="t" x="790" y="372" text-anchor="middle">Standalone 2</text>
+  <rect x="705" y="400" width="170" height="48" rx="7" fill="#e8f5ee" stroke="#2a8f5c" stroke-width="1.5"/>
+  <text class="l" x="790" y="429" text-anchor="middle" fill="#2a8f5c">Table 1</text>
+  <rect x="705" y="468" width="170" height="48" rx="7" fill="#e8f4fa" stroke="#2f8fb5" stroke-width="1.5"/>
+  <text class="l" x="790" y="497" text-anchor="middle" fill="#2f8fb5">Table 2</text>
+  <rect x="705" y="536" width="170" height="48" rx="7" fill="#fdeeec" stroke="#c2544a" stroke-width="1.5"/>
+  <text class="l" x="790" y="565" text-anchor="middle" fill="#c2544a">Table 3</text>
+  <path class="rep2" d="M472 424 L698 424"/>
+  <path class="rep2" d="M472 492 L698 492"/>
+  <path class="rep2" d="M472 560 L698 560"/>
+  <text class="lbl" x="585" y="396" text-anchor="middle">Replicate</text>
+  <text class="s" x="66" y="668" text-anchor="start">Region 1</text>
+  <text class="s" x="576" y="668" text-anchor="start">Region 2</text>
+</svg>

--- a/versioned_docs/version-1.2/user-guide/deployments-administration/disaster-recovery/dr-solution-based-on-cross-region-deployment-in-single-cluster.md
+++ b/versioned_docs/version-1.2/user-guide/deployments-administration/disaster-recovery/dr-solution-based-on-cross-region-deployment-in-single-cluster.md
@@ -41,7 +41,7 @@ those numbers when comparing the solutions.
 
 ### Metadata across 2 regions, data in the same region
 
-![DR-across-2dc-1region](/DR-across-2dc-1region.png)
+![DR-across-2dc-1region](/DR-across-2dc-1region.svg)
 
 In this solution, the data is in one region (2 DCs), while the metadata across 2 regions.
 
@@ -62,7 +62,7 @@ If you want a regional-level disaster recovery solution, you can take it a step 
 
 ### Data across 2 regions
 
-![DR-across-3dc-2region](/DR-across-3dc-2region.png)
+![DR-across-3dc-2region](/DR-across-3dc-2region.svg)
 
 In this solution, the data across 2 regions.
 
@@ -80,7 +80,7 @@ If you can't tolerate performance degradation from a single DC failure, consider
 
 ### Metadata across 3 regions, data across 2 regions
 
-![DR-across-5dc-2region](/DR-across-5dc-2region.png)
+![DR-across-5dc-2region](/DR-across-5dc-2region.svg)
 
 In this solution, the data across 2 regions, while the metadata across 3 regions.
 
@@ -103,7 +103,7 @@ You can take it a step further by providing read and write services on both 3 re
 
 ### Data across 3 regions
 
-![DR-across-5dc-3region](/DR-across-5dc-3region.png)
+![DR-across-5dc-3region](/DR-across-5dc-3region.svg)
 
 In this solution, the data across 3 regions.
 

--- a/versioned_docs/version-1.2/user-guide/deployments-administration/disaster-recovery/overview.md
+++ b/versioned_docs/version-1.2/user-guide/deployments-administration/disaster-recovery/overview.md
@@ -20,12 +20,12 @@ This document contains:
 
 The following figure illustrates these two concepts:
 
-![RTO-RPO-explain](/RTO-RPO-explain.png)
+![RTO-RPO-explain](/RTO-RPO-explain.svg)
 
 * **Write-Ahead Logging (WAL)**: persistently records every data modification to ensure data integrity and consistency.
 
 GreptimeDB storage engine is a typical [LSM Tree](https://en.wikipedia.org/wiki/Log-structured_merge-tree) :
-![LSM-tree-explain](/LSM-tree-explain.png)
+![LSM-tree-explain](/LSM-tree-explain.svg)
 
 The data written is going firstly persisted into WAL, then applied into Memtable in memory. Under specific conditions (e.g., exceeding the memory threshold), the Memtable will be flushed and persisted as an SSTable. So the DR of WAL and SSTable is key to the DR of GreptimeDB.
 
@@ -36,7 +36,7 @@ The data written is going firstly persisted into WAL, then applied into Memtable
 ### GreptimeDB
 
 Before digging into the specific DR solution, let's explain the architecture of GreptimeDB components in the perspective of DR:
-![Component-architecture](/Component-architecture.png)
+![Component-architecture](/Component-architecture.svg)
 
 GreptimeDB is designed with a cloud-native architecture based on storage-compute separation:
 * **Frontend**:  the ingestion and query service layer, which forwards requests to Datanode and processes, and merges responses from Datanode.
@@ -50,7 +50,7 @@ At the same time, the WAL component is pluggable, e.g. using Kafka as the WAL se
 
 ### Backup and restore
 
-![BR-explain](/BR-explain.png)
+![BR-explain](/BR-explain.svg)
 
 The Backup & Restore (BR) tool can perform a full snapshot backup of databases or tables at a specific time and supports incremental backup.
 When a cluster encounters a disaster, you can restore the cluster from backup data. Generally speaking, BR is the last resort for disaster recovery.
@@ -66,7 +66,7 @@ If the Standalone is running on the local disk for WAL and data, then:
 A good start is to deploy GreptimeDB Standalone into an IaaS platform that has a backup and recovery solution. For example, Amazon EC2 with EBS volumes provides a comprehensive [Backup and Recovery solution](https://docs.aws.amazon.com/prescriptive-guidance/latest/backup-recovery/backup-recovery-ec2-ebs.html).
 
 But if running the Standalone with remote WAL and object storage, there is a better DR solution:
-![DR-Standalone](/DR-Standalone.png)
+![DR-Standalone](/DR-Standalone.svg)
 
 Write the WAL to the Kafka cluster and store the data in object storage, so that the ingested data no longer depends on the node's local disk.
 
@@ -76,7 +76,7 @@ The node is not fully stateless, though: a standalone instance keeps its metadat
 
 ### DR solution based on Active-Active Failover
 
-![Active-active failover](/active-active-failover.png)
+![Active-active failover](/active-active-failover.svg)
 
 In some edge or small-to-medium scale scenarios, or if you lack the resources to deploy remote WAL or object storage, Active-Active Failover offers a better solution compared to Standalone DR. Two actively serving standalone nodes replicate data changes asynchronously. If a peer or the inter-site network fails, the healthy node continues serving, retains pending changes on its local storage, and sends them after the peer recovers.
 
@@ -94,7 +94,7 @@ For more information about this solution, see [DR solution based on Active-Activ
 
 ### DR solution  based on cross-region deployment in a single cluster
 
-![Cross-region-single-cluster](/Cross-region-single-cluster.png)
+![Cross-region-single-cluster](/Cross-region-single-cluster.svg)
 
 For medium-to-large scale scenarios requiring zero RPO, this solution is highly recommended. In this deployment architecture, the entire cluster spans across three regions, with each region capable of handling both read and write requests. Data replication is achieved using remote WAL and object storage, both of which must have cross-region DR enabled.
 If Region 1 becomes completely unavailable due to a disaster, the table regions within it will be opened and recovered in the other regions.
@@ -110,7 +110,7 @@ Confirm the resulting RPO and RTO with an end-to-end failure drill. For more inf
 
 ### DR solution based on BR
 
-![/BR-DR](/BR-DR.png)
+![/BR-DR](/BR-DR.svg)
 
 In this architecture, GreptimeDB Cluster 1 is deployed in region 1. The BR process continuously and regularly backs up the data from Cluster 1 to region 2. If region 1 experiences a disaster rendering Cluster 1 unrecoverable, you can use the backup data to restore a new cluster (Cluster 2) in region 2 to resume services.
 


### PR DESCRIPTION
Twelve PNG diagrams in the DR docs were still in an older visual style, while the same docset had already moved to hand-authored SVG — `img/active-active-forwarding.svg` (#2689) and the concepts pages. This redraws all twelve in that style: vector, Arial, the `#6f6fff` palette, `title` and `desc` for accessibility.

## Two kinds of change

**The eight overview diagrams** keep their content unchanged — same boxes, same labels, same numbers. Only the drawing changes.

**The four cross-region diagrams** are remodelled to use the element set of `Single-region-single-cluster.svg`, so the overview and the cross-region page read as one family: Metasrv and Frontend over AZ frames holding one Datanode per DC, a Region Failover, and one shared Remote WAL / object storage / metadata backend tier.

What that trades away, deliberately:

- leader and follower roles on the Metasrv and WAL broker pills — the 2-2-1 majority is now carried by the per-region `Metasrv × N` counts
- the split between `wal metasrv` and `wal brokers`, and the per-AZ broker placement — folded into the single `Remote WAL` element
- two Datanodes per AZ — one per DC now, as in the single-region diagram
- `T1-1` style table shard ids — now `Region N`, with colour still grouping the regions of one table

What it adds: the object storage and metadata backend tiers, which the page's own prose requires but the diagrams never showed, and a Region Failover, which none of them showed.

## Errors found in the current diagrams

- `BR-explain`: "dowload" — fixed.
- `Cross-region-single-cluster`: `Region 2-2` on both Datanode 2 and Datanode 3 — fixed. Table 2 sits on Datanodes 1, 2, 3 and 5, and now runs 2-1 to 2-4 in Datanode order, the way table 1 runs 1-1 to 1-5 and table 3 runs 3-1 to 3-4.
- `BR-DR`: `Region 1-2` twice inside Cluster 2's Datanode — fixed. Cluster 1 holds Region 1-1 on Datanode 1 and Region 1-2 on Datanode 2, so the restored Datanode carries 1-1 and 1-2.

Correct them in review if the intended distribution was different.

## Scope

Nightly and 1.2. Version 1.2 referenced the same twelve PNGs and its cross-region page is word for word the nightly one, so that swap is a reference change only. The PNGs stay in `static/` for 1.1 and older, which still reference them.

Chinese variants (`*.zh.svg`, the pattern the August concepts diagrams use) are not part of this PR — both locales share the English SVGs, exactly as they share the PNGs today.

## Checks

- `DOC_LANG=en pnpm check:links` passes
- `DOC_LANG=zh pnpm check:links` passes
- `git diff --check` clean; no lockfile or generated files touched


